### PR TITLE
perf: Parallelize bundle/bootstrap fetches, tighten dispatch, lift connection pool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ MCP_TRANSPORT=streamable-http MCP_API_KEY=<token> python -m odoo_mcp
 python -m odoo_mcp --setup
 
 # Tests — unit (no Odoo needed)
-pytest tests/test_safety.py
+pytest tests/test_safety.py tests/test_token_gate.py
 pytest tests/test_safety.py::TestClassifyOperation::test_safe_methods_are_safe   # single test
 
 # Tests — live (requires .env with real Odoo creds; script-style runners)
@@ -96,7 +96,7 @@ src/odoo_mcp/
 - **BLOCKED_MODELS** (writes always refused): `ir.rule`, `ir.model.access`, `ir.module.module`, `ir.config_parameter`, `ir.model`, `ir.model.fields`, `res.users`, `res.groups`. The `resolve_json` parameter also rejects these as targets — agents cannot use it to read security-critical data.
 - **SENSITIVE_MODELS** (writes always confirm): `account.move`, `account.payment`, `account.bank.statement`, `hr.payslip`, `ir.cron`.
 - **Cascade warnings** are surfaced for: `sale.order.action_confirm` (creates deliveries), `account.move.action_post` (irreversible journal entries), `stock.picking.button_validate` (stock changes), `purchase.order.button_confirm` (incoming receipts), `account.payment.action_post` (journal + reconciliation).
-- **Token gate** (v1.14.0): `_issue_confirmation_token()` issues a single-use, 120s-TTL nonce bound to the exact `model+method`. Validation consumes the token. Same flow applies to `batch_execute` and `execute_workflow`.
+- **Token gate** (v1.14.0): `_issue_confirmation_token()` issues a single-use, 120s-TTL nonce bound to `(model, method, payload_digest)` — a SHA-256 over the deterministic JSON of the operation payload. The confirmation re-call must reproduce the *exact same args/kwargs* the gate saw at issue time, so an agent can't get a token for `unlink([1])` and then re-call with `unlink([1,2,…,1000])`. Digest covers `{"args": args, "kwargs": kwargs}` post-`resolve_json` and post-context-merge for `execute_method`, the full ops list for `batch_execute`, and the params dict for `execute_workflow`.
 
 ```python
 # Step 1: triggers gate, returns confirmation_token in hint
@@ -107,7 +107,7 @@ execute_method("sale.order", "action_confirm", args_json='[[15]]',
     confirmed=True, confirmation_token='ymzyOtsZTDTJpKKysu_xWQ')
 ```
 
-Audit log to stderr when `MCP_SAFETY_AUDIT=true`.
+Audit log via `logging.getLogger("odoo_mcp.safety")` (configured in `__init__.py` to stderr at INFO+) when `MCP_SAFETY_AUDIT=true`. `MCP_SAFETY_MODE`, `MCP_SAFETY_AUDIT`, and `MCP_DEFAULT_CONTEXT` are read at call time, so reconfiguring after import (or `patch.dict(os.environ, …)` in tests) takes effect immediately.
 
 ## Configuration
 

--- a/src/odoo_mcp/odoo_client.py
+++ b/src/odoo_mcp/odoo_client.py
@@ -71,6 +71,14 @@ class OdooClient:
         self.session.verify = verify_ssl
         self.session.headers['Content-Type'] = 'application/json'
 
+        # Lift the default per-host connection pool from 10 to 20. Bundle and
+        # session-bootstrap fan out up to 10 concurrent fetches; without this,
+        # any concurrent execute_method call would block waiting for a free
+        # connection.
+        _adapter = requests.adapters.HTTPAdapter(pool_connections=20, pool_maxsize=20)
+        self.session.mount("https://", _adapter)
+        self.session.mount("http://", _adapter)
+
         # Only set X-Odoo-Database for non-SaaS instances.
         # Odoo.com SaaS identifies the DB via subdomain — sending this header causes 404.
         hostname_lower = (parsed_url.hostname or "").lower()

--- a/src/odoo_mcp/resources.py
+++ b/src/odoo_mcp/resources.py
@@ -8,6 +8,7 @@ registers all resources with the FastMCP instance.
 import json
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List
 
 from .app import mcp
@@ -237,21 +238,33 @@ def get_bundle(models_csv: str) -> str:
 
     URI format: odoo://bundle/res.partner,sale.order,stock.picking
     Max 10 models per request to keep response size reasonable.
+
+    Schema fetches run in parallel (one thread per model, capped at 10) so
+    bundle latency is bounded by the slowest fetch, not their sum.
     """
     odoo_client = get_odoo_client()
     model_names = [m.strip() for m in models_csv.split(",") if m.strip()]
     if len(model_names) > 10:
         return json.dumps({"error": "Maximum 10 models per bundle request", "requested": len(model_names)})
 
-    bundle = {"models": {}, "errors": {}}
-    for model_name in model_names:
+    bundle: Dict[str, Any] = {"models": {}, "errors": {}}
+
+    def _fetch(name: str) -> tuple[str, Any]:
         try:
-            fields = odoo_client.get_model_fields(model_name)
+            fields = odoo_client.get_model_fields(name)
             schema = _build_compact_schema(fields)
             schema["field_count"] = len(schema["fields"])
-            bundle["models"][model_name] = schema
-        except Exception as e:
-            bundle["errors"][model_name] = str(e)
+            return name, schema
+        except Exception as exc:
+            return name, exc
+
+    if model_names:
+        with ThreadPoolExecutor(max_workers=min(len(model_names), 10)) as executor:
+            for name, payload in executor.map(_fetch, model_names):
+                if isinstance(payload, Exception):
+                    bundle["errors"][name] = str(payload)
+                else:
+                    bundle["models"][name] = payload
 
     bundle["total"] = len(bundle["models"])
     return json.dumps(bundle, separators=(",", ":"))
@@ -272,19 +285,29 @@ def get_session_bootstrap() -> str:
     models_csv = os.environ.get("MCP_BOOTSTRAP_MODELS", _DEFAULT_BOOTSTRAP_MODELS)
     model_names = [m.strip() for m in models_csv.split(",") if m.strip()][:20]
 
-    result = {"schemas": {}, "workflows": {}, "errors": {}}
+    result: Dict[str, Any] = {"schemas": {}, "workflows": {}, "errors": {}}
 
-    for model_name in model_names:
-        # Get compact schema
+    def _fetch(name: str) -> tuple[str, Any]:
         try:
-            fields = odoo_client.get_model_fields(model_name)
+            fields = odoo_client.get_model_fields(name)
             schema = _build_compact_schema(fields)
             schema["field_count"] = len(schema["fields"])
-            result["schemas"][model_name] = schema
-        except Exception as e:
-            result["errors"][model_name] = str(e)
+            return name, schema
+        except Exception as exc:
+            return name, exc
 
-        # Get workflow if available
+    # Schema fetches run in parallel (capped at 10 workers, well within the
+    # OdooClient session's 20-conn pool so a concurrent execute_method still
+    # has headroom). Workflows are read from the in-memory state-machine table.
+    if model_names:
+        with ThreadPoolExecutor(max_workers=min(len(model_names), 10)) as executor:
+            for name, payload in executor.map(_fetch, model_names):
+                if isinstance(payload, Exception):
+                    result["errors"][name] = str(payload)
+                else:
+                    result["schemas"][name] = payload
+
+    for model_name in model_names:
         if model_name in MODEL_STATE_MACHINES:
             result["workflows"][model_name] = MODEL_STATE_MACHINES[model_name]
 

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -680,8 +680,10 @@ async def batch_execute(
                     )
 
             await progress.increment()
-            # Small delay to allow progress updates to propagate
-            await asyncio.sleep(0.01)
+            # Yield to let the event loop flush progress notifications.
+            # Was sleep(0.01) — that added ~1s of dead wall-time to a 100-op batch
+            # without buying anything; sleep(0) is enough to schedule pending sends.
+            await asyncio.sleep(0)
 
         elapsed_ms = (time.time() - start_time) * 1000
         return BatchExecuteResponse(
@@ -1151,37 +1153,42 @@ async def execute_workflow(
 
 
 # ----- URI Routing for read_resource tool -----
-# Maps odoo:// URIs to their handler functions.
+# Maps odoo:// URIs to their handler functions. Patterns are compiled once at
+# import time (re.Pattern objects) so read_resource doesn't depend on Python's
+# implicit re._MAXCACHE for its dispatch path.
 # More specific patterns (e.g. /schema, /fields, /docs) MUST come before generic /model/{name}.
 
-_RESOURCE_ROUTES: list[tuple[str, callable, list[str]]] = [
-    (r"^odoo://models$", _resources.get_models, []),
-    (r"^odoo://session-bootstrap$", _resources.get_session_bootstrap, []),
-    (r"^odoo://bundle/(.+)$", _resources.get_bundle, ["models_csv"]),
-    (r"^odoo://model/([^/]+)/quick-schema$", _resources.get_model_quick_schema, ["model_name"]),
-    (r"^odoo://model/([^/]+)/workflow$", _resources.get_model_workflow, ["model_name"]),
-    (r"^odoo://model/([^/]+)/schema$", _resources.get_model_schema, ["model_name"]),
-    (r"^odoo://model/([^/]+)/fields$", _resources.get_model_fields_light, ["model_name"]),
-    (r"^odoo://model/([^/]+)/docs$", _resources.get_model_docs, ["model_name"]),
-    (r"^odoo://model/([^/]+)$", _resources.get_model_info, ["model_name"]),
-    (r"^odoo://record/([^/]+)/(\d+)$", _resources.get_record, ["model_name", "record_id"]),
-    (r"^odoo://methods/([^/]+)$", _resources.get_methods, ["model_name"]),
-    (r"^odoo://find-model/(.+)$", _resources.find_model_resource, ["concept"]),
-    (r"^odoo://actions/([^/]+)$", _resources.discover_actions_resource, ["model"]),
-    (r"^odoo://tools/(.+)$", _resources.search_tools_resource, ["query"]),
-    (r"^odoo://docs/(.+)$", _resources.get_documentation_urls, ["target"]),
-    (r"^odoo://module-knowledge/(.+)$", _resources.get_module_knowledge_by_name, ["module_name"]),
-    (r"^odoo://module-knowledge$", _resources.get_module_knowledge, []),
-    (r"^odoo://concepts$", _resources.get_concept_mappings, []),
-    (r"^odoo://templates$", _resources.get_resource_templates, []),
-    (r"^odoo://workflows$", _resources.get_workflows, []),
-    (r"^odoo://server/info$", _resources.get_server_info, []),
-    (r"^odoo://domain-syntax$", _resources.get_domain_syntax, []),
-    (r"^odoo://model-limitations$", _resources.get_model_limitations, []),
-    (r"^odoo://pagination$", _resources.get_pagination_guide, []),
-    (r"^odoo://hierarchical$", _resources.get_hierarchical_guide, []),
-    (r"^odoo://aggregation$", _resources.get_aggregation_guide, []),
-    (r"^odoo://tool-registry$", _resources.get_tool_registry, []),
+_RESOURCE_ROUTES: list[tuple[re.Pattern[str], Any, list[str]]] = [
+    (re.compile(pattern), handler, param_names)
+    for pattern, handler, param_names in [
+        (r"^odoo://models$", _resources.get_models, []),
+        (r"^odoo://session-bootstrap$", _resources.get_session_bootstrap, []),
+        (r"^odoo://bundle/(.+)$", _resources.get_bundle, ["models_csv"]),
+        (r"^odoo://model/([^/]+)/quick-schema$", _resources.get_model_quick_schema, ["model_name"]),
+        (r"^odoo://model/([^/]+)/workflow$", _resources.get_model_workflow, ["model_name"]),
+        (r"^odoo://model/([^/]+)/schema$", _resources.get_model_schema, ["model_name"]),
+        (r"^odoo://model/([^/]+)/fields$", _resources.get_model_fields_light, ["model_name"]),
+        (r"^odoo://model/([^/]+)/docs$", _resources.get_model_docs, ["model_name"]),
+        (r"^odoo://model/([^/]+)$", _resources.get_model_info, ["model_name"]),
+        (r"^odoo://record/([^/]+)/(\d+)$", _resources.get_record, ["model_name", "record_id"]),
+        (r"^odoo://methods/([^/]+)$", _resources.get_methods, ["model_name"]),
+        (r"^odoo://find-model/(.+)$", _resources.find_model_resource, ["concept"]),
+        (r"^odoo://actions/([^/]+)$", _resources.discover_actions_resource, ["model"]),
+        (r"^odoo://tools/(.+)$", _resources.search_tools_resource, ["query"]),
+        (r"^odoo://docs/(.+)$", _resources.get_documentation_urls, ["target"]),
+        (r"^odoo://module-knowledge/(.+)$", _resources.get_module_knowledge_by_name, ["module_name"]),
+        (r"^odoo://module-knowledge$", _resources.get_module_knowledge, []),
+        (r"^odoo://concepts$", _resources.get_concept_mappings, []),
+        (r"^odoo://templates$", _resources.get_resource_templates, []),
+        (r"^odoo://workflows$", _resources.get_workflows, []),
+        (r"^odoo://server/info$", _resources.get_server_info, []),
+        (r"^odoo://domain-syntax$", _resources.get_domain_syntax, []),
+        (r"^odoo://model-limitations$", _resources.get_model_limitations, []),
+        (r"^odoo://pagination$", _resources.get_pagination_guide, []),
+        (r"^odoo://hierarchical$", _resources.get_hierarchical_guide, []),
+        (r"^odoo://aggregation$", _resources.get_aggregation_guide, []),
+        (r"^odoo://tool-registry$", _resources.get_tool_registry, []),
+    ]
 ]
 
 
@@ -1225,7 +1232,7 @@ def read_resource(uri: str, max_chars: int = _READ_RESOURCE_MAX_CHARS) -> str:
         return json.dumps({"error": "Invalid URI: must start with odoo://", "uri": uri})
 
     for pattern, handler, param_names in _RESOURCE_ROUTES:
-        match = re.match(pattern, uri)
+        match = pattern.match(uri)
         if match:
             args = dict(zip(param_names, match.groups()))
             result = handler(**args)


### PR DESCRIPTION
## Summary

Four small perf improvements that together remove the largest user-visible
latency sources outside of the Odoo round-trip itself, plus a doc sync to
match the recent token-digest binding work.

## Changes

### perf (bee42da) — `src/odoo_mcp/{server,resources,odoo_client}.py`

- **P1** — `batch_execute`: replace `asyncio.sleep(0.01)` per op with `sleep(0)`. Saves up to ~1s of dead wall-time on a 100-op batch. The 10ms gap was speculative; one event-loop yield is enough to flush queued progress notifications.

- **P2** — `get_bundle` / `get_session_bootstrap`: replace sequential `fields_get` loops with a `ThreadPoolExecutor(max_workers=10)`. With 5 default bootstrap models @ 100ms RTT, latency drops from ~500ms to ~100ms; a 10-model bundle drops from ~1s to ~100ms. Order preserved (`executor.map` yields in input order), errors captured per model, JSON byte-identical.

  `requests.Session` is safe to share across threads provided we don't mutate session-level attrs after init — `OdooClient` sets headers/auth/verify in `__init__` and never touches them again.

- **P3** — `_RESOURCE_ROUTES`: compile each regex once at import (`re.Pattern` objects). Removes the implicit `re._MAXCACHE` dependency and corrects the placeholder `callable` (lowercase = builtin function, mypy reads it as `function`) annotation.

- **P5** — `OdooClient`: lift the `urllib3` per-host pool from the default of 10 to 20. P2 fans out up to 10 concurrent fetches; without P5, any concurrent `execute_method` would block waiting for a free connection.

### docs (bdd4b99) — `CLAUDE.md`

Drift fixes against `7fba877` (token payload-digest binding) and `4a39f13` (call-time env reads + `logging` module adoption):

- `tests/test_token_gate.py` added to the unit-test invocation
- Token-gate description updated to `(model, method, payload_digest)` with what the digest covers at each call site
- Audit-log line clarified: routes through Python `logging`, env vars are call-time

## Test plan

- [x] `pytest tests/test_safety.py tests/test_token_gate.py` — 143/143 pass
- [x] `ruff check src/odoo_mcp/{server,resources}.py` — 54 → 52 errors (zero new)
- [x] `mypy src/odoo_mcp/{server,resources}.py` — 80 → 73 errors (zero new)
- [x] Routing smoke test — 11/11 representative URIs match expected handlers
- [x] Pool smoke test — both http/https adapters report `pool_maxsize=20`
- [ ] Live test on real Odoo: `python tests/live/test_v1110_live.py` (script-style, needs `.env`)
- [ ] Manual: trigger a `session-bootstrap` and verify wall-time drops to ~1 RTT