### PR TITLE
feat(safety): MCP_SAFETY_MODE=locked + write-path hardening (v1.15.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ wiki/
 .claude/
 .superpowers/
 .omc/
+docs/superpowers/
 
 # uv lockfile (project uses pip + pyproject.toml)
 uv.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ Audit log via `logging.getLogger("odoo_mcp.safety")` (configured in `__init__.py
 | `MCP_SAFETY_AUDIT` | No | — | `true` to log audit entries to stderr |
 | `MCP_DEFAULT_CONTEXT` | No | — | JSON merged into all op contexts. Max 4KB. e.g. `{"lang":"fr_FR"}` |
 | `MCP_BOOTSTRAP_MODELS` | No | `res.partner,sale.order,account.move,product.product,stock.picking` | Models for `odoo://session-bootstrap`. Max 20. |
-| `MCP_READ_ONLY` | No | derived from mode | `true` to globally reject all side-effect methods (writes, `action_*`, `button_*`). |
+| `MCP_READ_ONLY` | No | derived from mode | `true` to reject every method that is not a known read. Fail-closed: the gate is `method not in SAFE_METHODS`, so unrecognised methods (`message_post`, `toggle_active`, `convert_opportunity`, `create_from_urls`, …) are blocked rather than assumed safe. The 13 SAFE_METHODS (`search_read`, `read`, `fields_get`, …) pass through. |
 | `MCP_WRITE_ALLOWLIST` | No | empty | Comma-separated `model.method` (or `model.*`) entries permitted as side effects. Enforced under `locked`, or explicitly via this var. |
 | `MCP_VALIDATE_PAYLOADS` | No | derived from mode | `true` to validate write payloads against live `fields_get` before issuing a confirmation token. |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,21 @@ execute_method("sale.order", "action_confirm", args_json='[[15]]',
     confirmed=True, confirmation_token='ymzyOtsZTDTJpKKysu_xWQ')
 ```
 
+### Locked mode (v1.15.0)
+
+`MCP_SAFETY_MODE=locked` adds four overlapping protections on top of the existing classifier and token gate:
+
+| Protection | Default under `locked` | Override |
+|---|---|---|
+| Global write kill-switch | on | `MCP_READ_ONLY=false` |
+| Side-effect allowlist enforced | on (empty list = no writes) | populate `MCP_WRITE_ALLOWLIST` |
+| HTTP bind | `127.0.0.1` | `MCP_HOST=0.0.0.0` |
+| Live `fields_get` payload pre-flight | on | `MCP_VALIDATE_PAYLOADS=false` |
+
+Each protection is independently overridable. Read `odoo://server-status` to see the resolved profile at runtime, including any foot-gun warnings.
+
+**Allowlist syntax**: `MCP_WRITE_ALLOWLIST="sale.order.action_confirm,res.partner.message_post,product.product.*"`. The wildcard matches any method on the named model. There is no `*.method` form (too easy to over-grant).
+
 Audit log via `logging.getLogger("odoo_mcp.safety")` (configured in `__init__.py` to stderr at INFO+) when `MCP_SAFETY_AUDIT=true`. `MCP_SAFETY_MODE`, `MCP_SAFETY_AUDIT`, and `MCP_DEFAULT_CONTEXT` are read at call time, so reconfiguring after import (or `patch.dict(os.environ, …)` in tests) takes effect immediately.
 
 ## Configuration
@@ -175,10 +190,13 @@ Audit log via `logging.getLogger("odoo_mcp.safety")` (configured in `__init__.py
 | `TOKEN_ENCRYPTION_KEY` / `TOKEN_ENCRYPTION_KEY_FILE` | With `USERS_DB_PATH` | — | Secret to decrypt registry Odoo credentials — must equal CLORAG's value |
 | `MCP_HOST` / `MCP_PORT` | No | `0.0.0.0` / `8080` | HTTP bind |
 | `MCP_VERBOSE` | No | `true` | Slant-ASCII startup banner (version, transport, masked creds, safety mode, capability counts). Writes to **stderr** only, so STDIO's stdout stays protocol-clean. Set `false` to silence. |
-| `MCP_SAFETY_MODE` | No | `strict` | Or `permissive` (only HIGH/BLOCKED confirm) |
+| `MCP_SAFETY_MODE` | No | `strict` | `permissive`, `strict`, or **`locked`** (new in v1.15.0). `locked` activates `MCP_READ_ONLY=true`, `MCP_WRITE_ALLOWLIST` enforcement, `MCP_HOST=127.0.0.1` default, and `MCP_VALIDATE_PAYLOADS=true`. |
 | `MCP_SAFETY_AUDIT` | No | — | `true` to log audit entries to stderr |
 | `MCP_DEFAULT_CONTEXT` | No | — | JSON merged into all op contexts. Max 4KB. e.g. `{"lang":"fr_FR"}` |
 | `MCP_BOOTSTRAP_MODELS` | No | `res.partner,sale.order,account.move,product.product,stock.picking` | Models for `odoo://session-bootstrap`. Max 20. |
+| `MCP_READ_ONLY` | No | derived from mode | `true` to globally reject all side-effect methods (writes, `action_*`, `button_*`). |
+| `MCP_WRITE_ALLOWLIST` | No | empty | Comma-separated `model.method` (or `model.*`) entries permitted as side effects. Enforced under `locked`, or explicitly via this var. |
+| `MCP_VALIDATE_PAYLOADS` | No | derived from mode | `true` to validate write payloads against live `fields_get` before issuing a confirmation token. |
 
 ## Tools (5)
 
@@ -203,6 +221,7 @@ Audit log via `logging.getLogger("odoo_mcp.safety")` (configured in `__init__.py
 | `odoo://methods/{model}` | Live-enriched (signatures, return types, decorators) via `/doc-bearer/`; static fallback |
 | `odoo://model-limitations` | Known issues + runtime-detected problematic combos |
 | `odoo://domain-syntax` / `odoo://aggregation` / `odoo://pagination` / `odoo://hierarchical` | Reference docs |
+| `odoo://server-status` | Resolved safety profile, transport, host, allowlist, warnings. Non-secret. New in v1.15.0. |
 
 When read through the `read_resource` tool (rather than a native resource client), every one of these is capped at 15 000 chars by default — `odoo://model/{model}/schema` needs `max_chars=0` to come back whole.
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ layer blocks every non-safe method.
 | | |
 |---|---|
 | **5 tools** | `execute_method` reaches any method on any model; `batch_execute`, `execute_workflow`, `configure_odoo`, and `read_resource` cover the rest |
-| **27 resources** | Model discovery, compact schemas, state-machine workflows, and introspection |
+| **28 resources** | Model discovery, compact schemas, state-machine workflows, introspection, and runtime posture (`odoo://server-status`) |
 | **19 prompts** | 12 generic guided workflows plus 7 `cyanview-*` skill prompts, gated per user in multi-user mode |
 | **Safety layer** | Risk classification before execution, 8 blocked models, 6 sensitive models, cascade warnings |
+| **Locked mode** | One flag (`MCP_SAFETY_MODE=locked`) turns writes off, enforces a write allowlist, binds HTTP to localhost, and pre-flights payloads against live `fields_get` — each layer independently overridable |
 | **Multi-user mode** | Per-user bearer keys and personal Odoo clients, so every write is attributed to a real person |
 | **Reference data** | 30 documented ORM methods, 13 modules with special-method knowledge, including the Enterprise AI module |
 
@@ -269,7 +270,7 @@ token issued for `unlink([1])` and reuse it on `unlink([1, 2, …, 1000])`.
 | `configure_odoo` | Interactive connection setup |
 | `read_resource` | Read any `odoo://` resource by URI |
 
-### Resources (27)
+### Resources (28)
 
 | Resource | Description |
 |----------|-------------|
@@ -300,6 +301,7 @@ token issued for `unlink([1])` and reuse it on `unlink([1, 2, …, 1000])`.
 | `odoo://hierarchical` | Parent/child tree query patterns |
 | `odoo://aggregation` | Aggregation guide (formatted_read_group) |
 | `odoo://model-limitations` | Known model issues + runtime problems |
+| `odoo://server-status` | Runtime safety posture (mode, host, allowlist, warnings). Non-secret. **New in v1.15.0.** |
 
 ### Prompts (19)
 
@@ -371,6 +373,41 @@ Side effects are surfaced for workflow actions:
 
 Tokens are single-use, expire after 120s, and are bound to the specific model+method. This prevents agents from bypassing the safety gate by always passing `confirmed=true`.
 
+### Locked mode (v1.15.0)
+
+`MCP_SAFETY_MODE=locked` adds four overlapping protections on top of the classifier and token gate. Designed for safe-by-default deployments where a colleague might point an over-eager AI agent at their own Odoo instance.
+
+| Protection | Default under `locked` | Override env var |
+|---|---|---|
+| Global write kill-switch | on | `MCP_READ_ONLY=false` |
+| Side-effect allowlist enforced | on (empty list = no writes) | populate `MCP_WRITE_ALLOWLIST` |
+| HTTP bind | `127.0.0.1` (localhost-only) | `MCP_HOST=0.0.0.0` |
+| Live `fields_get` payload pre-flight | on | `MCP_VALIDATE_PAYLOADS=false` |
+
+Each protection is independently overridable — set `locked` and tune the individual flags as needed. `permissive` and `strict` semantics are unchanged from v1.14.0; no existing deploy changes posture on upgrade unless the operator opts in.
+
+**Allowlist syntax**: `MCP_WRITE_ALLOWLIST="sale.order.action_confirm,res.partner.message_post,product.product.*"`. Each entry is `model.method` or `model.*` (any method on the model). Cross-model wildcards (`*.method`) are rejected — too easy to over-grant.
+
+**Three typical configurations:**
+
+```bash
+# Safe-by-default — paste this and forget
+MCP_SAFETY_MODE=locked
+
+# Locked but allow specific side-effect methods
+MCP_SAFETY_MODE=locked
+MCP_READ_ONLY=false
+MCP_WRITE_ALLOWLIST=res.partner.message_post,sale.order.action_confirm
+
+# Power user — current v1.14.0 behaviour, no changes
+MCP_SAFETY_MODE=strict
+```
+
+**Posture introspection**: read `odoo://server-status` to see the resolved profile at runtime — current mode, host, allowlist contents, and any foot-gun warnings (e.g. `locked` + `MCP_HOST=0.0.0.0`, or `locked` + `MCP_READ_ONLY=false`). The startup banner shows a one-line summary: `[SAFETY locked · READ-ONLY · BIND 127.0.0.1 · ALLOWLIST 0 entries]`.
+
+**Payload pre-flight** (`MCP_VALIDATE_PAYLOADS=true`): before issuing a confirmation token for a write, the validator fetches `fields_get` for the target model (60s LRU cache) and rejects payloads that reference non-existent fields, write to readonly fields, or arrive when the connection is silently down (`fields_get` returns `{}`). Catches hallucinated field names before they reach Odoo.
+
+## DX Improvements (v1.11.0)
 ## Token-efficient discovery
 
 ### Quick schema
@@ -527,10 +564,14 @@ env `ODOO_*` credentials become optional (only the `env-admin` fallback uses the
 | `MCP_API_KEY` | HTTP: this **or** `USERS_DB_PATH` | — | Static bearer token (single-user HTTP, or admin fallback in multi-user mode). HTTP server `sys.exit(1)` if neither is set |
 | `USERS_DB_PATH` | No | — | Path to the CLORAG registry (`users.db`) → enables [multi-user mode](#multi-user-mode) |
 | `TOKEN_ENCRYPTION_KEY` / `TOKEN_ENCRYPTION_KEY_FILE` | With `USERS_DB_PATH` | — | Secret to decrypt registry Odoo credentials — must equal CLORAG's value |
-| `MCP_HOST` | No | `0.0.0.0` | HTTP bind address |
+| `MCP_HOST` | No | `0.0.0.0` (`127.0.0.1` under `locked`) | HTTP bind address. Default flips to localhost when `MCP_SAFETY_MODE=locked`. |
 | `MCP_PORT` | No | `8080` | HTTP port |
 | `MCP_VERBOSE` | No | `true` | Slant-ASCII startup banner to stderr (version, transport, masked creds, safety mode, capability counts). `false` to silence |
-| `MCP_SAFETY_MODE` | No | `strict` | `strict` or `permissive` |
+| `MCP_SAFETY_MODE` | No | `strict` | `permissive`, `strict`, or **`locked`** (v1.15.0). `locked` activates `MCP_READ_ONLY=true`, `MCP_WRITE_ALLOWLIST` enforcement, `MCP_HOST=127.0.0.1` default, and `MCP_VALIDATE_PAYLOADS=true`. |
+| `MCP_SAFETY_MODE` | No | `strict` | `permissive`, `strict`, or **`locked`** (v1.15.0). `locked` activates `MCP_READ_ONLY=true`, `MCP_WRITE_ALLOWLIST` enforcement, `MCP_HOST=127.0.0.1` default, and `MCP_VALIDATE_PAYLOADS=true`. |
+| `MCP_READ_ONLY` | No | derived from mode | `true` to globally reject all side-effect methods (`create`, `write`, `unlink`, `copy`, `name_create`, `load`, `action_*`, `button_*`, `_action_*`). Reads pass through. |
+| `MCP_WRITE_ALLOWLIST` | No | empty | Comma-separated `model.method` (or `model.*`) entries permitted as side effects. Enforced under `locked` mode, or whenever set explicitly. |
+| `MCP_VALIDATE_PAYLOADS` | No | derived from mode | `true` to validate write payloads against live `fields_get` before issuing a confirmation token. Catches hallucinated fields and readonly writes. |
 | `MCP_SAFETY_AUDIT` | No | — | `true` to log safety audit to stderr |
 | `MCP_DEFAULT_CONTEXT` | No | — | JSON object merged into all contexts (max 4KB) |
 | `MCP_BOOTSTRAP_MODELS` | No | `res.partner,sale.order,account.move,product.product,stock.picking` | Models for session-bootstrap (max 20) |

--- a/README.md
+++ b/README.md
@@ -568,8 +568,7 @@ env `ODOO_*` credentials become optional (only the `env-admin` fallback uses the
 | `MCP_PORT` | No | `8080` | HTTP port |
 | `MCP_VERBOSE` | No | `true` | Slant-ASCII startup banner to stderr (version, transport, masked creds, safety mode, capability counts). `false` to silence |
 | `MCP_SAFETY_MODE` | No | `strict` | `permissive`, `strict`, or **`locked`** (v1.15.0). `locked` activates `MCP_READ_ONLY=true`, `MCP_WRITE_ALLOWLIST` enforcement, `MCP_HOST=127.0.0.1` default, and `MCP_VALIDATE_PAYLOADS=true`. |
-| `MCP_SAFETY_MODE` | No | `strict` | `permissive`, `strict`, or **`locked`** (v1.15.0). `locked` activates `MCP_READ_ONLY=true`, `MCP_WRITE_ALLOWLIST` enforcement, `MCP_HOST=127.0.0.1` default, and `MCP_VALIDATE_PAYLOADS=true`. |
-| `MCP_READ_ONLY` | No | derived from mode | `true` to globally reject all side-effect methods (`create`, `write`, `unlink`, `copy`, `name_create`, `load`, `action_*`, `button_*`, `_action_*`). Reads pass through. |
+| `MCP_READ_ONLY` | No | derived from mode | `true` to reject every method that is not a known read. Fail-closed: the gate is `method not in SAFE_METHODS`, so unrecognised methods (`message_post`, `toggle_active`, `convert_opportunity`, `create_from_urls`, …) are blocked rather than assumed safe. The 13 SAFE_METHODS (`search_read`, `read`, `fields_get`, …) pass through. |
 | `MCP_WRITE_ALLOWLIST` | No | empty | Comma-separated `model.method` (or `model.*`) entries permitted as side effects. Enforced under `locked` mode, or whenever set explicitly. |
 | `MCP_VALIDATE_PAYLOADS` | No | derived from mode | `true` to validate write payloads against live `fields_get` before issuing a confirmation token. Catches hallucinated fields and readonly writes. |
 | `MCP_SAFETY_AUDIT` | No | — | `true` to log safety audit to stderr |

--- a/src/odoo_mcp/__main__.py
+++ b/src/odoo_mcp/__main__.py
@@ -300,10 +300,28 @@ def _print_startup_banner(transport: str, host: str, port: int) -> None:
     ]
     if ssl_disabled:
         parts.append("  WARNING       : SSL verification is DISABLED -- vulnerable to MITM")
+    from .safety_profile import get_profile
+    profile = get_profile()
+    posture_line = (
+        f"[SAFETY {profile.safety_mode.value}"
+        f"{' · READ-ONLY' if profile.read_only else ' · WRITES ON'}"
+        f" · BIND {profile.host}"
+    )
+    if profile.write_allowlist_enforced:
+        posture_line += f" · ALLOWLIST {len(profile.write_allowlist)} entries"
+    posture_line += "]"
+    for warn in profile.warnings:
+        parts.append(f"  WARNING       : {warn}")
+
     parts += [
         "",
         "  -- Safety layer --",
-        f"  Mode          : {safety_mode}",
+        f"  {posture_line}",
+        f"  Mode          : {profile.safety_mode.value}",
+        f"  Read-only     : {profile.read_only}",
+        f"  Allowlist     : {len(profile.write_allowlist)} entries"
+        + (" (enforced)" if profile.write_allowlist_enforced else ""),
+        f"  Validate pl.  : {profile.validate_payloads}",
         f"  Audit log     : {safety_audit}",
         "",
         "  -- DX defaults --",

--- a/src/odoo_mcp/__main__.py
+++ b/src/odoo_mcp/__main__.py
@@ -327,8 +327,11 @@ def main():
         run_setup_wizard()
         return
 
+    from .safety_profile import get_profile
+
     transport = os.environ.get("MCP_TRANSPORT", "stdio")
-    host = os.environ.get("MCP_HOST", "0.0.0.0")
+    profile = get_profile()
+    host = profile.host
     port = int(os.environ.get("MCP_PORT", "8080"))
 
     # Verbose startup banner. On by default for both transports — the banner

--- a/src/odoo_mcp/__main__.py
+++ b/src/odoo_mcp/__main__.py
@@ -139,7 +139,9 @@ def run_setup_wizard():
 
     # --- Safety ---
     print("── Safety ──")
-    config["safety_mode"] = _prompt_choice("Safety mode", ["strict", "permissive"], "strict")
+    config["safety_mode"] = _prompt_choice(
+        "Safety mode", ["strict", "permissive", "locked"], "strict"
+    )
     print()
 
     # --- Output ---

--- a/src/odoo_mcp/__main__.py
+++ b/src/odoo_mcp/__main__.py
@@ -139,9 +139,7 @@ def run_setup_wizard():
 
     # --- Safety ---
     print("── Safety ──")
-    config["safety_mode"] = _prompt_choice(
-        "Safety mode", ["strict", "permissive", "locked"], "strict"
-    )
+    config["safety_mode"] = _prompt_choice("Safety mode", ["strict", "permissive", "locked"], "strict")
     print()
 
     # --- Output ---
@@ -264,7 +262,6 @@ def _print_startup_banner(transport: str, host: str, port: int) -> None:
     odoo_ssl = os.environ.get("ODOO_VERIFY_SSL", "true")
     ssl_disabled = odoo_ssl.lower() in ("0", "false", "no", "off") and odoo_url.startswith("https://")
 
-    safety_mode = os.environ.get("MCP_SAFETY_MODE", "strict")
     safety_audit = os.environ.get("MCP_SAFETY_AUDIT", "false")
     default_ctx = os.environ.get("MCP_DEFAULT_CONTEXT", "(none)")
     bootstrap = os.environ.get(
@@ -303,6 +300,7 @@ def _print_startup_banner(transport: str, host: str, port: int) -> None:
     if ssl_disabled:
         parts.append("  WARNING       : SSL verification is DISABLED -- vulnerable to MITM")
     from .safety_profile import get_profile
+
     profile = get_profile()
     posture_line = (
         f"[SAFETY {profile.safety_mode.value}"

--- a/src/odoo_mcp/resources.py
+++ b/src/odoo_mcp/resources.py
@@ -9,7 +9,7 @@ import json
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from .app import mcp
 from .constants import (
@@ -1366,6 +1366,7 @@ def get_tool_registry() -> str:
 
 # ----- Server-status resource -----
 
+
 @mcp.resource(
     "odoo://server-status",
     name="server-status",
@@ -1402,7 +1403,10 @@ def _server_status_payload() -> str:
     except ValueError:
         port = 8080
     audit = os.environ.get("MCP_SAFETY_AUDIT", "").lower() in (
-        "true", "1", "yes", "on",
+        "true",
+        "1",
+        "yes",
+        "on",
     )
     default_ctx_raw = os.environ.get("MCP_DEFAULT_CONTEXT", "")
     try:

--- a/src/odoo_mcp/resources.py
+++ b/src/odoo_mcp/resources.py
@@ -1362,3 +1362,67 @@ def get_tool_registry() -> str:
         },
         indent=2,
     )
+
+
+# ----- Server-status resource -----
+
+@mcp.resource(
+    "odoo://server-status",
+    name="server-status",
+    description=(
+        "Runtime posture: resolved safety profile, transport, host, "
+        "allowlist, and any foot-gun warnings. Non-secret. Useful for "
+        "monitoring scripts and agents to know which gates are active."
+    ),
+)
+def server_status() -> str:
+    """Decorated handler for odoo://server-status. Delegates to the helper
+    so the read_resource bridge can call the same code path."""
+    return _server_status_payload()
+
+
+def _server_status_payload() -> str:
+    """Build the server-status JSON payload. Pure function — reads env each
+    call so tests can monkeypatch."""
+    import os
+    from importlib.metadata import version as _pkg_version
+
+    from .safety_profile import get_profile
+
+    try:
+        version = _pkg_version("odoo-mcp-19")
+    except Exception:
+        version = "unknown"
+
+    profile = get_profile()
+    transport = os.environ.get("MCP_TRANSPORT", "stdio")
+    port_raw = os.environ.get("MCP_PORT", "8080")
+    try:
+        port = int(port_raw)
+    except ValueError:
+        port = 8080
+    audit = os.environ.get("MCP_SAFETY_AUDIT", "").lower() in (
+        "true", "1", "yes", "on",
+    )
+    default_ctx_raw = os.environ.get("MCP_DEFAULT_CONTEXT", "")
+    try:
+        default_ctx = json.loads(default_ctx_raw) if default_ctx_raw else None
+    except json.JSONDecodeError:
+        default_ctx = None
+
+    payload = {
+        "version": version,
+        "transport": transport,
+        "host": profile.host,
+        "port": port,
+        "safety_mode": profile.safety_mode.value,
+        "read_only": profile.read_only,
+        "write_allowlist": sorted(profile.write_allowlist),
+        "write_allowlist_enforced": profile.write_allowlist_enforced,
+        "validate_payloads": profile.validate_payloads,
+        "audit_logging": audit,
+        "default_context": default_ctx,
+        "posture_open": profile.posture_open,
+        "warnings": list(profile.warnings),
+    }
+    return json.dumps(payload, indent=2)

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -12,6 +12,7 @@ Environment variables:
 import json
 import logging
 import os
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
@@ -623,3 +624,83 @@ def audit_log(
             logger.error("[SAFETY AUDIT ERROR] %s", exc)
         except Exception:
             pass
+
+
+# ----- Payload Pre-flight Validation (Phase 2) -----
+
+@dataclass(frozen=True)
+class PayloadValidationResult:
+    ok: bool
+    errors: list[str]
+
+
+def _extract_vals_dict(method: str, args: list) -> dict | None:
+    """Pull the vals dict out of an operation's args, depending on method."""
+    if not args:
+        return None
+    if method == "create":
+        # create([{...}]) or create({...})
+        first = args[0]
+        if isinstance(first, dict):
+            return first
+        if isinstance(first, list) and first and isinstance(first[0], dict):
+            return first[0]  # validate first record only
+        return None
+    if method in ("write", "copy"):
+        # write([ids], {...})
+        if len(args) >= 2 and isinstance(args[1], dict):
+            return args[1]
+    return None  # action_*, button_*, unlink: no vals dict
+
+
+def validate_payload_against_schema(
+    client,
+    model: str,
+    method: str,
+    args: list | None = None,
+    kwargs: dict | None = None,
+) -> PayloadValidationResult:
+    """Validate that a write payload references only real, writable fields.
+
+    Returns ok=True for non-vals methods (action_*, button_*, unlink) — those
+    have no payload to validate.
+
+    Empty fields_get response counts as a failure: a silent connection
+    drop must not grant a write token.
+    """
+    from .utils import get_fields_for_model
+
+    args = args or []
+    vals = _extract_vals_dict(method, args)
+    if vals is None:
+        return PayloadValidationResult(ok=True, errors=[])
+
+    fields = get_fields_for_model(client, model)
+    if not fields:
+        return PayloadValidationResult(
+            ok=False,
+            errors=[
+                f"Could not load schema for '{model}' (fields_get returned "
+                f"empty). Refusing to issue a confirmation token without a "
+                f"verified field list."
+            ],
+        )
+
+    errors: list[str] = []
+    for field_name, value in vals.items():
+        if field_name == "context":
+            continue  # context is a kwargs concern, not a vals field
+        spec = fields.get(field_name)
+        if spec is None:
+            errors.append(
+                f"Field '{field_name}' does not exist on model '{model}'. "
+                f"Read odoo://model/{model}/quick-schema for the field list."
+            )
+            continue
+        if spec.get("readonly"):
+            errors.append(
+                f"Field '{field_name}' is readonly on '{model}' and cannot "
+                f"be written."
+            )
+
+    return PayloadValidationResult(ok=not errors, errors=errors)

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -143,8 +143,11 @@ CASCADE_WARNINGS: dict[tuple[str, str], str] = {
 # ----- Side-Effect Method Predicate -----
 
 # Methods whose names are explicitly side-effects regardless of pattern.
+# action_archive/action_unarchive are also covered by the "action_" prefix
+# below — kept here for explicit defense-in-depth.
 _LITERAL_SIDE_EFFECT_METHODS = frozenset({
     "create", "write", "unlink", "copy",
+    "name_create", "load",
     "action_archive", "action_unarchive",
 })
 

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -177,6 +177,25 @@ def is_side_effect_method(method: str) -> bool:
     return any(method.startswith(p) for p in _SIDE_EFFECT_PREFIXES)
 
 
+def _allowlist_blocks(model: str, method: str, profile) -> bool:
+    """Return True if the resolved profile's allowlist is enforced AND the
+    given (model, method) is not permitted.
+
+    Does NOT short-circuit BLOCKED_MODELS or SAFE methods — callers must
+    check those first.
+    """
+    if not profile.write_allowlist_enforced:
+        return False
+    if not is_side_effect_method(method):
+        return False
+    full_key = f"{model}.{method}"
+    wildcard_key = f"{model}.*"
+    return (
+        full_key not in profile.write_allowlist
+        and wildcard_key not in profile.write_allowlist
+    )
+
+
 # ----- Pydantic Models -----
 
 
@@ -294,12 +313,15 @@ def classify_operation(
     Classification logic:
     1. SAFE_METHODS → SAFE (even on blocked/sensitive models)
     2. BLOCKED_MODELS + non-safe method → BLOCKED
-    3. HIGH_METHODS → HIGH (always confirm)
-    4. MEDIUM_METHODS → depends on mode/model/volume
-    5. Unknown methods → MEDIUM
+    3. Allowlist enforcement — side-effect calls blocked unless explicitly permitted
+    4. HIGH_METHODS → HIGH (always confirm)
+    5. MEDIUM_METHODS → depends on mode/model/volume
+    6. Unknown methods → MEDIUM
     """
     args = args or []
     kwargs = kwargs or {}
+    from .safety_profile import get_profile
+    profile = get_profile()
     mode = _get_safety_mode()
     record_count = _estimate_record_count(method, args, kwargs)
     cascade_warning = CASCADE_WARNINGS.get((model, method))
@@ -341,7 +363,23 @@ def classify_operation(
             ),
         )
 
-    # 3. High-risk methods always require confirmation
+    # 3. Allowlist enforcement — explicit permits required for side-effect calls.
+    if _allowlist_blocks(model, method, profile):
+        return SafetyClassification(
+            risk_level=RiskLevel.BLOCKED,
+            model=model,
+            method=method,
+            record_count=record_count,
+            requires_confirmation=False,
+            reason=f"'{model}.{method}' is not in MCP_WRITE_ALLOWLIST.",
+            blocked_reason=(
+                f"Side-effect call '{model}.{method}' rejected: not present in "
+                f"MCP_WRITE_ALLOWLIST. Add the entry to allow it, or use a "
+                f"safe read method instead."
+            ),
+        )
+
+    # 4. High-risk methods always require confirmation
     if method in HIGH_METHODS:
         reason = f"'{method}' is a high-risk operation"
         if record_count and record_count > 1:
@@ -357,7 +395,7 @@ def classify_operation(
             cascade_warning=cascade_warning,
         )
 
-    # 4. Medium-risk methods: depends on mode, model, volume
+    # 5. Medium-risk methods: depends on mode, model, volume
     if method in MEDIUM_METHODS:
         # Sensitive models always need confirmation for writes
         if model in SENSITIVE_MODELS:
@@ -397,7 +435,7 @@ def classify_operation(
             cascade_warning=cascade_warning,
         )
 
-    # 5. Unknown methods → MEDIUM, confirmation depends on mode
+    # 6. Unknown methods → MEDIUM, confirmation depends on mode
     requires_confirm = mode == "strict"
     return SafetyClassification(
         risk_level=RiskLevel.MEDIUM,

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -157,6 +157,12 @@ _SIDE_EFFECT_PREFIXES: tuple[str, ...] = (
     "action_", "button_", "_action_",
 )
 
+# Modes whose classifier behaviour requires confirmation for unknown methods
+# and for batch (record_count > 1) MEDIUM operations. "locked" inherits the
+# "strict" classifier semantics in addition to its own profile-layer gates
+# (read_only, write_allowlist, validate_payloads).
+_STRICT_EQUIV: frozenset[str] = frozenset({"strict", "locked"})
+
 
 def is_side_effect_method(method: str) -> bool:
     """Return True if calling this method should be treated as a side effect.
@@ -410,8 +416,12 @@ def classify_operation(
                 cascade_warning=cascade_warning,
             )
 
-        # Strict mode: confirm if batch (record_count > 1)
-        if mode == "strict" and record_count is not None and record_count > 1:
+        # Modes treated as confirmation-required ("strict" semantics).
+        # Note: "locked" inherits "strict" classifier behaviour for unknown
+        # and batch operations (in addition to its own read_only / allowlist
+        # gates resolved at the profile layer).
+        # Strict and locked modes: confirm if batch (record_count > 1)
+        if mode in _STRICT_EQUIV and record_count is not None and record_count > 1:
             return SafetyClassification(
                 risk_level=RiskLevel.MEDIUM,
                 model=model,
@@ -437,7 +447,7 @@ def classify_operation(
         )
 
     # 6. Unknown methods → MEDIUM, confirmation depends on mode
-    requires_confirm = mode == "strict"
+    requires_confirm = mode in _STRICT_EQUIV
     return SafetyClassification(
         risk_level=RiskLevel.MEDIUM,
         model=model,

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -140,6 +140,40 @@ CASCADE_WARNINGS: dict[tuple[str, str], str] = {
 }
 
 
+# ----- Side-Effect Method Predicate -----
+
+# Methods whose names are explicitly side-effects regardless of pattern.
+_LITERAL_SIDE_EFFECT_METHODS = frozenset({
+    "create", "write", "unlink", "copy",
+    "action_archive", "action_unarchive",
+})
+
+# Method-name prefixes that always indicate side effects.
+_SIDE_EFFECT_PREFIXES: tuple[str, ...] = (
+    "action_", "button_", "_action_",
+)
+
+
+def is_side_effect_method(method: str) -> bool:
+    """Return True if calling this method should be treated as a side effect.
+
+    Single source of truth for the read-only guard, the write allowlist, and
+    the payload pre-flight. Cheap pattern match — does NOT call the classifier.
+
+    Side-effect methods include:
+      * Literal CRUD names (create, write, unlink, copy, action_archive, ...)
+      * Anything matching action_*, button_*, _action_*
+
+    SAFE methods (search_read, read, fields_get, ...) and unknown read-like
+    methods return False.
+    """
+    if not method:
+        return False
+    if method in _LITERAL_SIDE_EFFECT_METHODS:
+        return True
+    return any(method.startswith(p) for p in _SIDE_EFFECT_PREFIXES)
+
+
 # ----- Pydantic Models -----
 
 

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -143,29 +143,6 @@ CASCADE_WARNINGS: dict[tuple[str, str], str] = {
 
 # ----- Side-Effect Method Predicate -----
 
-# Methods whose names are explicitly side-effects regardless of pattern.
-# action_archive/action_unarchive are also covered by the "action_" prefix
-# below — kept here for explicit defense-in-depth.
-_LITERAL_SIDE_EFFECT_METHODS = frozenset(
-    {
-        "create",
-        "write",
-        "unlink",
-        "copy",
-        "name_create",
-        "load",
-        "action_archive",
-        "action_unarchive",
-    }
-)
-
-# Method-name prefixes that always indicate side effects.
-_SIDE_EFFECT_PREFIXES: tuple[str, ...] = (
-    "action_",
-    "button_",
-    "_action_",
-)
-
 # Modes whose classifier behaviour requires confirmation for unknown methods
 # and for batch (record_count > 1) MEDIUM operations. "locked" inherits the
 # "strict" classifier semantics in addition to its own profile-layer gates
@@ -174,23 +151,26 @@ _STRICT_EQUIV: frozenset[str] = frozenset({"strict", "locked"})
 
 
 def is_side_effect_method(method: str) -> bool:
-    """Return True if calling this method should be treated as a side effect.
+    """Return True if calling this method must be treated as a side effect.
 
     Single source of truth for the read-only guard, the write allowlist, and
-    the payload pre-flight. Cheap pattern match — does NOT call the classifier.
+    the payload pre-flight. Cheap set lookup — does NOT call the classifier.
 
-    Side-effect methods include:
-      * Literal CRUD names (create, write, unlink, copy, action_archive, ...)
-      * Anything matching action_*, button_*, _action_*
+    **Fail-closed: anything outside SAFE_METHODS counts as a side effect.**
+    Recognising writes by name shape (a literal CRUD set plus action_* /
+    button_* prefixes) is not sufficient for a kill-switch, because Odoo is
+    full of write methods that match neither. `module_knowledge.json` alone
+    documents `add_members`, `article_create`, `article_duplicate`,
+    `channel_create`, `convert_opportunity`, `create_from_urls`,
+    `create_from_attachments`, `create_from_binary_files`, `document_create`,
+    `get_direct_response` and `open_agent_chat`; the standard ORM adds
+    ubiquitous ones like `message_post` and `toggle_active`. Under
+    MCP_READ_ONLY none of those may reach Odoo, so the only defensible
+    default is to gate everything we cannot prove is a read.
 
-    SAFE methods (search_read, read, fields_get, ...) and unknown read-like
-    methods return False.
+    SAFE_METHODS (search_read, read, fields_get, ...) return False.
     """
-    if not method:
-        return False
-    if method in _LITERAL_SIDE_EFFECT_METHODS:
-        return True
-    return any(method.startswith(p) for p in _SIDE_EFFECT_PREFIXES)
+    return method not in SAFE_METHODS
 
 
 def _allowlist_blocks(model: str, method: str, profile) -> bool:
@@ -652,23 +632,37 @@ class PayloadValidationResult:
     errors: list[str]
 
 
-def _extract_vals_dict(method: str, args: list) -> dict | None:
-    """Pull the vals dict out of an operation's args, depending on method."""
-    if not args:
-        return None
-    if method == "create":
-        # create([{...}]) or create({...})
-        first = args[0]
-        if isinstance(first, dict):
-            return first
-        if isinstance(first, list) and first and isinstance(first[0], dict):
-            return first[0]  # validate first record only
-        return None
-    if method in ("write", "copy"):
-        # write([ids], {...})
-        if len(args) >= 2 and isinstance(args[1], dict):
-            return args[1]
-    return None  # action_*, button_*, unlink: no vals dict
+# Where the vals payload lives for each method: (positional index, kwargs key).
+# The v2 API is named-args-only, so the same payload reaches us either way and
+# both spellings must be read — checking only the positional form lets a write
+# skip validation by moving its vals into kwargs_json. Same class of bug as
+# _estimate_record_count before it learned to read _COUNTED_ARG from kwargs.
+_VALS_ARG: dict[str, tuple[int, str]] = {
+    "create": (0, "vals_list"),
+    "write": (1, "vals"),
+    "copy": (1, "default"),
+}
+
+
+def _extract_vals_dict(method: str, args: list, kwargs: dict | None = None) -> dict | None:
+    """Pull the vals dict out of an operation's args or kwargs, by method."""
+    spec = _VALS_ARG.get(method)
+    if spec is None:
+        return None  # action_*, button_*, unlink: no vals dict
+    position, key = spec
+    kwargs = kwargs or {}
+
+    raw: Any = None
+    if args and len(args) > position:
+        raw = args[position]
+    elif key in kwargs:
+        raw = kwargs[key]
+
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list) and raw and isinstance(raw[0], dict):
+        return raw[0]  # create([{...}]) — validate the first record only
+    return None
 
 
 def validate_payload_against_schema(
@@ -689,7 +683,7 @@ def validate_payload_against_schema(
     from .utils import get_fields_for_model
 
     args = args or []
-    vals = _extract_vals_dict(method, args)
+    vals = _extract_vals_dict(method, args, kwargs)
     if vals is None:
         return PayloadValidationResult(ok=True, errors=[])
 

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -146,15 +146,24 @@ CASCADE_WARNINGS: dict[tuple[str, str], str] = {
 # Methods whose names are explicitly side-effects regardless of pattern.
 # action_archive/action_unarchive are also covered by the "action_" prefix
 # below — kept here for explicit defense-in-depth.
-_LITERAL_SIDE_EFFECT_METHODS = frozenset({
-    "create", "write", "unlink", "copy",
-    "name_create", "load",
-    "action_archive", "action_unarchive",
-})
+_LITERAL_SIDE_EFFECT_METHODS = frozenset(
+    {
+        "create",
+        "write",
+        "unlink",
+        "copy",
+        "name_create",
+        "load",
+        "action_archive",
+        "action_unarchive",
+    }
+)
 
 # Method-name prefixes that always indicate side effects.
 _SIDE_EFFECT_PREFIXES: tuple[str, ...] = (
-    "action_", "button_", "_action_",
+    "action_",
+    "button_",
+    "_action_",
 )
 
 # Modes whose classifier behaviour requires confirmation for unknown methods
@@ -197,10 +206,7 @@ def _allowlist_blocks(model: str, method: str, profile) -> bool:
         return False
     full_key = f"{model}.{method}"
     wildcard_key = f"{model}.*"
-    return (
-        full_key not in profile.write_allowlist
-        and wildcard_key not in profile.write_allowlist
-    )
+    return full_key not in profile.write_allowlist and wildcard_key not in profile.write_allowlist
 
 
 # ----- Pydantic Models -----
@@ -328,6 +334,7 @@ def classify_operation(
     args = args or []
     kwargs = kwargs or {}
     from .safety_profile import get_profile
+
     profile = get_profile()
     mode = _get_safety_mode()
     record_count = _estimate_record_count(method, args, kwargs)
@@ -638,6 +645,7 @@ def audit_log(
 
 # ----- Payload Pre-flight Validation (Phase 2) -----
 
+
 @dataclass(frozen=True)
 class PayloadValidationResult:
     ok: bool
@@ -708,9 +716,6 @@ def validate_payload_against_schema(
             )
             continue
         if spec.get("readonly"):
-            errors.append(
-                f"Field '{field_name}' is readonly on '{model}' and cannot "
-                f"be written."
-            )
+            errors.append(f"Field '{field_name}' is readonly on '{model}' and cannot " f"be written.")
 
     return PayloadValidationResult(ok=not errors, errors=errors)

--- a/src/odoo_mcp/safety_profile.py
+++ b/src/odoo_mcp/safety_profile.py
@@ -1,0 +1,166 @@
+"""Safety profile resolution for the Odoo MCP server.
+
+Reads MCP_SAFETY_MODE (umbrella) plus four override env vars and produces a
+ResolvedProfile value object. Hybrid umbrella + per-flag override pattern:
+the mode picks sensible defaults; explicit individual env vars override them.
+
+Environment variables:
+    MCP_SAFETY_MODE: 'permissive' | 'strict' (default) | 'locked'
+    MCP_READ_ONLY: 'true' | 'false' — global write kill-switch
+    MCP_WRITE_ALLOWLIST: comma-separated 'model.method' entries
+    MCP_HOST: host to bind for HTTP transport
+    MCP_VALIDATE_PAYLOADS: 'true' | 'false' — Phase 2 fields_get pre-flight
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Mapping
+
+logger = logging.getLogger(__name__)
+
+
+class SafetyMode(str, Enum):
+    PERMISSIVE = "permissive"
+    STRICT = "strict"
+    LOCKED = "locked"
+
+
+_TRUE_VALUES = frozenset({"true", "1", "yes", "on"})
+_FALSE_VALUES = frozenset({"false", "0", "no", "off", ""})
+
+
+def _parse_bool(raw: str | None, default: bool) -> bool:
+    """Parse a truthy/falsy env string. Garbage falls back to default."""
+    if raw is None:
+        return default
+    lowered = raw.strip().lower()
+    if lowered in _TRUE_VALUES:
+        return True
+    if lowered in _FALSE_VALUES:
+        return False
+    logger.warning("Could not parse boolean env value %r, using default %r", raw, default)
+    return default
+
+
+def _parse_allowlist(raw: str | None) -> frozenset[str]:
+    """Parse a comma-separated 'model.method' list into a frozenset."""
+    if not raw:
+        return frozenset()
+    return frozenset(
+        entry.strip()
+        for entry in raw.split(",")
+        if entry.strip()
+    )
+
+
+def _parse_mode(raw: str | None) -> SafetyMode:
+    if not raw:
+        return SafetyMode.STRICT
+    lowered = raw.strip().lower()
+    try:
+        return SafetyMode(lowered)
+    except ValueError:
+        logger.warning(
+            "Unknown MCP_SAFETY_MODE=%r, falling back to 'strict'", raw,
+        )
+        return SafetyMode.STRICT
+
+
+@dataclass(frozen=True)
+class ResolvedProfile:
+    """Fully-resolved safety profile read once from env at startup (and on
+    each call from get_profile() so tests can monkeypatch env)."""
+
+    safety_mode: SafetyMode
+    read_only: bool
+    write_allowlist: frozenset[str]
+    write_allowlist_enforced: bool
+    host: str
+    host_default: str
+    validate_payloads: bool
+    posture_open: bool
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+
+def resolve(env: Mapping[str, str]) -> ResolvedProfile:
+    """Resolve a ResolvedProfile from a mapping of env vars.
+
+    Pure function: takes a mapping (typically os.environ), returns a frozen
+    dataclass. No side effects, no global state.
+    """
+    mode = _parse_mode(env.get("MCP_SAFETY_MODE"))
+
+    # Defaults derived from mode.
+    if mode is SafetyMode.LOCKED:
+        default_read_only = True
+        default_host = "127.0.0.1"
+        default_validate = True
+        default_allowlist_enforced = True
+    else:
+        default_read_only = False
+        default_host = "0.0.0.0"
+        default_validate = False
+        default_allowlist_enforced = False
+
+    # Per-flag overrides.
+    read_only = _parse_bool(env.get("MCP_READ_ONLY"), default_read_only)
+    validate_payloads = _parse_bool(
+        env.get("MCP_VALIDATE_PAYLOADS"), default_validate,
+    )
+    raw_host = env.get("MCP_HOST")
+    host = raw_host if raw_host else default_host
+
+    raw_allowlist = env.get("MCP_WRITE_ALLOWLIST")
+    write_allowlist = _parse_allowlist(raw_allowlist)
+    # Allowlist enforcement: locked mode always enforces. Explicit allowlist
+    # under any mode also enforces (the operator opted in).
+    write_allowlist_enforced = (
+        default_allowlist_enforced or raw_allowlist is not None
+    )
+
+    # posture_open: maximally-loose configuration.
+    posture_open = (
+        mode is SafetyMode.PERMISSIVE
+        and host == "0.0.0.0"
+        and not write_allowlist_enforced
+        and not read_only
+    )
+
+    # Warnings: surface foot-gun combinations explicitly.
+    warnings: list[str] = []
+    if mode is SafetyMode.LOCKED and host == "0.0.0.0":
+        warnings.append(
+            "MCP_SAFETY_MODE=locked but MCP_HOST=0.0.0.0 — "
+            "remote bind enabled despite locked profile."
+        )
+    if read_only and write_allowlist:
+        warnings.append(
+            "MCP_READ_ONLY=true makes MCP_WRITE_ALLOWLIST redundant — "
+            "no writes will be permitted regardless of allowlist."
+        )
+
+    return ResolvedProfile(
+        safety_mode=mode,
+        read_only=read_only,
+        write_allowlist=write_allowlist,
+        write_allowlist_enforced=write_allowlist_enforced,
+        host=host,
+        host_default=default_host,
+        validate_payloads=validate_payloads,
+        posture_open=posture_open,
+        warnings=tuple(warnings),
+    )
+
+
+def get_profile() -> ResolvedProfile:
+    """Resolve the profile from os.environ at call time.
+
+    Re-reads env on each call so tests can monkeypatch env vars and see the
+    new profile immediately, matching the existing get_default_context() and
+    _get_safety_mode() pattern in the codebase.
+    """
+    import os
+    return resolve(os.environ)

--- a/src/odoo_mcp/safety_profile.py
+++ b/src/odoo_mcp/safety_profile.py
@@ -15,6 +15,7 @@ Environment variables:
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Mapping
@@ -45,15 +46,34 @@ def _parse_bool(raw: str | None, default: bool) -> bool:
     return default
 
 
+_ALLOWLIST_ENTRY_RE = re.compile(r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+\.([\w]+|\*)$")
+
+
 def _parse_allowlist(raw: str | None) -> frozenset[str]:
-    """Parse a comma-separated 'model.method' list into a frozenset."""
+    """Parse a comma-separated 'model.method' list into a frozenset.
+
+    Each entry must match either 'model.method' or 'model.*'. Entries that
+    do not match are dropped with a warning — this catches mistakes like
+    '*.write' (cross-model wildcards are deliberately not supported because
+    they over-grant) and obvious typos.
+    """
     if not raw:
         return frozenset()
-    return frozenset(
-        entry.strip()
-        for entry in raw.split(",")
-        if entry.strip()
-    )
+    valid: set[str] = set()
+    for entry in raw.split(","):
+        cleaned = entry.strip()
+        if not cleaned:
+            continue
+        if _ALLOWLIST_ENTRY_RE.match(cleaned):
+            valid.add(cleaned)
+        else:
+            logger.warning(
+                "MCP_WRITE_ALLOWLIST entry %r is not in 'model.method' or "
+                "'model.*' form — dropped (cross-model wildcards like "
+                "'*.method' are not supported).",
+                cleaned,
+            )
+    return frozenset(valid)
 
 
 def _parse_mode(raw: str | None) -> SafetyMode:
@@ -135,6 +155,12 @@ def resolve(env: Mapping[str, str]) -> ResolvedProfile:
         warnings.append(
             "MCP_SAFETY_MODE=locked but MCP_HOST=0.0.0.0 — "
             "remote bind enabled despite locked profile."
+        )
+    if mode is SafetyMode.LOCKED and not read_only:
+        warnings.append(
+            "MCP_SAFETY_MODE=locked but MCP_READ_ONLY=false — "
+            "the primary write kill-switch is disabled; only "
+            "MCP_WRITE_ALLOWLIST gates side-effect calls."
         )
     if read_only and write_allowlist:
         warnings.append(

--- a/src/odoo_mcp/safety_profile.py
+++ b/src/odoo_mcp/safety_profile.py
@@ -84,7 +84,8 @@ def _parse_mode(raw: str | None) -> SafetyMode:
         return SafetyMode(lowered)
     except ValueError:
         logger.warning(
-            "Unknown MCP_SAFETY_MODE=%r, falling back to 'strict'", raw,
+            "Unknown MCP_SAFETY_MODE=%r, falling back to 'strict'",
+            raw,
         )
         return SafetyMode.STRICT
 
@@ -128,7 +129,8 @@ def resolve(env: Mapping[str, str]) -> ResolvedProfile:
     # Per-flag overrides.
     read_only = _parse_bool(env.get("MCP_READ_ONLY"), default_read_only)
     validate_payloads = _parse_bool(
-        env.get("MCP_VALIDATE_PAYLOADS"), default_validate,
+        env.get("MCP_VALIDATE_PAYLOADS"),
+        default_validate,
     )
     raw_host = env.get("MCP_HOST")
     host = raw_host if raw_host else default_host
@@ -137,25 +139,17 @@ def resolve(env: Mapping[str, str]) -> ResolvedProfile:
     write_allowlist = _parse_allowlist(raw_allowlist)
     # Allowlist enforcement: locked mode always enforces. Explicit allowlist
     # under any mode also enforces (the operator opted in).
-    write_allowlist_enforced = (
-        default_allowlist_enforced or raw_allowlist is not None
-    )
+    write_allowlist_enforced = default_allowlist_enforced or raw_allowlist is not None
 
     # posture_open: maximally-loose configuration.
     posture_open = (
-        mode is SafetyMode.PERMISSIVE
-        and host == "0.0.0.0"
-        and not write_allowlist_enforced
-        and not read_only
+        mode is SafetyMode.PERMISSIVE and host == "0.0.0.0" and not write_allowlist_enforced and not read_only
     )
 
     # Warnings: surface foot-gun combinations explicitly.
     warnings: list[str] = []
     if mode is SafetyMode.LOCKED and host == "0.0.0.0":
-        warnings.append(
-            "MCP_SAFETY_MODE=locked but MCP_HOST=0.0.0.0 — "
-            "remote bind enabled despite locked profile."
-        )
+        warnings.append("MCP_SAFETY_MODE=locked but MCP_HOST=0.0.0.0 — " "remote bind enabled despite locked profile.")
     if mode is SafetyMode.LOCKED and not read_only:
         warnings.append(
             "MCP_SAFETY_MODE=locked but MCP_READ_ONLY=false — "
@@ -189,4 +183,5 @@ def get_profile() -> ResolvedProfile:
     _get_safety_mode() pattern in the codebase.
     """
     import os
+
     return resolve(os.environ)

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -253,8 +253,9 @@ def execute_method(
             success=False,
             error=(
                 f"read-only mode is active: '{method}' on '{model}' is a "
-                f"side-effect operation (set MCP_READ_ONLY=false or "
-                f"MCP_SAFETY_MODE=strict to enable writes)."
+                f"side-effect operation. Set MCP_READ_ONLY=false to enable "
+                f"writes (or change MCP_SAFETY_MODE away from 'locked' if "
+                f"MCP_READ_ONLY is not set explicitly)."
             ),
             execution_time_ms=int((time.time() - start_time) * 1000),
         )
@@ -596,8 +597,10 @@ async def batch_execute(
                     success=False,
                     error=(
                         f"read-only mode is active: batch contains side-effect "
-                        f"operation '{method}' on '{op.get('model', '?')}' "
-                        f"(set MCP_READ_ONLY=false or MCP_SAFETY_MODE=strict to enable writes)."
+                        f"operation '{method}' on '{op.get('model', '?')}'. "
+                        f"Set MCP_READ_ONLY=false to enable writes (or change "
+                        f"MCP_SAFETY_MODE away from 'locked' if MCP_READ_ONLY "
+                        f"is not set explicitly)."
                     ),
                     results=[],
                     total_operations=len(operations),
@@ -960,8 +963,10 @@ async def execute_workflow(
             success=False,
             error=(
                 f"read-only mode is active: workflow '{workflow}' is a "
-                f"multi-step action and is rejected under MCP_READ_ONLY=true "
-                f"(set MCP_READ_ONLY=false or MCP_SAFETY_MODE=strict to enable workflows)."
+                f"multi-step action and is rejected under MCP_READ_ONLY=true. "
+                f"Set MCP_READ_ONLY=false to enable workflows (or change "
+                f"MCP_SAFETY_MODE away from 'locked' if MCP_READ_ONLY is "
+                f"not set explicitly)."
             ),
         )
 

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -1158,6 +1158,7 @@ _RESOURCE_ROUTES: list[tuple[re.Pattern[str], Any, list[str]]] = [
     for pattern, handler, param_names in [
         (r"^odoo://models$", _resources.get_models, []),
         (r"^odoo://session-bootstrap$", _resources.get_session_bootstrap, []),
+        (r"^odoo://server-status$", _resources._server_status_payload, []),
         (r"^odoo://bundle/(.+)$", _resources.get_bundle, ["models_csv"]),
         (r"^odoo://model/([^/]+)/quick-schema$", _resources.get_model_quick_schema, ["model_name"]),
         (r"^odoo://model/([^/]+)/workflow$", _resources.get_model_workflow, ["model_name"]),

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -19,7 +19,7 @@ import secrets
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from fastmcp import Context
 from fastmcp.dependencies import Progress
@@ -402,8 +402,13 @@ def execute_method(
             # Only when the profile asks for it AND this is a write-shaped call.
             if get_profile().validate_payloads and is_side_effect_method(method):
                 from .safety import validate_payload_against_schema as _validate_payload
+
                 _validation = _validate_payload(
-                    odoo, model, method, args=args, kwargs=kwargs,
+                    odoo,
+                    model,
+                    method,
+                    args=args,
+                    kwargs=kwargs,
                 )
                 if not _validation.ok:
                     elapsed_ms = (time.time() - start_time) * 1000

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -397,6 +397,22 @@ def execute_method(
             )
 
         if classification.requires_confirmation:
+            # Phase 2: payload pre-flight against live fields_get.
+            # Only when the profile asks for it AND this is a write-shaped call.
+            if get_profile().validate_payloads and is_side_effect_method(method):
+                from .safety import validate_payload_against_schema as _validate_payload
+                _validation = _validate_payload(
+                    odoo, model, method, args=args, kwargs=kwargs,
+                )
+                if not _validation.ok:
+                    elapsed_ms = (time.time() - start_time) * 1000
+                    return ExecuteMethodResponse(
+                        success=False,
+                        error="Payload validation failed:\n  - " + "\n  - ".join(_validation.errors),
+                        hint=f"Read odoo://model/{model}/quick-schema for the field list.",
+                        execution_time_ms=round(elapsed_ms, 2),
+                    )
+
             # Bind the token to the exact (model, method, args, kwargs) seen here.
             # Args/kwargs are post-resolve_json and post-context-merge, so the digest
             # captures what would actually be sent to Odoo.

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -948,17 +948,6 @@ async def execute_workflow(
         Results from each step of the workflow
     """
     start_time = time.time()
-    # Get Odoo client directly (works in both sync and background task modes)
-    odoo = get_odoo_client()
-
-    try:
-        params = json.loads(params_json) if params_json else {}
-    except json.JSONDecodeError as e:
-        return ExecuteWorkflowResponse(
-            workflow=workflow,
-            success=False,
-            error=f"Invalid params_json: {e}",
-        )
 
     # Read-only kill-switch — workflows are by definition multi-step actions.
     profile = get_profile()
@@ -973,6 +962,18 @@ async def execute_workflow(
                 f"MCP_SAFETY_MODE away from 'locked' if MCP_READ_ONLY is "
                 f"not set explicitly)."
             ),
+        )
+
+    # Get Odoo client directly (works in both sync and background task modes)
+    odoo = get_odoo_client()
+
+    try:
+        params = json.loads(params_json) if params_json else {}
+    except json.JSONDecodeError as e:
+        return ExecuteWorkflowResponse(
+            workflow=workflow,
+            success=False,
+            error=f"Invalid params_json: {e}",
         )
 
     # --- Safety Classification for workflow ---

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -568,6 +568,27 @@ async def batch_execute(
         confirmed: Set to true to bypass safety confirmation
     """
     start_time = time.time()
+
+    # Read-only kill-switch — reject the whole batch if any operation is a
+    # side-effect call. Runs before classification.
+    profile = get_profile()
+    if profile.read_only:
+        for op in operations:
+            method = op.get("method", "")
+            if is_side_effect_method(method):
+                return BatchExecuteResponse(
+                    success=False,
+                    error=(
+                        f"read-only mode is active: batch contains side-effect "
+                        f"operation '{method}' on '{op.get('model', '?')}' "
+                        f"(set MCP_READ_ONLY=false or MCP_SAFETY_MODE=strict to enable writes)."
+                    ),
+                    results=[],
+                    total_operations=len(operations),
+                    successful_operations=0,
+                    failed_operations=0,
+                )
+
     # Get Odoo client directly (works in both sync and background task modes)
     odoo = get_odoo_client()
     results: List[BatchOperationResult] = []
@@ -913,6 +934,19 @@ async def execute_workflow(
             workflow=workflow,
             success=False,
             error=f"Invalid params_json: {e}",
+        )
+
+    # Read-only kill-switch — workflows are by definition multi-step actions.
+    profile = get_profile()
+    if profile.read_only:
+        return ExecuteWorkflowResponse(
+            workflow=workflow,
+            success=False,
+            error=(
+                f"read-only mode is active: workflow '{workflow}' is a "
+                f"multi-step action and is rejected under MCP_READ_ONLY=true "
+                f"(set MCP_READ_ONLY=false or MCP_SAFETY_MODE=strict to enable workflows)."
+            ),
         )
 
     # --- Safety Classification for workflow ---

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -54,7 +54,9 @@ from .safety import (
     classify_batch,
     classify_operation,
     classify_workflow,
+    is_side_effect_method,
 )
+from .safety_profile import get_profile
 from .user_clients import current_role
 from .utils import (
     _get_live_doc,
@@ -242,6 +244,20 @@ def execute_method(
     method_err = _validate_method(method)
     if method_err:
         return ExecuteMethodResponse(success=False, error=method_err, execution_time_ms=0)
+
+    # Read-only kill-switch (MCP_READ_ONLY / MCP_SAFETY_MODE=locked).
+    # Runs before the classifier — cheap pattern match, no Odoo round-trip.
+    profile = get_profile()
+    if profile.read_only and is_side_effect_method(method):
+        return ExecuteMethodResponse(
+            success=False,
+            error=(
+                f"read-only mode is active: '{method}' on '{model}' is a "
+                f"side-effect operation (set MCP_READ_ONLY=false or "
+                f"MCP_SAFETY_MODE=strict to enable writes)."
+            ),
+            execution_time_ms=int((time.time() - start_time) * 1000),
+        )
 
     odoo = get_odoo_client()
 

--- a/src/odoo_mcp/utils.py
+++ b/src/odoo_mcp/utils.py
@@ -8,7 +8,9 @@ schema building, and issue tracking.
 import json
 import logging
 import re
+import threading
 import time
+from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -422,3 +424,41 @@ def _get_documentation_urls(target: str) -> str:
             break
 
     return json.dumps(result, indent=2)
+
+
+# ----- Live fields_get cache (used by payload pre-flight) -----
+
+_FIELDS_CACHE: "OrderedDict[str, tuple[float, dict]]" = OrderedDict()
+_FIELDS_CACHE_LOCK = threading.Lock()
+_FIELDS_CACHE_TTL = 60  # seconds — shorter than _DOC_CACHE since model
+                        # schemas can change with module updates
+_FIELDS_CACHE_MAX = 100
+
+
+def get_fields_for_model(client, model: str) -> dict:
+    """Return the fields_get response for a model, with TTL+LRU caching.
+
+    Empty responses are NOT cached — they typically indicate a silently-failed
+    Odoo connection, and we don't want to grant a write token based on
+    'no fields exist therefore validation passes'.
+    """
+    now = time.time()
+    with _FIELDS_CACHE_LOCK:
+        cached = _FIELDS_CACHE.get(model)
+        if cached and (now - cached[0]) < _FIELDS_CACHE_TTL:
+            _FIELDS_CACHE.move_to_end(model)
+            return cached[1]
+
+    # Cache miss or expired — fetch fresh.
+    fields = client.execute_kw(model, "fields_get", [], {})
+
+    if not fields:
+        # Don't cache an empty response — we don't want to remember a failure.
+        return {}
+
+    with _FIELDS_CACHE_LOCK:
+        _FIELDS_CACHE[model] = (now, fields)
+        _FIELDS_CACHE.move_to_end(model)
+        while len(_FIELDS_CACHE) > _FIELDS_CACHE_MAX:
+            _FIELDS_CACHE.popitem(last=False)
+    return fields

--- a/src/odoo_mcp/utils.py
+++ b/src/odoo_mcp/utils.py
@@ -450,10 +450,18 @@ def get_fields_for_model(client, model: str) -> dict:
             return cached[1]
 
     # Cache miss or expired — fetch fresh.
-    fields = client.execute_kw(model, "fields_get", [], {})
+    # Treat any exception (network failure, model-not-found, auth error) as
+    # an empty schema — the caller's pre-flight will refuse to issue a
+    # token without a verified field list, which is the safe behaviour.
+    try:
+        fields = client.execute_method(model, "fields_get")
+    except Exception as exc:
+        logger.warning("fields_get for %r failed: %s", model, exc)
+        return {}
 
-    if not fields:
-        # Don't cache an empty response — we don't want to remember a failure.
+    if not fields or not isinstance(fields, dict):
+        # Don't cache an empty (or unexpected non-dict) response — we don't
+        # want to remember a failure.
         return {}
 
     with _FIELDS_CACHE_LOCK:

--- a/src/odoo_mcp/utils.py
+++ b/src/odoo_mcp/utils.py
@@ -431,7 +431,7 @@ def _get_documentation_urls(target: str) -> str:
 _FIELDS_CACHE: "OrderedDict[str, tuple[float, dict]]" = OrderedDict()
 _FIELDS_CACHE_LOCK = threading.Lock()
 _FIELDS_CACHE_TTL = 60  # seconds — shorter than _DOC_CACHE since model
-                        # schemas can change with module updates
+# schemas can change with module updates
 _FIELDS_CACHE_MAX = 100
 
 

--- a/tests/live/test_locked_mode_live.py
+++ b/tests/live/test_locked_mode_live.py
@@ -1,0 +1,120 @@
+"""Live integration test for MCP_SAFETY_MODE=locked.
+
+Mutates env state. Run directly with python:
+    python tests/live/test_locked_mode_live.py
+
+Requires .env in cwd with valid Odoo credentials.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+# Make src/ importable.
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv()
+
+
+def _reset_env():
+    for key in (
+        "MCP_SAFETY_MODE", "MCP_READ_ONLY", "MCP_WRITE_ALLOWLIST",
+        "MCP_HOST", "MCP_VALIDATE_PAYLOADS",
+    ):
+        os.environ.pop(key, None)
+
+
+def test_locked_blocks_write():
+    _reset_env()
+    os.environ["MCP_SAFETY_MODE"] = "locked"
+    from odoo_mcp.server import execute_method
+    from unittest.mock import MagicMock
+
+    response = execute_method(
+        ctx=MagicMock(),
+        model="res.partner",
+        method="write",
+        args_json='[[1], {"name": "live-test"}]',
+    )
+    assert not response.success
+    assert "read-only" in (response.error or "").lower()
+    print("✓ locked blocks write")
+
+
+def test_locked_allows_safe_read():
+    _reset_env()
+    os.environ["MCP_SAFETY_MODE"] = "locked"
+    from odoo_mcp.server import execute_method
+    from unittest.mock import MagicMock
+
+    response = execute_method(
+        ctx=MagicMock(),
+        model="res.partner",
+        method="search_read",
+        args_json='[[]]',
+        kwargs_json='{"fields": ["name"], "limit": 1}',
+    )
+    assert response.success, f"locked should permit reads, got: {response.error}"
+    print("✓ locked allows safe read")
+
+
+def test_allowlist_unblocks_named_method():
+    _reset_env()
+    os.environ["MCP_SAFETY_MODE"] = "locked"
+    os.environ["MCP_READ_ONLY"] = "false"  # Allow writes generally...
+    os.environ["MCP_WRITE_ALLOWLIST"] = "res.partner.message_post"
+    from odoo_mcp.safety import classify_operation, RiskLevel
+
+    # ...but only message_post on res.partner is allowed.
+    permitted = classify_operation(
+        "res.partner", "message_post", args=[[1], "live test"],
+    )
+    blocked = classify_operation(
+        "res.partner", "write", args=[[1], {"name": "X"}],
+    )
+    assert permitted.risk_level is not RiskLevel.BLOCKED
+    assert blocked.risk_level is RiskLevel.BLOCKED
+    print("✓ allowlist unblocks named method, blocks others")
+
+
+def test_server_status_resource():
+    _reset_env()
+    os.environ["MCP_SAFETY_MODE"] = "locked"
+    from odoo_mcp.server import read_resource
+
+    raw = read_resource("odoo://server-status")
+    payload = json.loads(raw)
+    assert payload["safety_mode"] == "locked"
+    assert payload["read_only"] is True
+    assert payload["host"] == "127.0.0.1"
+    print("✓ server-status reports locked posture")
+
+
+def test_payload_validation_catches_bad_field():
+    _reset_env()
+    os.environ["MCP_SAFETY_MODE"] = "strict"  # so writes are allowed
+    os.environ["MCP_VALIDATE_PAYLOADS"] = "true"
+    from odoo_mcp.server import execute_method
+    from unittest.mock import MagicMock
+
+    response = execute_method(
+        ctx=MagicMock(),
+        model="res.partner",
+        method="write",
+        args_json='[[1], {"definitely_not_a_field": "x"}]',
+    )
+    assert not response.success
+    assert "definitely_not_a_field" in (response.error or "")
+    print("✓ payload pre-flight catches hallucinated field")
+
+
+if __name__ == "__main__":
+    test_locked_blocks_write()
+    test_locked_allows_safe_read()
+    test_allowlist_unblocks_named_method()
+    test_server_status_resource()
+    test_payload_validation_catches_bad_field()
+    print("\nAll locked-mode live checks passed.")

--- a/tests/live/test_locked_mode_live.py
+++ b/tests/live/test_locked_mode_live.py
@@ -5,6 +5,7 @@ Mutates env state. Run directly with python:
 
 Requires .env in cwd with valid Odoo credentials.
 """
+
 import json
 import os
 import sys
@@ -21,8 +22,11 @@ load_dotenv()
 
 def _reset_env():
     for key in (
-        "MCP_SAFETY_MODE", "MCP_READ_ONLY", "MCP_WRITE_ALLOWLIST",
-        "MCP_HOST", "MCP_VALIDATE_PAYLOADS",
+        "MCP_SAFETY_MODE",
+        "MCP_READ_ONLY",
+        "MCP_WRITE_ALLOWLIST",
+        "MCP_HOST",
+        "MCP_VALIDATE_PAYLOADS",
     ):
         os.environ.pop(key, None)
 
@@ -30,8 +34,9 @@ def _reset_env():
 def test_locked_blocks_write():
     _reset_env()
     os.environ["MCP_SAFETY_MODE"] = "locked"
-    from odoo_mcp.server import execute_method
     from unittest.mock import MagicMock
+
+    from odoo_mcp.server import execute_method
 
     response = execute_method(
         ctx=MagicMock(),
@@ -47,14 +52,15 @@ def test_locked_blocks_write():
 def test_locked_allows_safe_read():
     _reset_env()
     os.environ["MCP_SAFETY_MODE"] = "locked"
-    from odoo_mcp.server import execute_method
     from unittest.mock import MagicMock
+
+    from odoo_mcp.server import execute_method
 
     response = execute_method(
         ctx=MagicMock(),
         model="res.partner",
         method="search_read",
-        args_json='[[]]',
+        args_json="[[]]",
         kwargs_json='{"fields": ["name"], "limit": 1}',
     )
     assert response.success, f"locked should permit reads, got: {response.error}"
@@ -66,14 +72,18 @@ def test_allowlist_unblocks_named_method():
     os.environ["MCP_SAFETY_MODE"] = "locked"
     os.environ["MCP_READ_ONLY"] = "false"  # Allow writes generally...
     os.environ["MCP_WRITE_ALLOWLIST"] = "res.partner.message_post"
-    from odoo_mcp.safety import classify_operation, RiskLevel
+    from odoo_mcp.safety import RiskLevel, classify_operation
 
     # ...but only message_post on res.partner is allowed.
     permitted = classify_operation(
-        "res.partner", "message_post", args=[[1], "live test"],
+        "res.partner",
+        "message_post",
+        args=[[1], "live test"],
     )
     blocked = classify_operation(
-        "res.partner", "write", args=[[1], {"name": "X"}],
+        "res.partner",
+        "write",
+        args=[[1], {"name": "X"}],
     )
     assert permitted.risk_level is not RiskLevel.BLOCKED
     assert blocked.risk_level is RiskLevel.BLOCKED
@@ -97,8 +107,9 @@ def test_payload_validation_catches_bad_field():
     _reset_env()
     os.environ["MCP_SAFETY_MODE"] = "strict"  # so writes are allowed
     os.environ["MCP_VALIDATE_PAYLOADS"] = "true"
-    from odoo_mcp.server import execute_method
     from unittest.mock import MagicMock
+
+    from odoo_mcp.server import execute_method
 
     response = execute_method(
         ctx=MagicMock(),

--- a/tests/test_fields_cache.py
+++ b/tests/test_fields_cache.py
@@ -22,7 +22,7 @@ def clear_cache():
 
 def test_first_call_hits_odoo():
     client = MagicMock()
-    client.execute_kw.return_value = {
+    client.execute_method.return_value = {
         "name": {"type": "char", "readonly": False, "required": True},
         "id": {"type": "integer", "readonly": True, "required": False},
     }
@@ -30,22 +30,22 @@ def test_first_call_hits_odoo():
     fields = get_fields_for_model(client, "res.partner")
 
     assert "name" in fields
-    assert client.execute_kw.call_count == 1
+    assert client.execute_method.call_count == 1
 
 
 def test_second_call_hits_cache():
     client = MagicMock()
-    client.execute_kw.return_value = {"name": {"type": "char"}}
+    client.execute_method.return_value = {"name": {"type": "char"}}
 
     get_fields_for_model(client, "res.partner")
     get_fields_for_model(client, "res.partner")
 
-    assert client.execute_kw.call_count == 1
+    assert client.execute_method.call_count == 1
 
 
 def test_cache_expires_after_ttl(monkeypatch):
     client = MagicMock()
-    client.execute_kw.return_value = {"name": {"type": "char"}}
+    client.execute_method.return_value = {"name": {"type": "char"}}
 
     get_fields_for_model(client, "res.partner")
 
@@ -55,28 +55,28 @@ def test_cache_expires_after_ttl(monkeypatch):
 
     get_fields_for_model(client, "res.partner")
 
-    assert client.execute_kw.call_count == 2
+    assert client.execute_method.call_count == 2
 
 
 def test_empty_response_not_cached():
     """An Odoo connection that returns {} should not poison the cache."""
     client = MagicMock()
-    client.execute_kw.return_value = {}
+    client.execute_method.return_value = {}
 
     fields = get_fields_for_model(client, "res.partner")
     assert fields == {}
 
     # Second call must re-query (we don't trust an empty response).
-    client.execute_kw.return_value = {"name": {"type": "char"}}
+    client.execute_method.return_value = {"name": {"type": "char"}}
     fields = get_fields_for_model(client, "res.partner")
     assert "name" in fields
-    assert client.execute_kw.call_count == 2
+    assert client.execute_method.call_count == 2
 
 
 def test_lru_eviction():
     """Cache caps at 100 entries; oldest evicted first."""
     client = MagicMock()
-    client.execute_kw.return_value = {"x": {"type": "char"}}
+    client.execute_method.return_value = {"x": {"type": "char"}}
 
     for i in range(110):
         get_fields_for_model(client, f"model.test_{i}")

--- a/tests/test_fields_cache.py
+++ b/tests/test_fields_cache.py
@@ -1,0 +1,85 @@
+"""Tests for the live fields_get cache used by payload pre-flight."""
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from odoo_mcp.utils import (
+    _FIELDS_CACHE,
+    _FIELDS_CACHE_LOCK,
+    get_fields_for_model,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    with _FIELDS_CACHE_LOCK:
+        _FIELDS_CACHE.clear()
+    yield
+    with _FIELDS_CACHE_LOCK:
+        _FIELDS_CACHE.clear()
+
+
+def test_first_call_hits_odoo():
+    client = MagicMock()
+    client.execute_kw.return_value = {
+        "name": {"type": "char", "readonly": False, "required": True},
+        "id": {"type": "integer", "readonly": True, "required": False},
+    }
+
+    fields = get_fields_for_model(client, "res.partner")
+
+    assert "name" in fields
+    assert client.execute_kw.call_count == 1
+
+
+def test_second_call_hits_cache():
+    client = MagicMock()
+    client.execute_kw.return_value = {"name": {"type": "char"}}
+
+    get_fields_for_model(client, "res.partner")
+    get_fields_for_model(client, "res.partner")
+
+    assert client.execute_kw.call_count == 1
+
+
+def test_cache_expires_after_ttl(monkeypatch):
+    client = MagicMock()
+    client.execute_kw.return_value = {"name": {"type": "char"}}
+
+    get_fields_for_model(client, "res.partner")
+
+    # Fast-forward time past the TTL (60s).
+    real_time = time.time
+    monkeypatch.setattr(time, "time", lambda: real_time() + 61)
+
+    get_fields_for_model(client, "res.partner")
+
+    assert client.execute_kw.call_count == 2
+
+
+def test_empty_response_not_cached():
+    """An Odoo connection that returns {} should not poison the cache."""
+    client = MagicMock()
+    client.execute_kw.return_value = {}
+
+    fields = get_fields_for_model(client, "res.partner")
+    assert fields == {}
+
+    # Second call must re-query (we don't trust an empty response).
+    client.execute_kw.return_value = {"name": {"type": "char"}}
+    fields = get_fields_for_model(client, "res.partner")
+    assert "name" in fields
+    assert client.execute_kw.call_count == 2
+
+
+def test_lru_eviction():
+    """Cache caps at 100 entries; oldest evicted first."""
+    client = MagicMock()
+    client.execute_kw.return_value = {"x": {"type": "char"}}
+
+    for i in range(110):
+        get_fields_for_model(client, f"model.test_{i}")
+
+    with _FIELDS_CACHE_LOCK:
+        assert len(_FIELDS_CACHE) <= 100

--- a/tests/test_fields_cache.py
+++ b/tests/test_fields_cache.py
@@ -1,4 +1,5 @@
 """Tests for the live fields_get cache used by payload pre-flight."""
+
 import time
 from unittest.mock import MagicMock
 

--- a/tests/test_main_bind_default.py
+++ b/tests/test_main_bind_default.py
@@ -25,3 +25,28 @@ def test_main_module_imports_cleanly(monkeypatch):
     from odoo_mcp import __main__ as main_mod
     importlib.reload(main_mod)
     assert hasattr(main_mod, "main")
+
+
+def test_banner_includes_posture_line(capfd, monkeypatch):
+    """Banner shows resolved posture: mode + read-only state + bind."""
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.setenv("MCP_VERBOSE", "true")
+
+    from odoo_mcp.__main__ import _print_startup_banner
+    _print_startup_banner("stdio", "127.0.0.1", 8080)
+
+    err = capfd.readouterr().err
+    assert "locked" in err.lower()
+    assert "read-only" in err.lower() or "read_only" in err.lower()
+
+
+def test_banner_includes_allowlist_count(capfd, monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "sale.order.action_confirm,res.partner.message_post")
+
+    from odoo_mcp.__main__ import _print_startup_banner
+    _print_startup_banner("stdio", "127.0.0.1", 8080)
+
+    err = capfd.readouterr().err
+    assert "2" in err  # allowlist count
+    assert "allowlist" in err.lower()

--- a/tests/test_main_bind_default.py
+++ b/tests/test_main_bind_default.py
@@ -1,0 +1,27 @@
+"""Tests for MCP_HOST default-resolution flip under locked mode."""
+
+from odoo_mcp.safety_profile import resolve
+
+
+def test_strict_mode_default_host_is_0_0_0_0():
+    profile = resolve({"MCP_SAFETY_MODE": "strict"})
+    assert profile.host == "0.0.0.0"
+
+
+def test_locked_mode_default_host_is_localhost():
+    profile = resolve({"MCP_SAFETY_MODE": "locked"})
+    assert profile.host == "127.0.0.1"
+
+
+def test_explicit_host_overrides_locked_default():
+    profile = resolve({"MCP_SAFETY_MODE": "locked", "MCP_HOST": "0.0.0.0"})
+    assert profile.host == "0.0.0.0"
+
+
+def test_main_module_imports_cleanly(monkeypatch):
+    """Smoke check — importing __main__ should not error after the host
+    resolution change."""
+    import importlib
+    from odoo_mcp import __main__ as main_mod
+    importlib.reload(main_mod)
+    assert hasattr(main_mod, "main")

--- a/tests/test_main_bind_default.py
+++ b/tests/test_main_bind_default.py
@@ -22,7 +22,9 @@ def test_main_module_imports_cleanly(monkeypatch):
     """Smoke check — importing __main__ should not error after the host
     resolution change."""
     import importlib
+
     from odoo_mcp import __main__ as main_mod
+
     importlib.reload(main_mod)
     assert hasattr(main_mod, "main")
 
@@ -33,6 +35,7 @@ def test_banner_includes_posture_line(capfd, monkeypatch):
     monkeypatch.setenv("MCP_VERBOSE", "true")
 
     from odoo_mcp.__main__ import _print_startup_banner
+
     _print_startup_banner("stdio", "127.0.0.1", 8080)
 
     err = capfd.readouterr().err
@@ -45,6 +48,7 @@ def test_banner_includes_allowlist_count(capfd, monkeypatch):
     monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "sale.order.action_confirm,res.partner.message_post")
 
     from odoo_mcp.__main__ import _print_startup_banner
+
     _print_startup_banner("stdio", "127.0.0.1", 8080)
 
     err = capfd.readouterr().err

--- a/tests/test_payload_validation.py
+++ b/tests/test_payload_validation.py
@@ -1,0 +1,110 @@
+"""Tests for live fields_get pre-flight validation."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from odoo_mcp.safety import (
+    PayloadValidationResult,
+    validate_payload_against_schema,
+)
+
+
+def _client_with_fields(fields: dict):
+    client = MagicMock()
+    client.execute_kw.return_value = fields
+    return client
+
+
+@pytest.fixture(autouse=True)
+def clear_fields_cache():
+    """Each test must see fresh fields_get behaviour."""
+    from odoo_mcp.utils import _FIELDS_CACHE, _FIELDS_CACHE_LOCK
+    with _FIELDS_CACHE_LOCK:
+        _FIELDS_CACHE.clear()
+    yield
+    with _FIELDS_CACHE_LOCK:
+        _FIELDS_CACHE.clear()
+
+
+def test_valid_payload_passes():
+    client = _client_with_fields({
+        "name": {"type": "char", "readonly": False, "required": True},
+        "email": {"type": "char", "readonly": False, "required": False},
+    })
+
+    result = validate_payload_against_schema(
+        client, "res.partner", "write", args=[[1], {"name": "X", "email": "a@b"}],
+    )
+
+    assert result.ok is True
+    assert result.errors == []
+
+
+def test_unknown_field_fails():
+    client = _client_with_fields({"name": {"type": "char"}})
+
+    result = validate_payload_against_schema(
+        client, "res.partner", "write", args=[[1], {"name": "X", "made_up_field": 42}],
+    )
+
+    assert result.ok is False
+    assert any("made_up_field" in e for e in result.errors)
+
+
+def test_readonly_field_fails():
+    client = _client_with_fields({
+        "name": {"type": "char", "readonly": False},
+        "id": {"type": "integer", "readonly": True},
+    })
+
+    result = validate_payload_against_schema(
+        client, "res.partner", "write", args=[[1], {"id": 42, "name": "X"}],
+    )
+
+    assert result.ok is False
+    assert any("id" in e and "readonly" in e.lower() for e in result.errors)
+
+
+def test_empty_fields_response_fails():
+    """A {} response indicates a connection failure or missing model — must
+    NOT pass validation."""
+    client = _client_with_fields({})
+
+    result = validate_payload_against_schema(
+        client, "res.partner", "create", args=[{"name": "X"}],
+    )
+
+    assert result.ok is False
+    assert any("schema" in e.lower() or "fields" in e.lower() for e in result.errors)
+
+
+def test_create_validates_first_arg_dict():
+    client = _client_with_fields({"name": {"type": "char"}})
+
+    result = validate_payload_against_schema(
+        client, "res.partner", "create", args=[{"name": "X"}],
+    )
+    assert result.ok is True
+
+
+def test_non_dict_payload_skipped():
+    """For methods like action_confirm with no vals dict, validation is a no-op."""
+    client = _client_with_fields({"name": {"type": "char"}})
+
+    result = validate_payload_against_schema(
+        client, "sale.order", "action_confirm", args=[[1]],
+    )
+    assert result.ok is True
+
+
+def test_validator_uses_fields_cache():
+    """Two calls in quick succession should share one fields_get round-trip."""
+    client = _client_with_fields({"name": {"type": "char"}})
+
+    validate_payload_against_schema(
+        client, "res.partner", "write", args=[[1], {"name": "A"}],
+    )
+    validate_payload_against_schema(
+        client, "res.partner", "write", args=[[1], {"name": "B"}],
+    )
+    assert client.execute_kw.call_count == 1

--- a/tests/test_payload_validation.py
+++ b/tests/test_payload_validation.py
@@ -27,6 +27,41 @@ def clear_fields_cache():
         _FIELDS_CACHE.clear()
 
 
+def test_write_vals_in_kwargs_is_validated():
+    """v2 is named-args-only: vals can arrive as kwargs, and must still be checked.
+
+    Reading only the positional form let a write skip validation entirely by
+    moving its payload into kwargs_json.
+    """
+    client = _client_with_fields({"name": {"type": "char", "readonly": False}})
+
+    result = validate_payload_against_schema(
+        client,
+        "res.partner",
+        "write",
+        args=[],
+        kwargs={"ids": [1], "vals": {"nonexistent_field": "X"}},
+    )
+
+    assert result.ok is False
+    assert any("nonexistent_field" in e for e in result.errors)
+
+
+def test_create_vals_list_in_kwargs_is_validated():
+    client = _client_with_fields({"name": {"type": "char", "readonly": False}})
+
+    result = validate_payload_against_schema(
+        client,
+        "res.partner",
+        "create",
+        args=[],
+        kwargs={"vals_list": [{"bogus": 1}]},
+    )
+
+    assert result.ok is False
+    assert any("bogus" in e for e in result.errors)
+
+
 def test_valid_payload_passes():
     client = _client_with_fields(
         {

--- a/tests/test_payload_validation.py
+++ b/tests/test_payload_validation.py
@@ -1,10 +1,10 @@
 """Tests for live fields_get pre-flight validation."""
+
 from unittest.mock import MagicMock
 
 import pytest
 
 from odoo_mcp.safety import (
-    PayloadValidationResult,
     validate_payload_against_schema,
 )
 
@@ -19,6 +19,7 @@ def _client_with_fields(fields: dict):
 def clear_fields_cache():
     """Each test must see fresh fields_get behaviour."""
     from odoo_mcp.utils import _FIELDS_CACHE, _FIELDS_CACHE_LOCK
+
     with _FIELDS_CACHE_LOCK:
         _FIELDS_CACHE.clear()
     yield
@@ -27,13 +28,18 @@ def clear_fields_cache():
 
 
 def test_valid_payload_passes():
-    client = _client_with_fields({
-        "name": {"type": "char", "readonly": False, "required": True},
-        "email": {"type": "char", "readonly": False, "required": False},
-    })
+    client = _client_with_fields(
+        {
+            "name": {"type": "char", "readonly": False, "required": True},
+            "email": {"type": "char", "readonly": False, "required": False},
+        }
+    )
 
     result = validate_payload_against_schema(
-        client, "res.partner", "write", args=[[1], {"name": "X", "email": "a@b"}],
+        client,
+        "res.partner",
+        "write",
+        args=[[1], {"name": "X", "email": "a@b"}],
     )
 
     assert result.ok is True
@@ -44,7 +50,10 @@ def test_unknown_field_fails():
     client = _client_with_fields({"name": {"type": "char"}})
 
     result = validate_payload_against_schema(
-        client, "res.partner", "write", args=[[1], {"name": "X", "made_up_field": 42}],
+        client,
+        "res.partner",
+        "write",
+        args=[[1], {"name": "X", "made_up_field": 42}],
     )
 
     assert result.ok is False
@@ -52,13 +61,18 @@ def test_unknown_field_fails():
 
 
 def test_readonly_field_fails():
-    client = _client_with_fields({
-        "name": {"type": "char", "readonly": False},
-        "id": {"type": "integer", "readonly": True},
-    })
+    client = _client_with_fields(
+        {
+            "name": {"type": "char", "readonly": False},
+            "id": {"type": "integer", "readonly": True},
+        }
+    )
 
     result = validate_payload_against_schema(
-        client, "res.partner", "write", args=[[1], {"id": 42, "name": "X"}],
+        client,
+        "res.partner",
+        "write",
+        args=[[1], {"id": 42, "name": "X"}],
     )
 
     assert result.ok is False
@@ -71,7 +85,10 @@ def test_empty_fields_response_fails():
     client = _client_with_fields({})
 
     result = validate_payload_against_schema(
-        client, "res.partner", "create", args=[{"name": "X"}],
+        client,
+        "res.partner",
+        "create",
+        args=[{"name": "X"}],
     )
 
     assert result.ok is False
@@ -82,7 +99,10 @@ def test_create_validates_first_arg_dict():
     client = _client_with_fields({"name": {"type": "char"}})
 
     result = validate_payload_against_schema(
-        client, "res.partner", "create", args=[{"name": "X"}],
+        client,
+        "res.partner",
+        "create",
+        args=[{"name": "X"}],
     )
     assert result.ok is True
 
@@ -92,7 +112,10 @@ def test_non_dict_payload_skipped():
     client = _client_with_fields({"name": {"type": "char"}})
 
     result = validate_payload_against_schema(
-        client, "sale.order", "action_confirm", args=[[1]],
+        client,
+        "sale.order",
+        "action_confirm",
+        args=[[1]],
     )
     assert result.ok is True
 
@@ -102,9 +125,15 @@ def test_validator_uses_fields_cache():
     client = _client_with_fields({"name": {"type": "char"}})
 
     validate_payload_against_schema(
-        client, "res.partner", "write", args=[[1], {"name": "A"}],
+        client,
+        "res.partner",
+        "write",
+        args=[[1], {"name": "A"}],
     )
     validate_payload_against_schema(
-        client, "res.partner", "write", args=[[1], {"name": "B"}],
+        client,
+        "res.partner",
+        "write",
+        args=[[1], {"name": "B"}],
     )
     assert client.execute_method.call_count == 1

--- a/tests/test_payload_validation.py
+++ b/tests/test_payload_validation.py
@@ -11,7 +11,7 @@ from odoo_mcp.safety import (
 
 def _client_with_fields(fields: dict):
     client = MagicMock()
-    client.execute_kw.return_value = fields
+    client.execute_method.return_value = fields
     return client
 
 
@@ -107,4 +107,4 @@ def test_validator_uses_fields_cache():
     validate_payload_against_schema(
         client, "res.partner", "write", args=[[1], {"name": "B"}],
     )
-    assert client.execute_kw.call_count == 1
+    assert client.execute_method.call_count == 1

--- a/tests/test_read_only_guard.py
+++ b/tests/test_read_only_guard.py
@@ -1,4 +1,5 @@
 """Tests for MCP_READ_ONLY enforcement in execute_method."""
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -94,3 +95,72 @@ def test_read_only_off_does_not_block(monkeypatch, mock_ctx):
 
     assert response.success is False
     assert "read-only" not in response.error.lower()
+
+
+def test_read_only_blocks_batch_with_writes(monkeypatch):
+    monkeypatch.setenv("MCP_READ_ONLY", "true")
+    from odoo_mcp.server import batch_execute
+
+    response = asyncio.run(batch_execute(
+        operations=[
+            {"model": "res.partner", "method": "write", "args_json": '[[1], {"name": "X"}]'},
+        ],
+    ))
+
+    assert response.success is False
+    assert "read-only" in (response.error or "").lower()
+
+
+def test_read_only_allows_batch_of_reads(monkeypatch):
+    """A batch where every operation is SAFE should not be rejected by the
+    read-only guard — the read-only guard must not return an error for it.
+
+    Note: batch_execute uses FastMCP Progress which requires MCP dependency injection.
+    When called directly (outside MCP context), it raises AssertionError after the
+    read-only guard passes. We verify the read-only guard did NOT fire by confirming
+    we get through it (either a response without 'read-only' or the Progress exception).
+    """
+    monkeypatch.setenv("MCP_READ_ONLY", "true")
+    from odoo_mcp.server import batch_execute
+
+    try:
+        response = asyncio.run(batch_execute(
+            operations=[
+                {"model": "not a model", "method": "search_read"},
+            ],
+        ))
+        # If we got a response, the error must not be about read-only.
+        assert "read-only" not in (response.error or "").lower()
+    except AssertionError as exc:
+        # FastMCP Progress requires MCP dependency injection outside MCP context.
+        # Reaching this point means the read-only guard did not fire (correct).
+        assert "read-only" not in str(exc).lower()
+
+
+def test_read_only_blocks_workflow(monkeypatch):
+    """Under read-only, ALL workflows are rejected (they're inherently multi-step)."""
+    monkeypatch.setenv("MCP_READ_ONLY", "true")
+    from odoo_mcp.server import execute_workflow
+
+    response = asyncio.run(execute_workflow(
+        workflow="quote_to_cash",
+        params_json='{"partner_id": 1, "product_id": 1, "quantity": 1}',
+    ))
+
+    assert response.success is False
+    assert "read-only" in (response.error or "").lower()
+
+
+def test_read_only_off_allows_workflow_to_proceed_to_validation(monkeypatch):
+    """When read-only is off, the workflow guard does not fire. (We don't actually
+    expect a successful run — just absence of the read-only error.)"""
+    monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+    from odoo_mcp.server import execute_workflow
+
+    response = asyncio.run(execute_workflow(
+        workflow="quote_to_cash",
+        params_json='{"partner_id": 1, "product_id": 1, "quantity": 1}',
+    ))
+
+    # Whatever happens downstream, the error (if any) must not be about read-only.
+    assert "read-only" not in (response.error or "").lower()

--- a/tests/test_read_only_guard.py
+++ b/tests/test_read_only_guard.py
@@ -1,0 +1,96 @@
+"""Tests for MCP_READ_ONLY enforcement in execute_method."""
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_ctx():
+    return MagicMock()
+
+
+def _import_execute_method():
+    from odoo_mcp.server import execute_method
+    return execute_method
+
+
+def test_read_only_blocks_write(monkeypatch, mock_ctx):
+    monkeypatch.setenv("MCP_READ_ONLY", "true")
+    execute_method = _import_execute_method()
+
+    response = execute_method(
+        ctx=mock_ctx,
+        model="res.partner",
+        method="write",
+        args_json='[[1], {"name": "X"}]',
+    )
+
+    assert response.success is False
+    assert "read-only" in response.error.lower()
+    assert "MCP_READ_ONLY" in response.error
+
+
+def test_read_only_blocks_create(monkeypatch, mock_ctx):
+    monkeypatch.setenv("MCP_READ_ONLY", "true")
+    execute_method = _import_execute_method()
+
+    response = execute_method(
+        ctx=mock_ctx,
+        model="res.partner",
+        method="create",
+        args_json='[{"name": "Test"}]',
+    )
+
+    assert response.success is False
+    assert "read-only" in response.error.lower()
+
+
+def test_read_only_blocks_action_method(monkeypatch, mock_ctx):
+    monkeypatch.setenv("MCP_READ_ONLY", "true")
+    execute_method = _import_execute_method()
+
+    response = execute_method(
+        ctx=mock_ctx,
+        model="sale.order",
+        method="action_confirm",
+        args_json='[[1]]',
+    )
+
+    assert response.success is False
+    assert "read-only" in response.error.lower()
+
+
+def test_read_only_allows_safe_method(monkeypatch, mock_ctx):
+    """Read-only must NOT short-circuit safe reads — they should reach the
+    Odoo client. We can't easily run a real call here, but we can check that
+    the read-only guard does not produce a 'read-only mode is active' error
+    for a safe method even when MCP_READ_ONLY=true."""
+    monkeypatch.setenv("MCP_READ_ONLY", "true")
+    execute_method = _import_execute_method()
+
+    response = execute_method(
+        ctx=mock_ctx,
+        model="not a model",   # Will fail _validate_model regex
+        method="search_read",
+    )
+
+    # The error should be about model validation, NOT read-only mode.
+    assert response.success is False
+    assert "read-only" not in response.error.lower()
+
+
+def test_read_only_off_does_not_block(monkeypatch, mock_ctx):
+    """When MCP_READ_ONLY is unset/false, the guard must not fire even for
+    write methods. We trigger model validation failure to short-circuit
+    before the actual Odoo call."""
+    monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+    execute_method = _import_execute_method()
+
+    response = execute_method(
+        ctx=mock_ctx,
+        model="not a model",
+        method="write",
+    )
+
+    assert response.success is False
+    assert "read-only" not in response.error.lower()

--- a/tests/test_read_only_guard.py
+++ b/tests/test_read_only_guard.py
@@ -1,4 +1,5 @@
 """Tests for MCP_READ_ONLY enforcement in execute_method."""
+
 import asyncio
 from unittest.mock import MagicMock
 
@@ -12,6 +13,7 @@ def mock_ctx():
 
 def _import_execute_method():
     from odoo_mcp.server import execute_method
+
     return execute_method
 
 
@@ -54,7 +56,7 @@ def test_read_only_blocks_action_method(monkeypatch, mock_ctx):
         ctx=mock_ctx,
         model="sale.order",
         method="action_confirm",
-        args_json='[[1]]',
+        args_json="[[1]]",
     )
 
     assert response.success is False
@@ -71,7 +73,7 @@ def test_read_only_allows_safe_method(monkeypatch, mock_ctx):
 
     response = execute_method(
         ctx=mock_ctx,
-        model="not a model",   # Will fail _validate_model regex
+        model="not a model",  # Will fail _validate_model regex
         method="search_read",
     )
 
@@ -101,11 +103,13 @@ def test_read_only_blocks_batch_with_writes(monkeypatch):
     monkeypatch.setenv("MCP_READ_ONLY", "true")
     from odoo_mcp.server import batch_execute
 
-    response = asyncio.run(batch_execute(
-        operations=[
-            {"model": "res.partner", "method": "write", "args_json": '[[1], {"name": "X"}]'},
-        ],
-    ))
+    response = asyncio.run(
+        batch_execute(
+            operations=[
+                {"model": "res.partner", "method": "write", "args_json": '[[1], {"name": "X"}]'},
+            ],
+        )
+    )
 
     assert response.success is False
     assert "read-only" in (response.error or "").lower()
@@ -124,11 +128,13 @@ def test_read_only_allows_batch_of_reads(monkeypatch):
     from odoo_mcp.server import batch_execute
 
     try:
-        response = asyncio.run(batch_execute(
-            operations=[
-                {"model": "not a model", "method": "search_read"},
-            ],
-        ))
+        response = asyncio.run(
+            batch_execute(
+                operations=[
+                    {"model": "not a model", "method": "search_read"},
+                ],
+            )
+        )
         # If we got a response, the error must not be about read-only.
         assert "read-only" not in (response.error or "").lower()
     except AssertionError as exc:
@@ -142,10 +148,12 @@ def test_read_only_blocks_workflow(monkeypatch):
     monkeypatch.setenv("MCP_READ_ONLY", "true")
     from odoo_mcp.server import execute_workflow
 
-    response = asyncio.run(execute_workflow(
-        workflow="quote_to_cash",
-        params_json='{"partner_id": 1, "product_id": 1, "quantity": 1}',
-    ))
+    response = asyncio.run(
+        execute_workflow(
+            workflow="quote_to_cash",
+            params_json='{"partner_id": 1, "product_id": 1, "quantity": 1}',
+        )
+    )
 
     assert response.success is False
     assert "read-only" in (response.error or "").lower()
@@ -157,10 +165,12 @@ def test_read_only_off_allows_workflow_to_proceed_to_validation(monkeypatch):
     monkeypatch.delenv("MCP_READ_ONLY", raising=False)
     from odoo_mcp.server import execute_workflow
 
-    response = asyncio.run(execute_workflow(
-        workflow="quote_to_cash",
-        params_json='{"partner_id": 1, "product_id": 1, "quantity": 1}',
-    ))
+    response = asyncio.run(
+        execute_workflow(
+            workflow="quote_to_cash",
+            params_json='{"partner_id": 1, "product_id": 1, "quantity": 1}',
+        )
+    )
 
     # Whatever happens downstream, the error (if any) must not be about read-only.
     assert "read-only" not in (response.error or "").lower()

--- a/tests/test_read_only_guard.py
+++ b/tests/test_read_only_guard.py
@@ -125,6 +125,9 @@ def test_read_only_allows_batch_of_reads(monkeypatch):
     we get through it (either a response without 'read-only' or the Progress exception).
     """
     monkeypatch.setenv("MCP_READ_ONLY", "true")
+    # Stub the client: these paths run past the read-only guard, and a real
+    # get_odoo_client() would need ODOO_* config that CI deliberately omits.
+    monkeypatch.setattr("odoo_mcp.server.get_odoo_client", lambda: MagicMock())
     from odoo_mcp.server import batch_execute
 
     try:
@@ -163,6 +166,9 @@ def test_read_only_off_allows_workflow_to_proceed_to_validation(monkeypatch):
     """When read-only is off, the workflow guard does not fire. (We don't actually
     expect a successful run — just absence of the read-only error.)"""
     monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+    # Stub the client: these paths run past the read-only guard, and a real
+    # get_odoo_client() would need ODOO_* config that CI deliberately omits.
+    monkeypatch.setattr("odoo_mcp.server.get_odoo_client", lambda: MagicMock())
     from odoo_mcp.server import execute_workflow
 
     response = asyncio.run(

--- a/tests/test_safety_profile.py
+++ b/tests/test_safety_profile.py
@@ -1,0 +1,136 @@
+"""Tests for safety profile resolver."""
+import pytest
+
+from odoo_mcp.safety_profile import (
+    ResolvedProfile,
+    SafetyMode,
+    resolve,
+)
+
+
+def test_default_mode_is_strict():
+    profile = resolve({})
+    assert profile.safety_mode is SafetyMode.STRICT
+    assert profile.read_only is False
+    assert profile.write_allowlist == frozenset()
+    assert profile.write_allowlist_enforced is False
+    assert profile.host_default == "0.0.0.0"
+    assert profile.validate_payloads is False
+
+
+def test_permissive_mode():
+    profile = resolve({"MCP_SAFETY_MODE": "permissive"})
+    assert profile.safety_mode is SafetyMode.PERMISSIVE
+    assert profile.read_only is False
+    assert profile.write_allowlist_enforced is False
+    assert profile.host_default == "0.0.0.0"
+    assert profile.validate_payloads is False
+
+
+def test_locked_mode_defaults():
+    profile = resolve({"MCP_SAFETY_MODE": "locked"})
+    assert profile.safety_mode is SafetyMode.LOCKED
+    assert profile.read_only is True
+    assert profile.write_allowlist_enforced is True
+    assert profile.host_default == "127.0.0.1"
+    assert profile.validate_payloads is True
+
+
+def test_unknown_mode_falls_back_to_strict():
+    profile = resolve({"MCP_SAFETY_MODE": "garbage"})
+    assert profile.safety_mode is SafetyMode.STRICT
+
+
+def test_read_only_override_beats_strict_default():
+    profile = resolve({"MCP_SAFETY_MODE": "strict", "MCP_READ_ONLY": "true"})
+    assert profile.safety_mode is SafetyMode.STRICT
+    assert profile.read_only is True
+
+
+def test_read_only_override_beats_locked_default():
+    profile = resolve({"MCP_SAFETY_MODE": "locked", "MCP_READ_ONLY": "false"})
+    assert profile.safety_mode is SafetyMode.LOCKED
+    assert profile.read_only is False
+
+
+def test_allowlist_explicit_under_strict_enables_enforcement():
+    profile = resolve({
+        "MCP_SAFETY_MODE": "strict",
+        "MCP_WRITE_ALLOWLIST": "sale.order.action_confirm,res.partner.message_post",
+    })
+    assert profile.write_allowlist_enforced is True
+    assert "sale.order.action_confirm" in profile.write_allowlist
+    assert "res.partner.message_post" in profile.write_allowlist
+
+
+def test_allowlist_wildcard_normalised():
+    profile = resolve({"MCP_WRITE_ALLOWLIST": "sale.order.*,product.product.write"})
+    assert "sale.order.*" in profile.write_allowlist
+    assert "product.product.write" in profile.write_allowlist
+
+
+def test_allowlist_whitespace_tolerant():
+    profile = resolve({
+        "MCP_WRITE_ALLOWLIST": "  sale.order.action_confirm , product.product.write ",
+    })
+    assert profile.write_allowlist == frozenset({
+        "sale.order.action_confirm",
+        "product.product.write",
+    })
+
+
+def test_host_default_under_locked_is_localhost():
+    profile = resolve({"MCP_SAFETY_MODE": "locked"})
+    assert profile.host_default == "127.0.0.1"
+
+
+def test_host_explicit_overrides_locked_default():
+    profile = resolve({"MCP_SAFETY_MODE": "locked", "MCP_HOST": "0.0.0.0"})
+    assert profile.host == "0.0.0.0"
+
+
+def test_host_unset_resolves_to_default_per_mode():
+    locked = resolve({"MCP_SAFETY_MODE": "locked"})
+    assert locked.host == "127.0.0.1"
+    strict = resolve({"MCP_SAFETY_MODE": "strict"})
+    assert strict.host == "0.0.0.0"
+
+
+def test_validate_payloads_explicit_enable_under_strict():
+    profile = resolve({"MCP_SAFETY_MODE": "strict", "MCP_VALIDATE_PAYLOADS": "true"})
+    assert profile.validate_payloads is True
+
+
+def test_posture_open_only_when_loose():
+    open_ = resolve({"MCP_SAFETY_MODE": "permissive", "MCP_HOST": "0.0.0.0"})
+    assert open_.posture_open is True
+
+    locked = resolve({"MCP_SAFETY_MODE": "locked"})
+    assert locked.posture_open is False
+
+    permissive_with_allowlist = resolve({
+        "MCP_SAFETY_MODE": "permissive",
+        "MCP_HOST": "0.0.0.0",
+        "MCP_WRITE_ALLOWLIST": "res.partner.message_post",
+    })
+    assert permissive_with_allowlist.posture_open is False
+
+
+def test_warnings_flag_locked_with_remote_bind():
+    profile = resolve({"MCP_SAFETY_MODE": "locked", "MCP_HOST": "0.0.0.0"})
+    assert any("0.0.0.0" in w for w in profile.warnings)
+
+
+def test_warnings_empty_under_default_strict():
+    profile = resolve({})
+    assert profile.warnings == ()
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("true", True), ("True", True), ("1", True), ("yes", True), ("on", True),
+    ("false", False), ("False", False), ("0", False), ("no", False), ("off", False),
+    ("", False), ("garbage", False),
+])
+def test_bool_env_parsing(raw: str, expected: bool):
+    profile = resolve({"MCP_READ_ONLY": raw})
+    assert profile.read_only is expected

--- a/tests/test_safety_profile.py
+++ b/tests/test_safety_profile.py
@@ -126,6 +126,32 @@ def test_warnings_empty_under_default_strict():
     assert profile.warnings == ()
 
 
+def test_warnings_flag_locked_with_read_only_disabled():
+    """Operator opting out of the primary kill-switch under locked mode
+    should see an explicit warning."""
+    profile = resolve({"MCP_SAFETY_MODE": "locked", "MCP_READ_ONLY": "false"})
+    assert any("MCP_READ_ONLY=false" in w for w in profile.warnings)
+
+
+def test_allowlist_drops_invalid_entries():
+    """Cross-model wildcards and malformed entries should be dropped with a
+    warning rather than silently stored. Odoo models are dotted (e.g.
+    'sale.order', 'product.product') — single-segment names are rejected."""
+    profile = resolve({
+        "MCP_WRITE_ALLOWLIST": "*.write,sale.order.action_confirm,nonsense, ,product.product.*",
+    })
+    # Valid entries remain.
+    assert "sale.order.action_confirm" in profile.write_allowlist
+    assert "product.product.*" in profile.write_allowlist
+    # Cross-model wildcard and bare junk are dropped.
+    assert "*.write" not in profile.write_allowlist
+    assert "nonsense" not in profile.write_allowlist
+    assert profile.write_allowlist == frozenset({
+        "sale.order.action_confirm",
+        "product.product.*",
+    })
+
+
 @pytest.mark.parametrize("raw,expected", [
     ("true", True), ("True", True), ("1", True), ("yes", True), ("on", True),
     ("false", False), ("False", False), ("0", False), ("no", False), ("off", False),

--- a/tests/test_safety_profile.py
+++ b/tests/test_safety_profile.py
@@ -1,8 +1,8 @@
 """Tests for safety profile resolver."""
+
 import pytest
 
 from odoo_mcp.safety_profile import (
-    ResolvedProfile,
     SafetyMode,
     resolve,
 )
@@ -54,10 +54,12 @@ def test_read_only_override_beats_locked_default():
 
 
 def test_allowlist_explicit_under_strict_enables_enforcement():
-    profile = resolve({
-        "MCP_SAFETY_MODE": "strict",
-        "MCP_WRITE_ALLOWLIST": "sale.order.action_confirm,res.partner.message_post",
-    })
+    profile = resolve(
+        {
+            "MCP_SAFETY_MODE": "strict",
+            "MCP_WRITE_ALLOWLIST": "sale.order.action_confirm,res.partner.message_post",
+        }
+    )
     assert profile.write_allowlist_enforced is True
     assert "sale.order.action_confirm" in profile.write_allowlist
     assert "res.partner.message_post" in profile.write_allowlist
@@ -70,13 +72,17 @@ def test_allowlist_wildcard_normalised():
 
 
 def test_allowlist_whitespace_tolerant():
-    profile = resolve({
-        "MCP_WRITE_ALLOWLIST": "  sale.order.action_confirm , product.product.write ",
-    })
-    assert profile.write_allowlist == frozenset({
-        "sale.order.action_confirm",
-        "product.product.write",
-    })
+    profile = resolve(
+        {
+            "MCP_WRITE_ALLOWLIST": "  sale.order.action_confirm , product.product.write ",
+        }
+    )
+    assert profile.write_allowlist == frozenset(
+        {
+            "sale.order.action_confirm",
+            "product.product.write",
+        }
+    )
 
 
 def test_host_default_under_locked_is_localhost():
@@ -108,11 +114,13 @@ def test_posture_open_only_when_loose():
     locked = resolve({"MCP_SAFETY_MODE": "locked"})
     assert locked.posture_open is False
 
-    permissive_with_allowlist = resolve({
-        "MCP_SAFETY_MODE": "permissive",
-        "MCP_HOST": "0.0.0.0",
-        "MCP_WRITE_ALLOWLIST": "res.partner.message_post",
-    })
+    permissive_with_allowlist = resolve(
+        {
+            "MCP_SAFETY_MODE": "permissive",
+            "MCP_HOST": "0.0.0.0",
+            "MCP_WRITE_ALLOWLIST": "res.partner.message_post",
+        }
+    )
     assert permissive_with_allowlist.posture_open is False
 
 
@@ -137,26 +145,42 @@ def test_allowlist_drops_invalid_entries():
     """Cross-model wildcards and malformed entries should be dropped with a
     warning rather than silently stored. Odoo models are dotted (e.g.
     'sale.order', 'product.product') — single-segment names are rejected."""
-    profile = resolve({
-        "MCP_WRITE_ALLOWLIST": "*.write,sale.order.action_confirm,nonsense, ,product.product.*",
-    })
+    profile = resolve(
+        {
+            "MCP_WRITE_ALLOWLIST": "*.write,sale.order.action_confirm,nonsense, ,product.product.*",
+        }
+    )
     # Valid entries remain.
     assert "sale.order.action_confirm" in profile.write_allowlist
     assert "product.product.*" in profile.write_allowlist
     # Cross-model wildcard and bare junk are dropped.
     assert "*.write" not in profile.write_allowlist
     assert "nonsense" not in profile.write_allowlist
-    assert profile.write_allowlist == frozenset({
-        "sale.order.action_confirm",
-        "product.product.*",
-    })
+    assert profile.write_allowlist == frozenset(
+        {
+            "sale.order.action_confirm",
+            "product.product.*",
+        }
+    )
 
 
-@pytest.mark.parametrize("raw,expected", [
-    ("true", True), ("True", True), ("1", True), ("yes", True), ("on", True),
-    ("false", False), ("False", False), ("0", False), ("no", False), ("off", False),
-    ("", False), ("garbage", False),
-])
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+        ("garbage", False),
+    ],
+)
 def test_bool_env_parsing(raw: str, expected: bool):
     profile = resolve({"MCP_READ_ONLY": raw})
     assert profile.read_only is expected

--- a/tests/test_server_status_resource.py
+++ b/tests/test_server_status_resource.py
@@ -1,0 +1,74 @@
+"""Tests for odoo://server-status resource."""
+import json
+
+
+def _read_status() -> dict:
+    """Read the server-status resource via the read_resource bridge."""
+    from odoo_mcp.server import read_resource
+    raw = read_resource("odoo://server-status")
+    return json.loads(raw)
+
+
+def test_status_includes_version(monkeypatch):
+    monkeypatch.delenv("MCP_SAFETY_MODE", raising=False)
+    status = _read_status()
+    assert "version" in status
+    assert isinstance(status["version"], str)
+
+
+def test_status_reflects_locked_mode(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.delenv("MCP_HOST", raising=False)
+    monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+    status = _read_status()
+    assert status["safety_mode"] == "locked"
+    assert status["read_only"] is True
+    assert status["host"] == "127.0.0.1"
+    assert status["validate_payloads"] is True
+
+
+def test_status_under_strict(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "strict")
+    monkeypatch.delenv("MCP_HOST", raising=False)
+    monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+    monkeypatch.delenv("MCP_WRITE_ALLOWLIST", raising=False)
+    monkeypatch.delenv("MCP_VALIDATE_PAYLOADS", raising=False)
+
+    status = _read_status()
+    assert status["safety_mode"] == "strict"
+    assert status["read_only"] is False
+    assert status["validate_payloads"] is False
+    assert status["host"] == "0.0.0.0"
+    assert status["write_allowlist"] == []
+
+
+def test_status_does_not_leak_secrets(monkeypatch):
+    monkeypatch.setenv("MCP_API_KEY", "supersecret-token-12345")
+    monkeypatch.setenv("ODOO_API_KEY", "odoo-key-xyz")
+    monkeypatch.setenv("ODOO_PASSWORD", "hunter2")
+
+    status = _read_status()
+    raw = json.dumps(status)
+
+    assert "supersecret" not in raw
+    assert "odoo-key-xyz" not in raw
+    assert "hunter2" not in raw
+
+
+def test_status_includes_warnings_array(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.setenv("MCP_HOST", "0.0.0.0")  # foot-gun: locked + remote
+    status = _read_status()
+    assert isinstance(status["warnings"], list)
+    assert len(status["warnings"]) >= 1
+    assert any("0.0.0.0" in w for w in status["warnings"])
+
+
+def test_status_includes_posture_open(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "permissive")
+    monkeypatch.setenv("MCP_HOST", "0.0.0.0")
+    monkeypatch.delenv("MCP_WRITE_ALLOWLIST", raising=False)
+    monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+
+    status = _read_status()
+    assert status["posture_open"] is True

--- a/tests/test_server_status_resource.py
+++ b/tests/test_server_status_resource.py
@@ -1,10 +1,12 @@
 """Tests for odoo://server-status resource."""
+
 import json
 
 
 def _read_status() -> dict:
     """Read the server-status resource via the read_resource bridge."""
     from odoo_mcp.server import read_resource
+
     raw = read_resource("odoo://server-status")
     return json.loads(raw)
 

--- a/tests/test_side_effect_predicate.py
+++ b/tests/test_side_effect_predicate.py
@@ -1,0 +1,40 @@
+"""Tests for is_side_effect_method() predicate."""
+import pytest
+
+from odoo_mcp.safety import is_side_effect_method
+
+
+@pytest.mark.parametrize("method", [
+    "create", "write", "unlink", "copy",
+    "action_archive", "action_unarchive", "action_confirm", "action_post",
+    "button_validate", "button_confirm", "button_cancel",
+])
+def test_known_side_effect_methods(method: str):
+    assert is_side_effect_method(method) is True
+
+
+@pytest.mark.parametrize("method", [
+    "search_read", "read", "search", "search_count",
+    "fields_get", "name_search", "default_get",
+    "has_access", "name_get",
+])
+def test_safe_methods_are_not_side_effects(method: str):
+    assert is_side_effect_method(method) is False
+
+
+@pytest.mark.parametrize("method", [
+    "action_my_custom_workflow",
+    "button_do_something",
+    "_action_private_hook",
+])
+def test_action_button_patterns(method: str):
+    assert is_side_effect_method(method) is True
+
+
+def test_empty_method_is_not_side_effect():
+    assert is_side_effect_method("") is False
+
+
+def test_unknown_read_like_method_is_not_side_effect():
+    # A method we've never heard of that doesn't match any side-effect pattern.
+    assert is_side_effect_method("get_widget_count") is False

--- a/tests/test_side_effect_predicate.py
+++ b/tests/test_side_effect_predicate.py
@@ -6,6 +6,7 @@ from odoo_mcp.safety import is_side_effect_method
 
 @pytest.mark.parametrize("method", [
     "create", "write", "unlink", "copy",
+    "name_create", "load",
     "action_archive", "action_unarchive", "action_confirm", "action_post",
     "button_validate", "button_confirm", "button_cancel",
 ])

--- a/tests/test_side_effect_predicate.py
+++ b/tests/test_side_effect_predicate.py
@@ -57,10 +57,39 @@ def test_action_button_patterns(method: str):
     assert is_side_effect_method(method) is True
 
 
-def test_empty_method_is_not_side_effect():
-    assert is_side_effect_method("") is False
+def test_empty_method_is_gated():
+    # Fail-closed: an unrecognised method is never assumed to be a read.
+    # (_validate_method rejects the empty string upstream anyway.)
+    assert is_side_effect_method("") is True
 
 
-def test_unknown_read_like_method_is_not_side_effect():
-    # A method we've never heard of that doesn't match any side-effect pattern.
-    assert is_side_effect_method("get_widget_count") is False
+def test_unknown_method_is_gated():
+    # A method we have never heard of must be treated as a write. Assuming
+    # otherwise is what let writes past the MCP_READ_ONLY kill-switch.
+    assert is_side_effect_method("get_widget_count") is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        # Documented in module_knowledge.json — all of these create or modify
+        # records while matching neither a literal CRUD name nor action_* /
+        # button_*, so a name-shape predicate waved them straight through.
+        "add_members",
+        "article_create",
+        "article_duplicate",
+        "channel_create",
+        "convert_opportunity",
+        "create_from_attachments",
+        "create_from_binary_files",
+        "create_from_urls",
+        "document_create",
+        "get_direct_response",
+        "open_agent_chat",
+        # Standard ORM write paths with read-shaped names.
+        "message_post",
+        "toggle_active",
+    ],
+)
+def test_write_methods_without_action_prefix_are_gated(method: str):
+    assert is_side_effect_method(method) is True

--- a/tests/test_side_effect_predicate.py
+++ b/tests/test_side_effect_predicate.py
@@ -1,33 +1,58 @@
 """Tests for is_side_effect_method() predicate."""
+
 import pytest
 
 from odoo_mcp.safety import is_side_effect_method
 
 
-@pytest.mark.parametrize("method", [
-    "create", "write", "unlink", "copy",
-    "name_create", "load",
-    "action_archive", "action_unarchive", "action_confirm", "action_post",
-    "button_validate", "button_confirm", "button_cancel",
-])
+@pytest.mark.parametrize(
+    "method",
+    [
+        "create",
+        "write",
+        "unlink",
+        "copy",
+        "name_create",
+        "load",
+        "action_archive",
+        "action_unarchive",
+        "action_confirm",
+        "action_post",
+        "button_validate",
+        "button_confirm",
+        "button_cancel",
+    ],
+)
 def test_known_side_effect_methods(method: str):
     assert is_side_effect_method(method) is True
 
 
-@pytest.mark.parametrize("method", [
-    "search_read", "read", "search", "search_count",
-    "fields_get", "name_search", "default_get",
-    "has_access", "name_get",
-])
+@pytest.mark.parametrize(
+    "method",
+    [
+        "search_read",
+        "read",
+        "search",
+        "search_count",
+        "fields_get",
+        "name_search",
+        "default_get",
+        "has_access",
+        "name_get",
+    ],
+)
 def test_safe_methods_are_not_side_effects(method: str):
     assert is_side_effect_method(method) is False
 
 
-@pytest.mark.parametrize("method", [
-    "action_my_custom_workflow",
-    "button_do_something",
-    "_action_private_hook",
-])
+@pytest.mark.parametrize(
+    "method",
+    [
+        "action_my_custom_workflow",
+        "button_do_something",
+        "_action_private_hook",
+    ],
+)
 def test_action_button_patterns(method: str):
     assert is_side_effect_method(method) is True
 

--- a/tests/test_user_clients.py
+++ b/tests/test_user_clients.py
@@ -8,7 +8,6 @@ from types import SimpleNamespace
 import pytest
 
 import odoo_mcp.user_clients as user_clients
-from odoo_mcp.users_db import UsersDb
 from tests.conftest import TEST_ENCRYPTION_KEY, encrypt_with_contract
 
 

--- a/tests/test_write_allowlist.py
+++ b/tests/test_write_allowlist.py
@@ -1,0 +1,68 @@
+"""Tests for MCP_WRITE_ALLOWLIST enforcement in classify_operation."""
+import pytest
+
+from odoo_mcp.safety import RiskLevel, classify_operation
+
+
+def test_safe_method_is_safe_even_under_locked(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    result = classify_operation("res.partner", "search_read")
+    assert result.risk_level is RiskLevel.SAFE
+
+
+def test_side_effect_method_blocked_when_allowlist_enforced_and_empty(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    result = classify_operation("sale.order", "action_confirm", args=[[1]])
+    assert result.risk_level is RiskLevel.BLOCKED
+    assert result.blocked_reason is not None
+    assert "MCP_WRITE_ALLOWLIST" in result.blocked_reason
+    assert "sale.order.action_confirm" in result.blocked_reason
+
+
+def test_side_effect_method_allowed_when_in_allowlist(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "sale.order.action_confirm")
+    result = classify_operation("sale.order", "action_confirm", args=[[1]])
+    assert result.risk_level is RiskLevel.HIGH
+
+
+def test_wildcard_model_match(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "sale.order.*")
+    result = classify_operation("sale.order", "action_confirm", args=[[1]])
+    assert result.risk_level is RiskLevel.HIGH
+
+
+def test_wildcard_does_not_match_other_models(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "sale.order.*")
+    result = classify_operation("res.partner", "write", args=[[1], {"name": "X"}])
+    assert result.risk_level is RiskLevel.BLOCKED
+
+
+def test_explicit_allowlist_under_strict_enforces(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "strict")
+    monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "res.partner.message_post")
+    result = classify_operation("res.partner", "write", args=[[1], {"name": "X"}])
+    assert result.risk_level is RiskLevel.BLOCKED
+
+
+def test_no_allowlist_no_enforcement(monkeypatch):
+    """Without MCP_WRITE_ALLOWLIST set and not under locked, classifier
+    behaviour is unchanged."""
+    monkeypatch.setenv("MCP_SAFETY_MODE", "strict")
+    monkeypatch.delenv("MCP_WRITE_ALLOWLIST", raising=False)
+    result = classify_operation("res.partner", "write", args=[[1], {"name": "X"}])
+    # write on res.partner under strict, single record → MEDIUM, no confirm.
+    assert result.risk_level is RiskLevel.MEDIUM
+
+
+def test_blocked_model_still_blocked_with_allowlist(monkeypatch):
+    """The allowlist must NOT be able to override BLOCKED_MODELS."""
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "res.users.write")
+    result = classify_operation("res.users", "write", args=[[1], {"name": "X"}])
+    assert result.risk_level is RiskLevel.BLOCKED
+    # The reason should still cite the security-critical model, not allowlist.
+    assert ("security-critical" in (result.blocked_reason or "").lower()
+            or "security-critical" in (result.reason or "").lower())

--- a/tests/test_write_allowlist.py
+++ b/tests/test_write_allowlist.py
@@ -64,5 +64,30 @@ def test_blocked_model_still_blocked_with_allowlist(monkeypatch):
     result = classify_operation("res.users", "write", args=[[1], {"name": "X"}])
     assert result.risk_level is RiskLevel.BLOCKED
     # The reason should still cite the security-critical model, not allowlist.
-    assert ("security-critical" in (result.blocked_reason or "").lower()
-            or "security-critical" in (result.reason or "").lower())
+    assert (
+        "security-critical" in (result.blocked_reason or "").lower()
+        or "security-critical" in (result.reason or "").lower()
+    )
+
+
+def test_locked_mode_unknown_method_requires_confirmation(monkeypatch):
+    """Under locked mode, an unknown method on a non-blocked model must
+    require confirmation (matches strict-mode classifier behaviour)."""
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.setenv("MCP_READ_ONLY", "false")
+    monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "res.partner.unknown_custom_method")
+    result = classify_operation("res.partner", "unknown_custom_method", args=[[1]])
+    assert result.requires_confirmation is True
+
+
+def test_locked_mode_batch_medium_requires_confirmation(monkeypatch):
+    """Under locked mode, MEDIUM batch operations (record_count > 1) must
+    require confirmation (matches strict-mode classifier behaviour)."""
+    monkeypatch.setenv("MCP_SAFETY_MODE", "locked")
+    monkeypatch.setenv("MCP_READ_ONLY", "false")
+    monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "res.partner.create")
+    # create() with a list of dicts → batch
+    result = classify_operation(
+        "res.partner", "create", args=[[{"name": "A"}, {"name": "B"}]],
+    )
+    assert result.requires_confirmation is True

--- a/tests/test_write_allowlist.py
+++ b/tests/test_write_allowlist.py
@@ -1,5 +1,4 @@
 """Tests for MCP_WRITE_ALLOWLIST enforcement in classify_operation."""
-import pytest
 
 from odoo_mcp.safety import RiskLevel, classify_operation
 
@@ -88,6 +87,8 @@ def test_locked_mode_batch_medium_requires_confirmation(monkeypatch):
     monkeypatch.setenv("MCP_WRITE_ALLOWLIST", "res.partner.create")
     # create() with a list of dicts → batch
     result = classify_operation(
-        "res.partner", "create", args=[[{"name": "A"}, {"name": "B"}]],
+        "res.partner",
+        "create",
+        args=[[{"name": "A"}, {"name": "B"}]],
     )
     assert result.requires_confirmation is True


### PR DESCRIPTION
## Summary
- **New `locked` value for `MCP_SAFETY_MODE`** activating four overlapping protections by default:
  - `MCP_READ_ONLY=true` (global write kill-switch)
  - `MCP_WRITE_ALLOWLIST` enforcement (empty list = no writes)
  - `MCP_HOST=127.0.0.1` default (localhost-only HTTP bind)
  - `MCP_VALIDATE_PAYLOADS=true` (live `fields_get` pre-flight)
- Each protection is independently overridable (hybrid umbrella + per-flag pattern). `permissive` and `strict` semantics unchanged.
- New `odoo://server-status` resource for runtime posture introspection (mode, host, allowlist, warnings).
- Banner update: `[SAFETY locked · READ-ONLY · BIND 127.0.0.1 · ALLOWLIST 0 entries]` posture line.
- Phase 2 payload validator catches hallucinated fields and readonly writes against live `fields_get` (60s LRU cache).

## Why
Threat model: an over-eager AI agent operating against a colleague's Odoo. Today's defaults assume a careful operator. `locked` mode flips defaults to fail-safe (writes off, localhost bind, allowlist required, payloads validated) so colleagues can opt in to a safe baseline with one env var.

## Design + plan
- Spec: `docs/superpowers/specs/2026-05-05-safety-locked-mode-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-05-safety-locked-mode.md`
- 12 TDD tasks executed via subagent-driven-development (fresh subagent per task, two-stage review)

## Files
**New:**
- `src/odoo_mcp/safety_profile.py` — `ResolvedProfile` dataclass + `resolve()` function
- `tests/test_side_effect_predicate.py`, `tests/test_safety_profile.py`, `tests/test_read_only_guard.py`, `tests/test_write_allowlist.py`, `tests/test_main_bind_default.py`, `tests/test_server_status_resource.py`, `tests/test_fields_cache.py`, `tests/test_payload_validation.py`
- `tests/live/test_locked_mode_live.py` (script-style; not collected by pytest; **run manually before merge**)

**Modified:**
- `src/odoo_mcp/safety.py` — `is_side_effect_method()`, `_allowlist_blocks()`, `validate_payload_against_schema()`, allowlist wired into `classify_operation`
- `src/odoo_mcp/server.py` — read-only guards in `execute_method`/`batch_execute`/`execute_workflow`, payload pre-flight before token issuance, server-status route
- `src/odoo_mcp/resources.py` — `server_status()` handler
- `src/odoo_mcp/__main__.py` — host default flip, banner posture line
- `src/odoo_mcp/utils.py` — `_FIELDS_CACHE`, `get_fields_for_model()`
- `CLAUDE.md` — config table rows, locked-mode section, posture resource entry
- `pyproject.toml` — version bump to 1.15.0

## Test plan
- [x] `pytest tests/ --ignore=tests/live -q` → 239 passed
- [x] `ruff check` clean on new code (pre-existing lint elsewhere unchanged)
- [x] `black --check` clean on changed files
- [ ] **Run manually before merge**: `python tests/live/test_locked_mode_live.py` (requires `.env` with valid Odoo credentials)
- [ ] Manual smoke: `MCP_SAFETY_MODE=locked python -m odoo_mcp 2>&1 | head -25` → posture banner shows `[SAFETY locked · READ-ONLY · BIND 127.0.0.1 · ALLOWLIST 0 entries]`
- [ ] Manual smoke: `MCP_SAFETY_MODE=locked python -c "from odoo_mcp.server import read_resource; print(read_resource('odoo://server-status'))"` → returns expected payload

## Backward compatibility
- `MCP_SAFETY_MODE=permissive` / `strict` behave identically to v1.14.0.
- No deploy changes posture on upgrade unless the operator opts in to `locked`.
- `MCP_HOST` default flip only applies under `locked`. Existing Docker deploys (`strict` default) continue binding to `0.0.0.0` on the same port.

## Out of scope (deliberate)
- 3-step preview/validate/execute write workflow (rejected in design — token gate + payload pre-flight covers the same threats with less friction)
- CI fixture with restricted Odoo user (Phase 3, not in this scope)
- Splitting `execute_method` out of `server.py` (now ~1320 LOC; revisit if it crosses 1500)