### PR TITLE
fix: skip X-Odoo-Database header for Odoo.com SaaS instances

### DIFF
--- a/src/odoo_mcp/odoo_client.py
+++ b/src/odoo_mcp/odoo_client.py
@@ -63,7 +63,10 @@ class OdooClient:
         self.session = requests.Session()
         self.session.verify = verify_ssl
         self.session.headers['Content-Type'] = 'application/json'
-        self.session.headers['X-Odoo-Database'] = db
+        # Only set X-Odoo-Database for multi-DB instances.
+        # Odoo.com SaaS identifies the DB via subdomain — sending this header causes 404.
+        if db and not self.url.endswith(".odoo.com"):
+            self.session.headers['X-Odoo-Database'] = db
 
         if api_key:
             self.session.headers['Authorization'] = f'Bearer {api_key}'


### PR DESCRIPTION
## Problem

When connecting to an Odoo.com SaaS instance (e.g. `mycompany.odoo.com`), all model API calls return **404**. The root cause is the `X-Odoo-Database` header set in `odoo_client.py`.

Odoo.com SaaS identifies the database via the subdomain — the header is redundant and conflicts with the SaaS routing layer, causing every `/json/2/{model}/{method}` request to 404.

**Confirmed via direct testing:**
```bash
# With X-Odoo-Database header → 404
curl -X POST https://mycompany.odoo.com/json/2/res.partner/search_read \
  -H "Authorization: Bearer <key>" \
  -H "X-Odoo-Database: mycompany" \
  -d '{"domain": [], "fields": ["name"], "limit": 1}'

# Without header → 200
curl -X POST https://mycompany.odoo.com/json/2/res.partner/search_read \
  -H "Authorization: Bearer <key>" \
  -d '{"domain": [], "fields": ["name"], "limit": 1}'
```

## Fix

Only send `X-Odoo-Database` when the instance URL does **not** end with `.odoo.com`. Self-hosted instances are unaffected.

```python
# Only set X-Odoo-Database for multi-DB instances.
# Odoo.com SaaS identifies the DB via subdomain — sending this header causes 404.
if db and not self.url.endswith(".odoo.com"):
    self.session.headers['X-Odoo-Database'] = db
```

## Notes

- Odoo.com SaaS is a significant deployment target — this fix unblocks the server for all SaaS users
- Self-hosted instances with multiple databases are unaffected
- The `ODOO_DB` env var is still used for logging/config; only the header is conditionally skipped