### PR TITLE
Pin FastMCP to 3.x and enforce the bound everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **FastMCP dependency is now bounded: `fastmcp[tasks]>=3.4.6,<4`** (was `>=3.2.0`, unbounded).
+  Because the package is installed from git rather than PyPI, `uv.lock` does not apply to the
+  documented install path — every fresh `pip install git+…` resolved dependencies anew. That
+  already pulled FastMCP 3.4.6 and a Starlette major bump (0.52 → 1.x) nobody had tested, and
+  would silently have pulled FastMCP 4.x on release. FastMCP 4.x is not a drop-in: it targets
+  MCP spec 2026-07-28 (stateless core, no server-initiated requests, so `configure_odoo`'s
+  elicitation raises at runtime), moves to MCP SDK v2 (`mcp>=2.0` plus the split-out
+  `mcp-types`, changing the `mcp.types` imports in `app.py` and `skill_visibility.py`),
+  switches to `httpx2`, and relocates background tasks into a separate `fastmcp-tasks`
+  package requiring an explicit `TasksExtension` — without which `batch_execute` and
+  `execute_workflow` fail to register. The tested baseline moves to 3.4.6 so development and
+  fresh installs converge on one verified version. See `docs/mcp-2026-07-28-migration.md`.
 - Install documentation now points to GitHub (`pip install git+https://github.com/AlanOgic/odoo-mcp-19.git`)
   and locally built Docker images. The package is deliberately **not** published to PyPI or
   Docker Hub; the previously documented `pip install odoo-mcp-19` and
   `docker pull alanogik/odoo-mcp-19` paths never existed.
+
+### Added
+- `tests/test_dependency_pins.py` — guards the FastMCP and MCP SDK majors from two angles:
+  the installed versions (catches a stale or bypassed lock) and the constraint declared in
+  `pyproject.toml` (catches the bound being widened without doing the migration).
 
 ### Removed
 - The `quote-to-cash` prompt and the `quote_to_cash` workflow (with its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Docker Hub; the previously documented `pip install odoo-mcp-19` and
   `docker pull alanogik/odoo-mcp-19` paths never existed.
 
+### Fixed
+- **Documentation accuracy pass.** Three claims in the wiki and tool descriptions were wrong:
+  - `batch_execute` was documented as running "in a single transaction" with `atomic`
+    meaning "rollback all on error". It does neither. Each operation is a separate JSON-2
+    request, and `atomic=true` returns at the first failure leaving every prior operation
+    **committed**. Corrected in `wiki/Tools.md` and `CLAUDE.md`, with an explicit warning.
+  - `execute_workflow`'s tool description advertised a `stock_transfer` workflow and
+    natural-language workflow synthesis. Neither is implemented — both return
+    `Unknown workflow`. The description now lists only `lead_to_won` and
+    `create_and_post_invoice` with their aliases and required parameters.
+  - The CHANGELOG link block pointed at 10 release tags that were never pushed. Only
+    v1.0.0, v1.6.0, v1.11.0, v1.14.0 and v1.15.0 exist; the dead links are gone and
+    `[Unreleased]` now resolves.
+
 ### Added
 - `tests/test_dependency_pins.py` — guards the FastMCP and MCP SDK majors from two angles:
   the installed versions (catches a stale or bypassed lock) and the constraint declared in
@@ -454,7 +468,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `discover_model_actions` tool (now `odoo://actions/{model}` resource)
 - `aggregate_data` tool (use `execute_method` with `read_group` + `odoo://aggregation` guide)
 
-### Why This Change?
+### Why this change
 Resources are read-only discovery mechanisms that don't count as "tools" in the MCP context.
 This reduces cognitive load and keeps the tool interface minimal:
 - **Tools** = Actions that modify data or execute operations
@@ -575,14 +589,11 @@ This reduces cognitive load and keeps the tool interface minimal:
   - Docker support with `Dockerfile` and `docker-compose.yml`
   - `run-docker.sh` wrapper for Claude Desktop
 
-[1.9.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.9.0
-[1.8.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.8.0
-[1.7.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.7.0
+<!-- Only versions with a published git tag are linked. Intermediate releases were
+     cut without tags; their entries above remain the record for those versions. -->
+[Unreleased]: https://github.com/AlanOgic/odoo-mcp-19/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.15.0
+[1.14.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.14.0
+[1.11.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.11.0
 [1.6.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.6.0
-[1.5.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.5.0
-[1.4.1]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.4.1
-[1.4.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.4.0
-[1.3.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.3.0
-[1.2.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.2.0
-[1.1.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.1.0
 [1.0.0]: https://github.com/AlanOgic/odoo-mcp-19/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,8 +173,8 @@ Audit log via `logging.getLogger("odoo_mcp.safety")` (configured in `__init__.py
 | Tool | Purpose |
 |------|---------|
 | `execute_method` | Universal Odoo API access |
-| `batch_execute` | Multiple ops with progress tracking |
-| `execute_workflow` | Pre-built multi-step workflows (`lead_to_won`, `create_and_post_invoice`, `stock_transfer`, …) |
+| `batch_execute` | Multiple ops with progress tracking. **`atomic=True` stops at the first failure — it does not roll back.** Each op is a separate JSON-2 request, so completed ops stay committed |
+| `execute_workflow` | Two implemented workflows: `lead_to_won` (aliases `crm_workflow`, `opportunity_won`) and `create_and_post_invoice` (alias `quick_invoice`). Anything else returns `Unknown workflow` — there is **no** natural-language workflow synthesis. Note `safety._WORKFLOW_STEPS` still carries a `stock_transfer` entry with no matching branch in `execute_workflow`; it classifies, then fails as unknown |
 | `configure_odoo` | Interactive connection setup (user elicitation) |
 | `read_resource` | Read any `odoo://` URI — bridge for clients without resource template support |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **odoo-mcp-19** — Standalone MCP server for Odoo 19+ using the **v2 JSON-2 API** (`POST /json/2/{model}/{method}`, Bearer token auth, named args only). No v1 fallback.
 
-- **Version**: 1.15.0 · **Python**: 3.10+ · **MCP**: 2025-11-25 (FastMCP `>=3.4.6,<4`)
+- **Version**: 1.15.0 · **Python**: 3.10+ · **MCP**: 2025-11-25 (FastMCP `>=3.4.6,<4`; `cryptography>=42` is a *direct* dependency of `token_crypto`, not just a transitive Authlib one)
 - **The `<4` ceiling is deliberate.** FastMCP 4.x targets MCP spec 2026-07-28 and is not a drop-in — see `docs/mcp-2026-07-28-migration.md` and `tests/test_dependency_pins.py`, which fails the build if the bound is widened or the environment drifts.
 - **Surface**: 5 tools, 27 `odoo://` resources, 19 prompts (12 generic + 7 `cyanview-*` workflow skill prompts)
 - **Discovery is via resources, action is via tools** — there is no `list_models` tool, agents read `odoo://models` instead.
@@ -134,6 +134,9 @@ Activated by `USERS_DB_PATH` (HTTP transport). Key invariants:
 
 Classification also takes a `role` (multi-user mode): `readonly` users get BLOCKED for any non-safe method, before model rules are even consulted. `tests/test_safety_role.py` pins this.
 
+- **Batch rule (strict mode)**: a MEDIUM method affecting more than one record is escalated to confirmation. The count comes from `_estimate_record_count`, which reads the payload from **either** `args_json` or `kwargs_json` (`_COUNTED_ARG` in `safety.py`: `write`/`unlink`/`copy` → `ids`, `create` → `vals_list`, `load` → `data`; `action_*`/`button_*` → `ids`). v2 is named-args-only, so both spellings must be counted — counting only the positional form lets a bulk `unlink` slip past the gate by moving `ids` into `kwargs_json`.
+- **Unknown methods** classify as MEDIUM: confirm in `strict`, allow in `permissive`.
+
 - **BLOCKED_MODELS** (writes always refused): `ir.rule`, `ir.model.access`, `ir.module.module`, `ir.config_parameter`, `ir.model`, `res.users`, `res.groups`, `res.users.apikeys`. The `resolve_json` parameter also rejects these as targets — agents cannot use it to read security-critical data. `res.users.apikeys` is blocked because Odoo 19.1+ exposes programmatic API-key management (`res.users.apikeys.generate` / `.revoke` over JSON-2 — Odoo restricts it to *Settings* admins by default, opt-in for others via `base.enable_programmatic_api_keys`, but the connected API user is often privileged); it's a distinct model name from `res.users`, so without an explicit entry an agent could mint a persistent API key (up to 3 months) that outlives the MCP session.
 - **SENSITIVE_MODELS** (writes always confirm, both modes): `account.move`, `account.payment`, `account.bank.statement`, `hr.payslip`, `ir.cron`, `ir.model.fields`. The last enables Studio-style custom-field creation/editing — allowed but always token-gated; whole-model changes (`ir.model`) remain BLOCKED.
 - **Cascade warnings** are surfaced for: `sale.order.action_confirm` (creates deliveries), `account.move.action_post` (irreversible journal entries), `stock.picking.button_validate` (stock changes), `purchase.order.button_confirm` (incoming receipts), `account.payment.action_post` (journal + reconciliation).
@@ -234,6 +237,7 @@ Read `odoo://model-limitations` for the full live list (static + runtime-detecte
 - **Thread safety**: `OdooClient` is a singleton with double-checked locking. `_DOC_CACHE` (100-entry LRU) and `RUNTIME_MODEL_ISSUES` use `threading.Lock`.
 - **Error sanitization**: never include Odoo `debug` tracebacks in MCP responses.
 - **Docker**: non-root user (UID 1001); `run-docker.sh` uses `--env-file`; `docker-compose.yml` uses `${MCP_API_KEY:?required}`.
+- **Docker must not restate dependency constraints.** The Dockerfile installs a stub package to resolve `pyproject.toml`'s dependency set into its own cached layer, then installs the real source with `--no-deps`. A hand-copied list drifts silently — it had already lost the `fastmcp<4` ceiling and never listed `cryptography>=42`. `tests/test_dependency_pins.py::TestDockerfileUsesDeclaredDependencies` fails if a restated pin reappears.
 - **HTTP**: `sys.exit(1)` unless `MCP_API_KEY` or `USERS_DB_PATH` is set. Wizard auto-generates keys with `secrets.token_urlsafe(32)`. Multi-user token compare uses `hmac.compare_digest` (static key) / sha256 hash lookup (registry keys — plaintext keys are never stored).
 - **Resource limits**: `MCP_DEFAULT_CONTEXT` ≤ 4KB; `MCP_BOOTSTRAP_MODELS` ≤ 20 models; `_DOC_CACHE` ≤ 100 entries.
 - **Gitignored**: `.env`, `.env.local`, `.mcp.json`, `odoo_config.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **odoo-mcp-19** — Standalone MCP server for Odoo 19+ using the **v2 JSON-2 API** (`POST /json/2/{model}/{method}`, Bearer token auth, named args only). No v1 fallback.
 
-- **Version**: 1.15.0 · **Python**: 3.10+ · **MCP**: 2025-11-25 (FastMCP 3.2.0+)
+- **Version**: 1.15.0 · **Python**: 3.10+ · **MCP**: 2025-11-25 (FastMCP `>=3.4.6,<4`)
+- **The `<4` ceiling is deliberate.** FastMCP 4.x targets MCP spec 2026-07-28 and is not a drop-in — see `docs/mcp-2026-07-28-migration.md` and `tests/test_dependency_pins.py`, which fails the build if the bound is widened or the environment drifts.
 - **Surface**: 5 tools, 27 `odoo://` resources, 19 prompts (12 generic + 7 `cyanview-*` workflow skill prompts)
 - **Discovery is via resources, action is via tools** — there is no `list_models` tool, agents read `odoo://models` instead.
 - **Two deployment shapes**: single-user (STDIO or HTTP with one static `MCP_API_KEY`) and **multi-user HTTP** (per-user `cv_odoo_…` keys from the CLORAG-managed registry, personal Odoo clients, per-user skill visibility — see "Multi-user mode" below).
@@ -58,6 +59,8 @@ Note: live tests under `tests/live/` are **script-style runners**, not pytest mo
 - **Unit (no Odoo)**: everything in `tests/` except `tests/live/` — run with `pytest --ignore=tests/live`. Highlights: `test_resources.py` patches `get_odoo_client` with a stub (pins resource-layer validation/error handling); `test_arg_mapping.py` pins the positional → JSON-2 named-arg contract; `test_odoo_client.py` pins bearer auth + no `result`-envelope unwrap; `test_token_gate.py` / `test_safety.py` / `test_safety_role.py` cover the gate and role-based classification; the multi-user tests (`test_auth_verifier.py`, `test_token_crypto.py`, `test_user_clients.py`, `test_skill_visibility.py`, `test_skill_prompts.py`) use the `users_db_seed` fixture in `tests/conftest.py`, which builds a temp registry with the **exact CLORAG DDL and crypto contract** — keep that fixture contract-true.
 - **Live (need `.env`)**: anything under `tests/live/` — run with `python <file>`, not pytest.
 
+**CI**: the only workflow is `.github/workflows/claude-code-review.yml` — an automated Claude code review on every PR. There is **no build/test CI**; run the unit tests, lint, and typecheck locally before pushing.
+
 ## High-level architecture
 
 The package was split in v1.14.0 (commit `ea10d79`) from a 3762-line `server.py` into focused modules; the multi-user layer (commit `4d1b7f8`) added the `skill_prompts`, `auth_verifier`, `users_db`, `user_clients`, `token_crypto`, and `skill_visibility` modules (see the tree below). Import order matters: `app.py` must be imported first so the `mcp` decorator is bound before `server.py`, `resources.py`, `prompts.py`, and `skill_prompts.py` register their handlers. `app.py` also wires auth (`_get_auth_provider`) and the skill-visibility middleware at import time, based on env.
@@ -103,7 +106,7 @@ src/odoo_mcp/
 
 **3. Live doc enrichment** — `odoo://methods/{model}` and `@api.private` detection both consult `/doc-bearer/<model>.json` (provided by Odoo's `api_doc` module, requires `api_doc.group_allow_doc` on the API user). Cached in `_DOC_CACHE`: 5-min TTL, 100-entry LRU, `threading.Lock`. Falls back silently to static data if unavailable.
 
-**4. Background tasks** — `batch_execute` and `execute_workflow` use FastMCP's `[tasks]` extra to support async execution with progress reporting (MCP 2025-11-25 SEP-1686).
+**4. Background tasks** — `batch_execute` and `execute_workflow` use FastMCP's `[tasks]` extra (backed by `pydocket` on the 3.x line) to support async execution with progress reporting (MCP 2025-11-25 SEP-1686). In FastMCP 4.x the extra becomes the separate `fastmcp-tasks` package and `task=True` tools additionally require an explicit `mcp.add_extension(TasksExtension())` — without it they fail to register at startup. This is one of the reasons for the `<4` pin.
 
 **5. Multi-user request path** (HTTP + `USERS_DB_PATH`): bearer token → `DbTokenVerifier` hashes it (sha256) and looks it up in the registry (`server='odoo'`, non-revoked key, active user) → `AccessToken` carries `client_id=user_id` and a `role` claim → every tool call passes `role=current_role()` into safety classification, and `get_odoo_client()` resolves the caller's **personal** OdooClient (their Odoo username + decrypted API key), so writes are attributed to the real Odoo account. STDIO and the static `MCP_API_KEY` fallback bypass all of this and use the env singleton — existing single-user behavior is unchanged.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,24 @@ RUN useradd --system --no-create-home --uid 1001 mcp
 # Copy dependency manifests first for layer caching
 COPY pyproject.toml README.md ./
 
-# Install dependencies only (without local package)
-RUN pip install --no-cache-dir \
-    "fastmcp[tasks]>=3.2.0" \
-    "requests>=2.32.4" \
-    "python-dotenv>=1.0.0"
+# Resolve dependencies from pyproject.toml — never from a list duplicated here.
+# A hand-copied list silently drifts from the declared constraints, which then
+# never apply because the package itself is installed with --no-deps. It had
+# already lost the deliberate `fastmcp<4` ceiling (carrying `>=3.2.0`) that
+# tests/test_dependency_pins.py exists to guard, and it never listed
+# `cryptography>=42` at all — token_crypto only imported because Authlib, a
+# transitive FastMCP dependency, happens to pull cryptography in.
+# Installing a stub package resolves the real dependency set into its own cached
+# layer, so editing src/ does not re-resolve them; the stub is then replaced by
+# the real package below.
+RUN mkdir -p src/odoo_mcp \
+    && touch src/odoo_mcp/__init__.py \
+    && pip install --no-cache-dir . \
+    && pip uninstall --yes odoo-mcp-19 \
+    && rm -rf src
 
-# Copy source and install local package without re-installing deps
+# Copy source and install the local package; dependencies are already resolved
+# above, so --no-deps keeps this layer cheap without weakening any constraint.
 COPY src/ src/
 RUN pip install --no-cache-dir --no-deps .
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Connect Claude and AI assistants to Odoo 19+ via the Model Context Protocol (MCP
 - **Safety layer** - Pre-execution risk classification, blocked models, cascade warnings
 - **DX optimizations** - Quick-schema, bundle, session-bootstrap, resolve_json for token-efficient AI operations
 - **MCP 2025-11-25** - Background tasks, progress tracking, icons, structured outputs
-- **FastMCP 3.2.0+** - Latest stable SDK with security fixes, providers, transforms, OpenTelemetry
+- **FastMCP 3.4.6 (`<4`)** - Latest 3.x with security fixes, providers, transforms, OpenTelemetry. FastMCP 4.x targets MCP spec 2026-07-28 and is intentionally not yet adopted
 - **Input validation** - Regex-validated model/method names, URI scheme guards, JSON type checks
 - **Thread-safe** - Singleton client, locked global caches for concurrent HTTP transport
 - **Hardened Docker** - Non-root container, `--env-file` for secrets, mandatory HTTP auth
@@ -528,7 +528,7 @@ Full documentation in the **[Wiki](https://github.com/AlanOgic/odoo-mcp-19/wiki)
 
 - Python 3.10+
 - Odoo 19+
-- FastMCP 3.2.0+ (with tasks extra)
+- FastMCP >=3.4.6,<4 (with tasks extra)
 - requests 2.32.4+
 
 ## License

--- a/README.md
+++ b/README.md
@@ -6,22 +6,52 @@
 \____/\__,_/\____/\____/  /_/  /_/\____/_/       /_//____/ /_/
 ```
 
-Connect Claude and AI assistants to Odoo 19+ via the Model Context Protocol (MCP).
+Ask Claude to read and write your Odoo 19 data in plain language — and stop it from doing
+the dangerous parts by accident.
 
-## Features
+This server connects any Model Context Protocol (MCP) client to Odoo 19+ over the v2 JSON-2
+API. An assistant discovers your models by reading schemas rather than guessing field names,
+then calls any ORM method through one tool. Before anything destructive runs, a safety layer
+classifies the operation and holds it behind a single-use confirmation token.
 
-- **5 tools, full power** - `execute_method` calls ANY method on ANY model. Combined with `batch_execute`, `execute_workflow`, `configure_odoo`, and `read_resource`, you have complete Odoo API access
-- **27 resources** - Dynamic model discovery, compact schemas, workflows, and introspection
-- **19 prompts** - 12 generic guided workflows + 7 `cyanview-*` workflow skill prompts (per-user gated in multi-user mode)
-- **30 ORM methods** - Complete documentation with examples
-- **13 modules** - Special methods including AI module (Enterprise)
-- **Safety layer** - Pre-execution risk classification, blocked models, cascade warnings
-- **DX optimizations** - Quick-schema, bundle, session-bootstrap, resolve_json for token-efficient AI operations
-- **MCP 2025-11-25** - Background tasks, progress tracking, icons, structured outputs
-- **FastMCP 3.4.6 (`<4`)** - Latest 3.x with security fixes, providers, transforms, OpenTelemetry. FastMCP 4.x targets MCP spec 2026-07-28 and is intentionally not yet adopted
-- **Input validation** - Regex-validated model/method names, URI scheme guards, JSON type checks
-- **Thread-safe** - Singleton client, locked global caches for concurrent HTTP transport
-- **Hardened Docker** - Non-root container, `--env-file` for secrets, mandatory HTTP auth
+```python
+# The assistant reads the schema first, then queries — no guessed field names
+read_resource("odoo://model/sale.order/quick-schema")
+execute_method("sale.order", "search_read",
+    kwargs_json='{"domain": [["state", "=", "sale"]], "fields": ["name", "amount_total"], "limit": 10}')
+```
+
+## Who this is for
+
+- **You run Odoo 19+** and want an assistant that queries and updates it directly, instead of
+  copying data between a chat window and the ERP.
+- **You need writes to be safe.** Posting a journal entry or validating a picking is
+  irreversible. Every such call is gated, and eight security-critical models refuse writes
+  outright.
+- **You care about token cost.** Compact schemas, batched model bundles, and one-call session
+  bootstrap keep discovery cheap on long conversations.
+
+If you only need read-only reporting, this still works — set a `readonly` role and the safety
+layer blocks every non-safe method.
+
+## What you get
+
+| | |
+|---|---|
+| **5 tools** | `execute_method` reaches any method on any model; `batch_execute`, `execute_workflow`, `configure_odoo`, and `read_resource` cover the rest |
+| **27 resources** | Model discovery, compact schemas, state-machine workflows, and introspection |
+| **19 prompts** | 12 generic guided workflows plus 7 `cyanview-*` skill prompts, gated per user in multi-user mode |
+| **Safety layer** | Risk classification before execution, 8 blocked models, 6 sensitive models, cascade warnings |
+| **Multi-user mode** | Per-user bearer keys and personal Odoo clients, so every write is attributed to a real person |
+| **Reference data** | 30 documented ORM methods, 13 modules with special-method knowledge, including the Enterprise AI module |
+
+Built on **MCP 2025-11-25** (background tasks, progress tracking, icons, structured outputs)
+and **FastMCP `>=3.4.6,<4`**. The ceiling is deliberate — FastMCP 4.x targets MCP spec
+2026-07-28 and is [not yet adopted](docs/mcp-2026-07-28-migration.md).
+
+Hardened by default: regex-validated model and method names, a non-root Docker container,
+mandatory authentication on HTTP, thread-safe caches, and no traceback ever forwarded to a
+client.
 
 ## Installation
 
@@ -29,7 +59,7 @@ Connect Claude and AI assistants to Odoo 19+ via the Model Context Protocol (MCP
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (recommended) **OR** Python 3.10+
 - An Odoo 19+ instance with API access
-- An API key from your Odoo instance (Settings > Users > API Keys)
+- An API key from your Odoo instance (**Preferences → Account Security → New API Key**)
 
 ### Option A: Docker (recommended)
 
@@ -91,7 +121,7 @@ python -m odoo_mcp
 pip install git+https://github.com/AlanOgic/odoo-mcp-19.git
 ```
 
-## Setup Wizard
+## Setup wizard
 
 Interactive wizard that generates `.env`, Docker commands, and Claude Desktop config:
 
@@ -191,9 +221,10 @@ Create a `.env` file in the project root with your credentials, then:
 
 **Restart Claude Desktop** after saving the config file.
 
-### Verify it works
+### Verify the connection
 
-Ask Claude: *"List the first 5 partners in Odoo"*
+Ask Claude: *"List the first 5 partners in Odoo"*. It should call `execute_method` on
+`res.partner` and come back with names.
 
 ## Quick start examples
 
@@ -218,9 +249,13 @@ result = execute_method("sale.order", "action_confirm", args_json='[[15]]')
 execute_method("sale.order", "action_confirm", args_json='[[15]]',
     confirmed=true, confirmation_token='<token from step 1>')
 
-# Multi-step workflow in one call
+# Multi-step workflow in one call (also gated — posting an invoice is irreversible)
 execute_workflow("create_and_post_invoice", '{"partner_id": 123, "invoice_lines": [...]}')
 ```
+
+Note that `confirmed=true` on its own does nothing. The token is single-use, expires after
+120 seconds, and is bound to the exact payload the gate inspected — so an agent cannot take a
+token issued for `unlink([1])` and reuse it on `unlink([1, 2, …, 1000])`.
 
 ## Architecture
 
@@ -297,7 +332,7 @@ execute_workflow("create_and_post_invoice", '{"partner_id": 123, "invoice_lines"
 | `cyanview-shipping-watchdog` | Audit unshipped/overdue orders |
 | `cyanview-inventory-watchdog` | Monitor stock levels and reorders |
 
-## Safety Layer (v1.10.0)
+## Safety layer
 
 Pre-execution safety classification gates dangerous operations behind confirmation.
 
@@ -327,7 +362,7 @@ Side effects are surfaced for workflow actions:
 - `purchase.order` + `button_confirm` → creates incoming receipts
 - `account.payment` + `action_post` → creates journal entries + reconciliation
 
-### Confirmation flow (token-based, v1.14.0)
+### Confirmation flow
 
 1. Caller sends `execute_method(model, method, args_json)`
 2. Safety layer classifies the operation
@@ -336,9 +371,9 @@ Side effects are surfaced for workflow actions:
 
 Tokens are single-use, expire after 120s, and are bound to the specific model+method. This prevents agents from bypassing the safety gate by always passing `confirmed=true`.
 
-## DX Improvements (v1.11.0)
+## Token-efficient discovery
 
-### Quick Schema
+### Quick schema
 
 `odoo://model/{model}/quick-schema` — Ultra-compact schema with short keys: `t` (type), `req` (required), `ro` (readonly), `rel` (relation). ~60-80% smaller than `/fields`.
 
@@ -346,7 +381,7 @@ Tokens are single-use, expire after 120s, and are bound to the specific model+me
 
 `odoo://bundle/res.partner,sale.order,stock.picking` — Batch quick-schema for up to 10 models in one call.
 
-### Session Bootstrap
+### Session bootstrap
 
 `odoo://session-bootstrap` — One call to bootstrap a conversation with schemas + workflows for common models. Configure via `MCP_BOOTSTRAP_MODELS` env var.
 
@@ -354,7 +389,7 @@ Tokens are single-use, expire after 120s, and are bound to the specific model+me
 
 `odoo://model/{model}/workflow` — State machine transitions for 6 main models with side effects and irreversibility flags. Dynamic fallback for unmapped models.
 
-### Many2one Resolution
+### Many2one resolution
 
 Auto-resolve field names to IDs with `resolve_json`:
 
@@ -364,7 +399,7 @@ execute_method("res.partner", "write",
     resolve_json='{"user_id": {"model": "res.users", "search": "John"}}')
 ```
 
-### Default Context
+### Default context
 
 Set `MCP_DEFAULT_CONTEXT` to apply context to all operations:
 
@@ -372,11 +407,11 @@ Set `MCP_DEFAULT_CONTEXT` to apply context to all operations:
 export MCP_DEFAULT_CONTEXT='{"lang": "fr_FR", "tz": "Europe/Paris"}'
 ```
 
-### Expanded Error Patterns
+### Error suggestions
 
 ~25 error patterns with actionable suggestions covering 422, 500, 403, 404 errors and fallback patterns.
 
-## HTTP Transport
+## HTTP transport
 
 Run as an HTTP server with Bearer token authentication for remote or multi-client access.
 
@@ -426,7 +461,7 @@ docker run -d -p 8080:8080 \
 }
 ```
 
-### Verify it works
+### Verify authentication
 
 ```bash
 # Should succeed (200)
@@ -484,7 +519,7 @@ env `ODOO_*` credentials become optional (only the `env-admin` fallback uses the
 | `ODOO_URL` | Yes | — | Odoo server URL |
 | `ODOO_DB` | Yes | — | Database name |
 | `ODOO_USERNAME` | Yes | — | Username |
-| `ODOO_API_KEY` | Yes | — | API key (Settings > Users > API Keys) |
+| `ODOO_API_KEY` | Yes | — | API key (Preferences → Account Security) |
 | `ODOO_PASSWORD` | No | — | Password (fallback if no API key) |
 | `ODOO_TIMEOUT` | No | `30` | Request timeout in seconds |
 | `ODOO_VERIFY_SSL` | No | `true` | SSL certificate verification |
@@ -502,16 +537,26 @@ env `ODOO_*` credentials become optional (only the `env-admin` fallback uses the
 
 ## Documentation
 
-Full documentation in the **[Wiki](https://github.com/AlanOgic/odoo-mcp-19/wiki)**:
+Full documentation lives in the **[Wiki](https://github.com/AlanOgic/odoo-mcp-19/wiki)**:
 
-- [Getting Started](https://github.com/AlanOgic/odoo-mcp-19/wiki/Getting-Started)
-- [Tools](https://github.com/AlanOgic/odoo-mcp-19/wiki/Tools)
-- [Resources](https://github.com/AlanOgic/odoo-mcp-19/wiki/Resources)
-- [ORM Methods](https://github.com/AlanOgic/odoo-mcp-19/wiki/ORM-Methods)
-- [Module Knowledge](https://github.com/AlanOgic/odoo-mcp-19/wiki/Module-Knowledge)
-- [AI Module](https://github.com/AlanOgic/odoo-mcp-19/wiki/AI-Module)
-- [Domain Syntax](https://github.com/AlanOgic/odoo-mcp-19/wiki/Domain-Syntax)
-- [Prompts](https://github.com/AlanOgic/odoo-mcp-19/wiki/Prompts)
+**Start here**
+
+- [Getting started](https://github.com/AlanOgic/odoo-mcp-19/wiki/Getting-Started) — install and connect in five minutes
+- [Tools](https://github.com/AlanOgic/odoo-mcp-19/wiki/Tools) — the 5 tools, their parameters, and when to reach for each
+- [Resources](https://github.com/AlanOgic/odoo-mcp-19/wiki/Resources) — the 27 `odoo://` discovery URIs
+
+**Reference**
+
+- [ORM methods](https://github.com/AlanOgic/odoo-mcp-19/wiki/ORM-Methods) — 30 methods with working examples
+- [Domain syntax](https://github.com/AlanOgic/odoo-mcp-19/wiki/Domain-Syntax) — Polish-prefix search filters
+- [Module knowledge](https://github.com/AlanOgic/odoo-mcp-19/wiki/Module-Knowledge) — special methods across 13 modules
+- [AI module](https://github.com/AlanOgic/odoo-mcp-19/wiki/AI-Module) — Odoo 19 Enterprise AI integration
+- [Prompts](https://github.com/AlanOgic/odoo-mcp-19/wiki/Prompts) — the 19 guided workflow prompts
+
+**Operations**
+
+- [Deployment](https://github.com/AlanOgic/odoo-mcp-19/wiki/Deployment) — production HTTP behind Nginx, multi-client routing
+- [MCP 2026-07-28 migration](docs/mcp-2026-07-28-migration.md) — why FastMCP is pinned below 4.x, and what moving costs
 
 ## Security
 

--- a/docs/mcp-2026-07-28-migration.md
+++ b/docs/mcp-2026-07-28-migration.md
@@ -1,0 +1,202 @@
+# Migrating to MCP 2026-07-28 / FastMCP 4.x
+
+**Status**: not started. The server is pinned to `fastmcp[tasks]>=3.4.6,<4` and speaks MCP `2025-11-25`.
+**Written**: 2026-08-07, against FastMCP `4.0.0b2` and MCP spec `2026-07-28` (final).
+
+This is a decision document, not a task list. It records what breaks, what it costs, and what
+was already decided — so the migration can be executed later without re-doing the analysis.
+
+---
+
+## 0. First, the thing that is easy to get wrong
+
+"MCP 2.0 removed FastMCP" is half true, and the half that is true does not apply here.
+
+- The **official MCP Python SDK v2.0.0** deleted its *in-SDK* `FastMCP` class
+  (`mcp.server.fastmcp.FastMCP` → `MCPServer` in `mcp.server.mcpserver`). This repo never
+  used it and is unaffected by that rename.
+- The **standalone `fastmcp` package** (PrefectHQ / jlowin) — our actual dependency — is
+  alive and actively released: `3.4.6` stable (2026-08-05), `4.0.0b2` beta (2026-08-07).
+- What genuinely changes is the **protocol underneath it**. MCP spec `2026-07-28` is final,
+  and FastMCP 4.x is where it lands.
+
+### Why there is no rush
+
+- The spec carries a **formal 12-month minimum deprecation window** for anything it retires.
+- FastMCP 4.x **negotiates protocol era per connection** — one deployment answers both the
+  sessionless `2026-07-28` protocol and the older session-based handshake.
+- Nothing in this server is protocol-coupled below the FastMCP layer. `safety.py` in
+  particular has zero FastMCP dependency by design, which is why the blast radius is small.
+
+### Trigger conditions — migrate when all three hold
+
+1. FastMCP 4.0 is **stable** (not `a`/`b`; it was `4.0.0b2` when this was written).
+2. The clients that matter here — Claude Desktop, Claude Code, CLORAG — actually negotiate
+   `2026-07-28`. Until then, 3.4.6 serves everyone with zero loss.
+3. Someone has time to run the full verification pass in §5, including the multi-user path
+   against a real CLORAG registry.
+
+Until then the `<4` pin holds and `tests/test_dependency_pins.py` enforces it.
+
+---
+
+## 1. Protocol delta, scoped to this server
+
+Changes in `2026-07-28` versus `2025-11-25` that touch anything we do. (The full changelog
+is at `modelcontextprotocol.io/specification/2026-07-28/changelog`; most of it is irrelevant
+to us and is deliberately not reproduced here.)
+
+| Change | Relevance |
+|---|---|
+| **Stateless core** — `initialize`/`notifications/initialized` handshake removed, `Mcp-Session-Id` gone; every request carries protocol version and client capabilities in `_meta` | Helps us — see §4 |
+| **`server/discover`** — servers MUST implement it to advertise versions, capabilities, identity | FastMCP provides it; no work |
+| **Server-initiated requests removed** — elicitation, sampling, roots replaced by Multi-Round-Trip Requests (`InputRequiredResult` / `inputRequests` / `inputResponses`) | **Breaks `configure_odoo`** — §2 |
+| **Tasks moved to an extension** (`io.modelcontextprotocol/tasks`); `tasks/result` → polling via `tasks/get`, plus `tasks/update`; `tasks/list` removed | **Breaks `batch_execute` / `execute_workflow`** — §2 |
+| **`CacheableResult`** — `ttlMs` + `cacheScope` required on `tools/list`, `prompts/list`, `resources/list`, `resources/read`, `resources/templates/list` | Opportunity — §4 |
+| **Deterministic `tools/list` ordering** SHOULD be provided, for client and LLM prompt caching | Trivial — 5 tools |
+| **`subscriptions/listen`** replaces the HTTP GET endpoint and `resources/subscribe` | We subscribe to nothing; no work |
+| Resource-not-found `-32002` → `-32602` | Error-code assertions only |
+| Roots, Sampling, **Logging** deprecated (12-month window) | We already log to stderr — no work |
+| SSE resumability / `Last-Event-ID` removed | Not used |
+| All results carry `resultType` (`"complete"` / `"input_required"`) | FastMCP handles |
+
+---
+
+## 2. Per-item impact
+
+Line numbers are as of v1.15.0 and will drift — treat them as pointers, not addresses.
+
+| # | Item | Where | Break type | Decision |
+|---|---|---|---|---|
+| 1 | `configure_odoo` elicitation | `server.py:714-845` | **Runtime** — `ctx.elicit()` raises on `2026-07-28`; `response_type=` becomes mandatory even on legacy connections | **Remove the tool** — §3 |
+| 2 | `task=True` tools | `server.py:536`, `server.py:870` | **Startup** — needs `fastmcp_tasks.TasksExtension` registered via `mcp.add_extension(...)`, else *"Task-enabled tools require the tasks extension"* | Adopt the extension |
+| 3 | Templated resources | all 27 in `resources.py` | **Behavior** — 4.x screens template params for path traversal by default | `ResourceSecurity(exempt_params=...)` |
+| 4 | `mcp.types` imports | `app.py:17` (`Icon`), `skill_visibility.py:14` (`mt`) | **Import** — SDK v2 moves wire types to `mcp-types` and renames attributes to snake_case (`mimeType` → `mime_type`) behind a warn-once bridge | Update both call sites |
+| 5 | `_current_transport` | `skill_visibility.py:34` | **Fragile** — private API; survives in `4.0.0b2` but unsupported, and "transport" is a weaker signal once sessionless | Replace the stdio escape hatch |
+| 6 | Middleware breadth | `skill_visibility.py` | **Behavior** — 4.x middleware observes all inbound messages incl. notifications and unroutable requests; `on_list_prompts` / `on_get_prompt` still fire once per valid request | Verify only |
+| 7 | `httpx` → `httpx2` | — | None — `odoo_client.py` uses `requests` | No action |
+| 8 | Dependency floors | `pyproject.toml` | pydantic `>=2.12` (have 2.12.5 ✓), starlette `>=1.0.1` (have 1.4.1 ✓) | Already satisfied |
+
+### Notes on the non-obvious ones
+
+**#3 — why the resource screening matters.** Every `odoo://` resource takes a dotted model
+name (`res.partner`), and `odoo://bundle/{m1,m2,...}` takes a comma-separated list. The 4.x
+default rejects `..` segments and absolute paths. Dotted model names are not `..`, so most
+should pass — but this must be **tested, not assumed**, particularly for the bundle route.
+Exempting is safe here because `_validate_model` already regex-gates every param against
+`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$` (max 128) before it reaches Odoo. Rejected reads
+return a non-leaky resource-not-found.
+
+**#5 — what the stdio hatch is actually for.** `SkillVisibilityMiddleware._allowed_skills()`
+returns `None` (unrestricted) when the transport is stdio, so Alan's local session sees every
+`cyanview-*` prompt. Under a sessionless protocol the useful question is no longer "which
+transport?" but "is there an authenticated identity?" — and the code already handles the
+HTTP cases directly below (missing token → fail closed; `ENV_ADMIN_CLIENT_ID` or
+`role == "admin"` → unrestricted). Prefer keying on **absence of an auth provider** rather
+than transport identity. Whatever replaces it must preserve the current fail-closed
+behavior, which `tests/test_skill_visibility.py` pins.
+
+---
+
+## 3. `configure_odoo`: remove it
+
+**Decided 2026-08-07.** Do not port it to the MRTR guard-tool pattern.
+
+Rationale:
+
+- `python -m odoo_mcp --setup` already covers the job, and covers it better — it generates
+  `.env`, the Docker command, and the Claude Desktop config.
+- In multi-user mode credentials come from the CLORAG registry. A runtime-configure tool has
+  no role there at all.
+- The MRTR rewrite is the single most expensive item in this document and depends on
+  client-side MRTR support that is brand new.
+
+Removal touches: `server.py:127` (module comment), `server.py:714-845` (the tool, its
+`ElicitationResult` model, and the `fastmcp.server.elicitation` import), `CLAUDE.md:10,71,170,177`,
+`README.md:13,227,234`. Tool surface goes **5 → 4**.
+
+The startup banner counts are introspected from the FastMCP instance (`__main__.py:223,330`),
+so they follow automatically — but confirm at runtime rather than trusting it.
+
+---
+
+## 4. Opportunities, not just repairs
+
+Two of these are worth doing on their own merits, independent of the forced changes.
+
+### `ttlMs` / `cacheScope` — the real prize
+
+This server is unusually well suited to result caching. It exposes **27 discovery resources**
+serving near-static schema data — `quick-schema`, `fields`, `schema`, `workflow`, `bundle`,
+`session-bootstrap`, plus the reference docs (`domain-syntax`, `aggregation`, `pagination`,
+`hierarchical`) which are effectively immutable between releases. The server already runs a
+`_DOC_CACHE` (5-min TTL, 100-entry LRU) internally; `ttlMs` extends that saving to the client
+and removes the round-trip entirely rather than just the Odoo call.
+
+Suggested tiering when this is implemented:
+
+- **Static reference docs** (`domain-syntax`, `aggregation`, `pagination`, `hierarchical`,
+  `templates`) — long `ttlMs`, `cacheScope: "public"`. They contain no tenant data.
+- **Schema resources** (`quick-schema`, `fields`, `schema`, `methods`, `bundle`) — moderate
+  `ttlMs`. `cacheScope: "private"`: schemas reflect the connected user's field visibility,
+  and in multi-user mode two callers are genuinely different Odoo users.
+- **Runtime-varying** (`model-limitations`, which merges runtime-detected issues) — short
+  `ttlMs` or none.
+
+`cacheScope: "public"` on anything user-dependent would leak one tenant's schema to another
+through a shared intermediary. When in doubt, `"private"`.
+
+Deterministic `tools/list` ordering is nearly free at 5 tools and improves LLM prompt-cache
+hit rates; do it in the same pass.
+
+### Statelessness suits the CLORAG deployment
+
+Bearer-token-per-request already matches the sessionless model — `DbTokenVerifier` hashes and
+looks up the token on every call and holds no session state. Dropping `Mcp-Session-Id` means
+no session affinity, so the multi-user HTTP deployment can scale behind a plain round-robin
+load balancer. Nothing to build; note it when capacity becomes a question.
+
+### FastMCP 4.x enterprise auth (SEP-990)
+
+FastMCP 4.x ships role-based access control that may subsume part of the hand-rolled role-claim
+layer in `auth_verifier.py` / `safety.py`. **Evaluate, do not assume.** The registry schema is
+a CLORAG-owned contract (`~/dev/clorag`, `core/user_db.py`) and any change starts there, not
+here. The current design deliberately keeps `safety.py` free of framework dependencies; do not
+trade that away for framework convenience without a concrete gain.
+
+---
+
+## 5. Verification for the migration
+
+Everything in Phase 1's gate (`uv run pytest tests/ --ignore=tests/live`, ruff, mypy, both
+transports, capability counts), plus:
+
+- **Dual-era**: connect a `mode="legacy"` client and a `2026-07-28` client to the same
+  running server; both must work. This is the whole premise of migrating without a flag day.
+- **Tasks**: `batch_execute` and `execute_workflow` must register at startup *and* report
+  progress through the new `tasks/get` polling flow.
+- **Resource templates**: read all 27 URIs, with attention to `odoo://bundle/{m1,m2,...}` and
+  any dotted model name, to confirm the path-traversal screen does not reject legitimate params.
+- **Multi-user, against a real CLORAG registry** (not just the seeded fixture): a registry
+  bearer token resolves to the caller's personal Odoo client; `readonly` still blocks every
+  non-safe method; `cyanview-*` filtering still applies in **both** `list_prompts` and
+  `get_prompt`; a missing token still fails closed.
+- **Token gate**: the `2026-07-28` payload-digest path must still bind a confirmation token to
+  `(model, method, payload_digest)`. `tests/test_token_gate.py` pins this; make sure it is not
+  quietly weakened by any argument-handling change.
+- Update `tests/test_dependency_pins.py` majors, and this document's status line, last.
+
+---
+
+## 6. Known unrelated breakage
+
+`tests/live/test_v1110_live.py` fails at TEST 2 with
+`AttributeError: module 'odoo_mcp.constants' has no attribute '_DEFAULT_CONTEXT'`.
+
+Pre-existing and unrelated to any of the above: commit `4a39f13` ("Read safety env vars at
+call time") replaced the module-level `_DEFAULT_CONTEXT` constant with the call-time
+`_parse_default_context()` / `get_default_context()` pair, and this live runner was never
+updated. It monkey-patches the old attribute to test `_merge_context`. Fixing it means
+patching `MCP_DEFAULT_CONTEXT` in the environment instead — which is how
+`tests/test_safety.py` already does it. Worth doing before relying on this runner as a
+migration gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,11 @@ authors = [
 ]
 
 dependencies = [
-    "fastmcp[tasks]>=3.2.0",
+    # Ceiling is deliberate: FastMCP 4.x targets MCP spec 2026-07-28 and moves to
+    # MCP SDK v2 (mcp>=2.0 + mcp-types), httpx2, and a separate fastmcp-tasks
+    # package for background tasks. See docs/mcp-2026-07-28-migration.md before
+    # raising it — tests/test_dependency_pins.py enforces the bound.
+    "fastmcp[tasks]>=3.4.6,<4",
     "requests>=2.32.4",
     "python-dotenv>=1.0.0",
     "cryptography>=42",

--- a/src/odoo_mcp/__main__.py
+++ b/src/odoo_mcp/__main__.py
@@ -92,9 +92,7 @@ def _generate_claude_desktop(config: dict) -> str:
             "url": f"http://{config['mcp_host']}:{config['mcp_port']}/mcp",
         }
         if config.get("mcp_api_key"):
-            server["headers"] = {
-                "Authorization": f"Bearer {config['mcp_api_key']}"
-            }
+            server["headers"] = {"Authorization": f"Bearer {config['mcp_api_key']}"}
     else:
         server = {
             "command": "docker",
@@ -118,19 +116,13 @@ def run_setup_wizard():
     config["odoo_url"] = _prompt("Odoo URL", "https://mycompany.odoo.com")
     config["odoo_db"] = _prompt("Database")
     config["odoo_username"] = _prompt("Username")
-    config["auth_method"] = _prompt_choice(
-        "Auth method", ["API Key", "Password"], "API Key"
-    )
-    config["auth_value"] = _prompt_secret(
-        "API Key" if config["auth_method"] == "API Key" else "Password"
-    )
+    config["auth_method"] = _prompt_choice("Auth method", ["API Key", "Password"], "API Key")
+    config["auth_value"] = _prompt_secret("API Key" if config["auth_method"] == "API Key" else "Password")
     print()
 
     # --- MCP Transport ---
     print("── MCP Transport ──")
-    config["transport"] = _prompt_choice(
-        "Transport", ["stdio", "streamable-http"], "stdio"
-    )
+    config["transport"] = _prompt_choice("Transport", ["stdio", "streamable-http"], "stdio")
     if config["transport"] == "streamable-http":
         config["mcp_host"] = _prompt("Host", "0.0.0.0")
         config["mcp_port"] = _prompt("Port", "8080")
@@ -147,9 +139,7 @@ def run_setup_wizard():
 
     # --- Safety ---
     print("── Safety ──")
-    config["safety_mode"] = _prompt_choice(
-        "Safety mode", ["strict", "permissive"], "strict"
-    )
+    config["safety_mode"] = _prompt_choice("Safety mode", ["strict", "permissive"], "strict")
     print()
 
     # --- Output ---
@@ -270,10 +260,7 @@ def _print_startup_banner(transport: str, host: str, port: int) -> None:
     odoo_key = os.environ.get("ODOO_API_KEY") or os.environ.get("ODOO_PASSWORD", "")
     odoo_timeout = os.environ.get("ODOO_TIMEOUT", "30")
     odoo_ssl = os.environ.get("ODOO_VERIFY_SSL", "true")
-    ssl_disabled = (
-        odoo_ssl.lower() in ("0", "false", "no", "off")
-        and odoo_url.startswith("https://")
-    )
+    ssl_disabled = odoo_ssl.lower() in ("0", "false", "no", "off") and odoo_url.startswith("https://")
 
     safety_mode = os.environ.get("MCP_SAFETY_MODE", "strict")
     safety_audit = os.environ.get("MCP_SAFETY_AUDIT", "false")
@@ -300,9 +287,7 @@ def _print_startup_banner(transport: str, host: str, port: int) -> None:
     ]
     if transport == "streamable-http":
         parts.append(f"  Bind          : http://{host}:{port}")
-        parts.append(
-            f"  Auth          : Bearer (MCP_API_KEY={_api_key_status(os.environ.get('MCP_API_KEY', ''))})"
-        )
+        parts.append(f"  Auth          : Bearer (MCP_API_KEY={_api_key_status(os.environ.get('MCP_API_KEY', ''))})")
     parts += [
         "",
         "  -- Odoo connection --",
@@ -314,9 +299,7 @@ def _print_startup_banner(transport: str, host: str, port: int) -> None:
         f"  Verify SSL    : {odoo_ssl}",
     ]
     if ssl_disabled:
-        parts.append(
-            "  WARNING       : SSL verification is DISABLED -- vulnerable to MITM"
-        )
+        parts.append("  WARNING       : SSL verification is DISABLED -- vulnerable to MITM")
     parts += [
         "",
         "  -- Safety layer --",
@@ -358,9 +341,7 @@ def main():
 
         # daemon=True so the timer never blocks Python shutdown if mcp.run()
         # exits early (fast STDIO disconnect, --help, misconfiguration, ...).
-        timer = threading.Timer(
-            0.4, _print_startup_banner, args=(transport, host, port)
-        )
+        timer = threading.Timer(0.4, _print_startup_banner, args=(transport, host, port))
         timer.daemon = True
         timer.start()
 
@@ -384,15 +365,11 @@ def main():
                 problems.append(f"registry not found: {users_db_path}")
             if not (db_path.parent / ".token_salt").is_file():
                 problems.append(f"salt file not found: {db_path.parent / '.token_salt'}")
-            if not (
-                os.environ.get("TOKEN_ENCRYPTION_KEY")
-                or os.environ.get("TOKEN_ENCRYPTION_KEY_FILE")
-            ):
+            if not (os.environ.get("TOKEN_ENCRYPTION_KEY") or os.environ.get("TOKEN_ENCRYPTION_KEY_FILE")):
                 problems.append("TOKEN_ENCRYPTION_KEY(_FILE) is not set")
             if problems:
                 print(
-                    "ERROR: multi-user registry misconfigured:\n  - "
-                    + "\n  - ".join(problems),
+                    "ERROR: multi-user registry misconfigured:\n  - " + "\n  - ".join(problems),
                     file=sys.stderr,
                 )
                 sys.exit(1)

--- a/src/odoo_mcp/app.py
+++ b/src/odoo_mcp/app.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 # ----- Icon Loading -----
 
+
 def _load_icon() -> Optional[Icon]:
     """Load the Odoo icon from assets as a data URI."""
     icon_path = Path(__file__).parent / "assets" / "odoo_icon.svg"
@@ -43,9 +44,11 @@ ODOO_ICON = _load_icon()
 
 # ----- Application Lifespan -----
 
+
 @dataclass
 class AppContext:
     """Application context for the MCP server"""
+
     odoo: Optional[OdooClient]
 
 
@@ -61,9 +64,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
         odoo_client: Optional[OdooClient] = get_odoo_client()
     except (FileNotFoundError, KeyError) as e:
         if os.environ.get("USERS_DB_PATH"):
-            logger.warning(
-                "No env Odoo credentials (%s) — multi-user registry mode only", e
-            )
+            logger.warning("No env Odoo credentials (%s) — multi-user registry mode only", e)
             odoo_client = None
         else:
             raise
@@ -74,6 +75,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 
 
 # ----- Authentication -----
+
 
 def _get_auth_provider():
     """Get the auth provider.
@@ -89,10 +91,12 @@ def _get_auth_provider():
     users_db = get_users_db()
     if users_db is not None:
         from .auth_verifier import DbTokenVerifier
+
         return DbTokenVerifier(users_db, static_api_key=api_key)
 
     if api_key:
         from fastmcp.server.auth import StaticTokenVerifier
+
         return StaticTokenVerifier(
             tokens={
                 api_key: {
@@ -120,12 +124,14 @@ mcp = FastMCP(
 
 # ----- Per-user skill visibility (multi-user mode only) -----
 
+
 def _register_skill_visibility() -> None:
     from .users_db import get_users_db
 
     users_db = get_users_db()
     if users_db is not None:
         from .skill_visibility import SkillVisibilityMiddleware
+
         mcp.add_middleware(SkillVisibilityMiddleware(users_db))
 
 

--- a/src/odoo_mcp/constants.py
+++ b/src/odoo_mcp/constants.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 # ----- Module Knowledge Base -----
 
+
 def load_module_knowledge() -> Dict[str, Any]:
     """Load the module knowledge base from JSON file."""
     knowledge_path = Path(__file__).parent / "module_knowledge.json"
@@ -78,8 +79,8 @@ def _merge_context(explicit_context: Optional[Dict] = None) -> Optional[Dict]:
 
 # ----- Input Validation -----
 
-_MODEL_RE = re.compile(r'^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$')
-_METHOD_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+_MODEL_RE = re.compile(r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$")
+_METHOD_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 
 def _validate_model(model: str) -> Optional[str]:
@@ -124,30 +125,53 @@ MODEL_STATE_MACHINES: Dict[str, Dict[str, Any]] = {
         "states": ["draft", "sent", "sale", "done", "cancel"],
         "transitions": [
             {"from": "draft", "to": "sent", "method": "action_quotation_sent", "label": "Mark as Sent"},
-            {"from": "draft", "to": "sale", "method": "action_confirm", "label": "Confirm Order",
-             "side_effects": ["Creates delivery orders (stock.picking)", "Reserves stock"],
-             "irreversible": False},
-            {"from": "sent", "to": "sale", "method": "action_confirm", "label": "Confirm Order",
-             "side_effects": ["Creates delivery orders (stock.picking)", "Reserves stock"],
-             "irreversible": False},
-            {"from": "sale", "to": "done", "method": "action_lock", "label": "Lock Order",
-             "irreversible": False},
-            {"from": ["draft", "sent", "sale"], "to": "cancel", "method": "action_cancel", "label": "Cancel",
-             "irreversible": False},
+            {
+                "from": "draft",
+                "to": "sale",
+                "method": "action_confirm",
+                "label": "Confirm Order",
+                "side_effects": ["Creates delivery orders (stock.picking)", "Reserves stock"],
+                "irreversible": False,
+            },
+            {
+                "from": "sent",
+                "to": "sale",
+                "method": "action_confirm",
+                "label": "Confirm Order",
+                "side_effects": ["Creates delivery orders (stock.picking)", "Reserves stock"],
+                "irreversible": False,
+            },
+            {"from": "sale", "to": "done", "method": "action_lock", "label": "Lock Order", "irreversible": False},
+            {
+                "from": ["draft", "sent", "sale"],
+                "to": "cancel",
+                "method": "action_cancel",
+                "label": "Cancel",
+                "irreversible": False,
+            },
         ],
     },
     "account.move": {
         "state_field": "state",
         "states": ["draft", "posted", "cancel"],
         "transitions": [
-            {"from": "draft", "to": "posted", "method": "action_post", "label": "Post/Validate",
-             "side_effects": ["Creates journal entries", "Updates account balances", "Assigns sequence number"],
-             "irreversible": True},
-            {"from": "posted", "to": "draft", "method": "button_draft", "label": "Reset to Draft",
-             "side_effects": ["Removes sequence assignment"],
-             "irreversible": False},
-            {"from": "posted", "to": "cancel", "method": "button_cancel", "label": "Cancel",
-             "irreversible": False},
+            {
+                "from": "draft",
+                "to": "posted",
+                "method": "action_post",
+                "label": "Post/Validate",
+                "side_effects": ["Creates journal entries", "Updates account balances", "Assigns sequence number"],
+                "irreversible": True,
+            },
+            {
+                "from": "posted",
+                "to": "draft",
+                "method": "button_draft",
+                "label": "Reset to Draft",
+                "side_effects": ["Removes sequence assignment"],
+                "irreversible": False,
+            },
+            {"from": "posted", "to": "cancel", "method": "button_cancel", "label": "Cancel", "irreversible": False},
         ],
     },
     "crm.lead": {
@@ -155,59 +179,105 @@ MODEL_STATE_MACHINES: Dict[str, Dict[str, Any]] = {
         "note": "CRM uses type (lead/opportunity) + stage_id, not a simple state field",
         "stages": "Dynamic - read crm.stage for available stages",
         "transitions": [
-            {"from": "lead", "to": "opportunity", "method": "convert_opportunity", "label": "Convert to Opportunity",
-             "side_effects": ["May create/link partner"],
-             "irreversible": False},
-            {"from": "opportunity", "to": "won", "method": "action_set_won", "label": "Mark Won",
-             "side_effects": ["Updates probability to 100%"],
-             "irreversible": False},
-            {"from": "opportunity", "to": "lost", "method": "action_set_lost", "label": "Mark Lost",
-             "side_effects": ["Archives the lead"],
-             "irreversible": False},
+            {
+                "from": "lead",
+                "to": "opportunity",
+                "method": "convert_opportunity",
+                "label": "Convert to Opportunity",
+                "side_effects": ["May create/link partner"],
+                "irreversible": False,
+            },
+            {
+                "from": "opportunity",
+                "to": "won",
+                "method": "action_set_won",
+                "label": "Mark Won",
+                "side_effects": ["Updates probability to 100%"],
+                "irreversible": False,
+            },
+            {
+                "from": "opportunity",
+                "to": "lost",
+                "method": "action_set_lost",
+                "label": "Mark Lost",
+                "side_effects": ["Archives the lead"],
+                "irreversible": False,
+            },
         ],
     },
     "stock.picking": {
         "state_field": "state",
         "states": ["draft", "waiting", "confirmed", "assigned", "done", "cancel"],
         "transitions": [
-            {"from": "draft", "to": "confirmed", "method": "action_confirm", "label": "Confirm",
-             "irreversible": False},
-            {"from": ["confirmed", "waiting"], "to": "assigned", "method": "action_assign", "label": "Check Availability",
-             "side_effects": ["Reserves stock quantities"],
-             "irreversible": False},
-            {"from": "assigned", "to": "done", "method": "button_validate", "label": "Validate",
-             "side_effects": ["Updates stock levels", "Creates stock moves"],
-             "irreversible": True},
-            {"from": ["draft", "confirmed", "assigned"], "to": "cancel", "method": "action_cancel", "label": "Cancel",
-             "irreversible": False},
+            {"from": "draft", "to": "confirmed", "method": "action_confirm", "label": "Confirm", "irreversible": False},
+            {
+                "from": ["confirmed", "waiting"],
+                "to": "assigned",
+                "method": "action_assign",
+                "label": "Check Availability",
+                "side_effects": ["Reserves stock quantities"],
+                "irreversible": False,
+            },
+            {
+                "from": "assigned",
+                "to": "done",
+                "method": "button_validate",
+                "label": "Validate",
+                "side_effects": ["Updates stock levels", "Creates stock moves"],
+                "irreversible": True,
+            },
+            {
+                "from": ["draft", "confirmed", "assigned"],
+                "to": "cancel",
+                "method": "action_cancel",
+                "label": "Cancel",
+                "irreversible": False,
+            },
         ],
     },
     "purchase.order": {
         "state_field": "state",
         "states": ["draft", "sent", "purchase", "done", "cancel"],
         "transitions": [
-            {"from": "draft", "to": "sent", "method": "action_rfq_send", "label": "Send RFQ",
-             "irreversible": False},
-            {"from": ["draft", "sent"], "to": "purchase", "method": "button_confirm", "label": "Confirm Order",
-             "side_effects": ["Creates incoming receipt (stock.picking)"],
-             "irreversible": False},
-            {"from": "purchase", "to": "done", "method": "button_lock", "label": "Lock",
-             "irreversible": False},
-            {"from": ["draft", "sent", "purchase"], "to": "cancel", "method": "button_cancel", "label": "Cancel",
-             "irreversible": False},
+            {"from": "draft", "to": "sent", "method": "action_rfq_send", "label": "Send RFQ", "irreversible": False},
+            {
+                "from": ["draft", "sent"],
+                "to": "purchase",
+                "method": "button_confirm",
+                "label": "Confirm Order",
+                "side_effects": ["Creates incoming receipt (stock.picking)"],
+                "irreversible": False,
+            },
+            {"from": "purchase", "to": "done", "method": "button_lock", "label": "Lock", "irreversible": False},
+            {
+                "from": ["draft", "sent", "purchase"],
+                "to": "cancel",
+                "method": "button_cancel",
+                "label": "Cancel",
+                "irreversible": False,
+            },
         ],
     },
     "hr.leave": {
         "state_field": "state",
         "states": ["draft", "confirm", "validate1", "validate", "refuse"],
         "transitions": [
-            {"from": "draft", "to": "confirm", "method": "action_confirm", "label": "Confirm",
-             "irreversible": False},
-            {"from": "confirm", "to": "validate", "method": "action_approve", "label": "Approve",
-             "side_effects": ["Deducts leave allocation"],
-             "irreversible": False},
-            {"from": ["confirm", "validate"], "to": "refuse", "method": "action_refuse", "label": "Refuse",
-             "irreversible": False},
+            {"from": "draft", "to": "confirm", "method": "action_confirm", "label": "Confirm", "irreversible": False},
+            {
+                "from": "confirm",
+                "to": "validate",
+                "method": "action_approve",
+                "label": "Approve",
+                "side_effects": ["Deducts leave allocation"],
+                "irreversible": False,
+            },
+            {
+                "from": ["confirm", "validate"],
+                "to": "refuse",
+                "method": "action_refuse",
+                "label": "Refuse",
+                "irreversible": False,
+            },
         ],
     },
 }
@@ -227,8 +297,8 @@ ERROR_CATEGORIES = {
             "Reduce limit parameter",
             "Simplify domain (remove complex joins)",
             "Use read_group for aggregation instead",
-            "Add database indexes on filtered fields"
-        ]
+            "Add database indexes on filtered fields",
+        ],
     },
     "relational_filter": {
         "patterns": ["relation", "join", "does not exist", "invalid field"],
@@ -236,8 +306,8 @@ ERROR_CATEGORIES = {
         "solutions": [
             "Avoid dot notation in domain (e.g., partner_id.name)",
             "Query related model separately and use 'in' operator",
-            "Use search+read fallback (automatic)"
-        ]
+            "Use search+read fallback (automatic)",
+        ],
     },
     "computed_field": {
         "patterns": ["compute", "depends", "_compute_", "stored=false"],
@@ -245,8 +315,8 @@ ERROR_CATEGORIES = {
         "solutions": [
             "Exclude computed fields from 'fields' parameter",
             "Use stored computed fields only",
-            "Fetch computed fields in separate read() call"
-        ]
+            "Fetch computed fields in separate read() call",
+        ],
     },
     "access_rights": {
         "patterns": ["access", "permission", "denied", "not allowed", "security"],
@@ -254,8 +324,8 @@ ERROR_CATEGORIES = {
         "solutions": [
             "Check user access rights on model",
             "Verify record rules allow access",
-            "Use fields the user has permission to read"
-        ]
+            "Use fields the user has permission to read",
+        ],
     },
     "memory": {
         "patterns": ["memory", "out of memory", "oom", "killed"],
@@ -263,8 +333,8 @@ ERROR_CATEGORIES = {
         "solutions": [
             "Reduce limit significantly",
             "Paginate with smaller batches",
-            "Remove large fields (binary, text) from fields list"
-        ]
+            "Remove large fields (binary, text) from fields list",
+        ],
     },
     "data_integrity": {
         "patterns": ["integrity", "constraint", "null", "foreign key", "duplicate"],
@@ -272,8 +342,8 @@ ERROR_CATEGORIES = {
         "solutions": [
             "Check for orphaned records",
             "Verify foreign key references exist",
-            "Contact database administrator"
-        ]
+            "Contact database administrator",
+        ],
     },
     "unknown": {
         "patterns": [],
@@ -281,9 +351,9 @@ ERROR_CATEGORIES = {
         "solutions": [
             "Check Odoo server logs for details",
             "Try with simpler parameters",
-            "Use search+read fallback (automatic)"
-        ]
-    }
+            "Use search+read fallback (automatic)",
+        ],
+    },
 }
 
 # ----- /doc-bearer/ Live Documentation Cache -----
@@ -305,39 +375,32 @@ CONCEPT_ALIASES: Dict[str, List[str]] = {
     "vendor": ["res.partner"],
     "supplier": ["res.partner"],
     "company": ["res.partner", "res.company"],
-
     # Sales
     "quote": ["sale.order"],
     "quotation": ["sale.order"],
     "sales order": ["sale.order"],
     "order": ["sale.order", "purchase.order"],
-
     # Accounting
     "invoice": ["account.move"],
     "bill": ["account.move"],
     "payment": ["account.payment"],
     "journal": ["account.journal"],
-
     # Products
     "product": ["product.product", "product.template"],
     "item": ["product.product"],
     "article": ["knowledge.article", "product.product"],
-
     # HR
     "employee": ["hr.employee"],
     "department": ["hr.department"],
     "leave": ["hr.leave"],
     "expense": ["hr.expense"],
-
     # Project
     "task": ["project.task"],
     "project": ["project.project"],
-
     # CRM
     "lead": ["crm.lead"],
     "opportunity": ["crm.lead"],
     "pipeline": ["crm.lead"],
-
     # Stock
     "stock": ["stock.quant", "stock.move"],
     "inventory": ["stock.quant"],
@@ -345,18 +408,15 @@ CONCEPT_ALIASES: Dict[str, List[str]] = {
     "delivery": ["stock.picking"],
     "shipment": ["stock.picking"],
     "transfer": ["stock.picking"],
-
     # Communication
     "message": ["mail.message"],
     "channel": ["discuss.channel"],
     "chat": ["discuss.channel"],
     "note": ["mail.message"],
-
     # Documents
     "document": ["documents.document", "ir.attachment"],
     "attachment": ["ir.attachment"],
     "file": ["ir.attachment"],
-
     # Users & Access
     "user": ["res.users"],
     "group": ["res.groups"],
@@ -391,7 +451,6 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "method": "_create_invoices",
         "params": {"order_ids": "list of int"},
     },
-
     # Accounting Operations
     "post_invoice": {
         "description": "Post/validate a draft invoice",
@@ -407,7 +466,11 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
     "get_overdue_invoices": {
         "description": "Find invoices past due date",
         "model": "account.move",
-        "domain_template": [["move_type", "=", "out_invoice"], ["payment_state", "in", ["not_paid", "partial"]], ["invoice_date_due", "<", "{today}"]],
+        "domain_template": [
+            ["move_type", "=", "out_invoice"],
+            ["payment_state", "in", ["not_paid", "partial"]],
+            ["invoice_date_due", "<", "{today}"],
+        ],
     },
     "get_ar_aging": {
         "description": "Get accounts receivable aging report",
@@ -416,7 +479,6 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "groupby": ["partner_id"],
         "fields": ["amount_residual:sum"],
     },
-
     # CRM Operations
     "create_lead": {
         "description": "Create a new CRM lead",
@@ -433,7 +495,6 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "model": "crm.lead",
         "method": "action_set_won",
     },
-
     # Stock Operations
     "check_stock_levels": {
         "description": "Check current stock quantities",
@@ -447,14 +508,12 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "model": "stock.picking",
         "method": "button_validate",
     },
-
     # HR Operations
     "create_employee": {
         "description": "Create a new employee record",
         "model": "hr.employee",
         "params": {"name": "str", "department_id": "int", "job_title": "str"},
     },
-
     # Communication
     "send_message": {
         "description": "Post a message on a record (chatter)",
@@ -464,7 +523,7 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
             "res_id": "int (target record ID)",
             "body": "html (message content)",
             "message_type": "str REQUIRED: 'comment'|'notification'|'email'",
-            "subtype_id": "int (1=visible to followers, 2=internal note)"
+            "subtype_id": "int (1=visible to followers, 2=internal note)",
         },
         "note": "Create mail.message directly. message_type is REQUIRED!",
         "example": {
@@ -472,8 +531,8 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
             "res_id": 123,
             "body": "<p>Hello!</p>",
             "message_type": "comment",
-            "subtype_id": 1
-        }
+            "subtype_id": 1,
+        },
     },
     "create_channel": {
         "description": "Create a discuss channel",

--- a/src/odoo_mcp/models.py
+++ b/src/odoo_mcp/models.py
@@ -11,9 +11,14 @@ from .safety import SafetyClassification
 
 class IssueAnalysis(BaseModel):
     """Analysis of issues encountered during execution."""
-    category: str = Field(description="Error category: timeout, relational_filter, computed_field, access_rights, memory, data_integrity, unknown")
+
+    category: str = Field(
+        description="Error category: timeout, relational_filter, computed_field, access_rights, memory, data_integrity, unknown"
+    )
     cause: str = Field(description="Human-readable cause description")
-    domain_patterns: List[str] = Field(default_factory=list, description="Detected patterns in domain that may cause issues")
+    domain_patterns: List[str] = Field(
+        default_factory=list, description="Detected patterns in domain that may cause issues"
+    )
     problematic_fields: List[str] = Field(default_factory=list, description="Fields that may cause issues")
     suggested_solutions: List[str] = Field(default_factory=list, description="Suggested solutions for the issue")
     model_specific_advice: List[str] = Field(default_factory=list, description="Model-specific recommendations")
@@ -21,6 +26,7 @@ class IssueAnalysis(BaseModel):
 
 class ExecuteMethodResponse(BaseModel):
     """Response model for execute_method tool with structured output."""
+
     success: bool = Field(description="Whether the execution was successful")
     result: Optional[Any] = Field(default=None, description="Result of the method call")
     error: Optional[str] = Field(default=None, description="Error message if failed")
@@ -30,12 +36,15 @@ class ExecuteMethodResponse(BaseModel):
     issue_analysis: Optional[IssueAnalysis] = Field(default=None, description="Issue analysis when fallback was used")
     note: Optional[str] = Field(default=None, description="Additional note about the execution")
     execution_time_ms: Optional[float] = Field(default=None, description="Execution time in milliseconds")
-    pending_confirmation: bool = Field(default=False, description="Whether the operation requires confirmation before execution")
+    pending_confirmation: bool = Field(
+        default=False, description="Whether the operation requires confirmation before execution"
+    )
     safety: Optional[SafetyClassification] = Field(default=None, description="Safety classification of the operation")
 
 
 class BatchOperationResult(BaseModel):
     """Result of a single batch operation."""
+
     operation_index: int = Field(description="Index of the operation in the batch")
     success: bool = Field(description="Whether this operation succeeded")
     result: Optional[Any] = Field(default=None, description="Result if successful")
@@ -44,6 +53,7 @@ class BatchOperationResult(BaseModel):
 
 class BatchExecuteResponse(BaseModel):
     """Response model for batch_execute tool with structured output."""
+
     success: bool = Field(description="Whether all operations succeeded")
     results: List[BatchOperationResult] = Field(description="Results for each operation")
     total_operations: int = Field(description="Total operations attempted")
@@ -51,13 +61,18 @@ class BatchExecuteResponse(BaseModel):
     failed_operations: int = Field(description="Failed operations count")
     error: Optional[str] = Field(default=None, description="Overall error message if any operation failed")
     execution_time_ms: Optional[float] = Field(default=None, description="Total execution time in milliseconds")
-    pending_confirmation: bool = Field(default=False, description="Whether the batch requires confirmation before execution")
-    safety_preview: Optional[List[SafetyClassification]] = Field(default=None, description="Safety classifications for each operation")
+    pending_confirmation: bool = Field(
+        default=False, description="Whether the batch requires confirmation before execution"
+    )
+    safety_preview: Optional[List[SafetyClassification]] = Field(
+        default=None, description="Safety classifications for each operation"
+    )
     overall_risk: Optional[str] = Field(default=None, description="Overall risk level across all operations")
 
 
 class WorkflowStepResult(BaseModel):
     """Result of a single workflow step."""
+
     step: str = Field(description="Name of the workflow step")
     success: bool = Field(description="Whether this step succeeded")
     skipped: bool = Field(default=False, description="Whether this step was skipped")
@@ -68,16 +83,23 @@ class WorkflowStepResult(BaseModel):
 
 class ExecuteWorkflowResponse(BaseModel):
     """Response model for execute_workflow tool with structured output."""
+
     workflow: str = Field(description="Name of the executed workflow")
     success: bool = Field(description="Whether the workflow completed successfully")
     steps: List[WorkflowStepResult] = Field(default_factory=list, description="Results for each workflow step")
     error: Optional[str] = Field(default=None, description="Error message if failed")
-    available_workflows: Optional[List[str]] = Field(default=None, description="Available workflows if unknown workflow requested")
+    available_workflows: Optional[List[str]] = Field(
+        default=None, description="Available workflows if unknown workflow requested"
+    )
     tip: Optional[str] = Field(default=None, description="Helpful tip for using workflows")
     # Additional result fields for specific workflows
     invoice_id: Optional[int] = Field(default=None, description="Created invoice ID (for invoice workflows)")
     invoice_ids: Optional[List[int]] = Field(default=None, description="Created invoice IDs (for order workflows)")
     execution_time_ms: Optional[float] = Field(default=None, description="Total execution time in milliseconds")
-    pending_confirmation: bool = Field(default=False, description="Whether the workflow requires confirmation before execution")
-    safety_preview: Optional[List[SafetyClassification]] = Field(default=None, description="Safety classifications for each workflow step")
+    pending_confirmation: bool = Field(
+        default=False, description="Whether the workflow requires confirmation before execution"
+    )
+    safety_preview: Optional[List[SafetyClassification]] = Field(
+        default=None, description="Safety classifications for each workflow step"
+    )
     overall_risk: Optional[str] = Field(default=None, description="Overall risk level across all workflow steps")

--- a/src/odoo_mcp/prompts.py
+++ b/src/odoo_mcp/prompts.py
@@ -5,9 +5,9 @@ All 12 @mcp.prompt decorated functions. Importing this module
 registers all prompts with the FastMCP instance.
 """
 
-from .app import mcp
 from fastmcp.prompts import Message
 
+from .app import mcp
 
 # ----- Discovery & Reference Prompts -----
 

--- a/src/odoo_mcp/resources.py
+++ b/src/odoo_mcp/resources.py
@@ -13,14 +13,14 @@ from typing import Any, Dict, List
 
 from .app import mcp
 from .constants import (
+    _DEFAULT_BOOTSTRAP_MODELS,
+    _RUNTIME_ISSUES_LOCK,
     CONCEPT_ALIASES,
     ERROR_CATEGORIES,
     MODEL_STATE_MACHINES,
     MODULE_KNOWLEDGE,
     RUNTIME_MODEL_ISSUES,
     TOOL_REGISTRY,
-    _DEFAULT_BOOTSTRAP_MODELS,
-    _RUNTIME_ISSUES_LOCK,
     _validate_model,
 )
 from .odoo_client import get_odoo_client
@@ -32,7 +32,6 @@ from .utils import (
     _get_module_knowledge_by_name,
     _strip_html,
 )
-
 
 # ----- Internal helpers -----
 
@@ -117,22 +116,22 @@ def get_model_schema(model_name: str) -> str:
         }
 
         for field_name, field_def in fields.items():
-            field_type = field_def.get('type', '')
+            field_type = field_def.get("type", "")
 
-            if field_type in ['many2one', 'one2many', 'many2many']:
-                schema['relationships'][field_name] = {
-                    'type': field_type,
-                    'relation': field_def.get('relation', ''),
-                    'string': field_def.get('string', '')
+            if field_type in ["many2one", "one2many", "many2many"]:
+                schema["relationships"][field_name] = {
+                    "type": field_type,
+                    "relation": field_def.get("relation", ""),
+                    "string": field_def.get("string", ""),
                 }
 
-            if field_def.get('required'):
-                schema['required_fields'].append(field_name)
+            if field_def.get("required"):
+                schema["required_fields"].append(field_name)
 
-            if field_type == 'selection' and field_def.get('selection'):
-                schema['selection_fields'][field_name] = {
-                    'label': field_def.get('string'),
-                    'values': field_def.get('selection'),
+            if field_type == "selection" and field_def.get("selection"):
+                schema["selection_fields"][field_name] = {
+                    "label": field_def.get("string"),
+                    "values": field_def.get("selection"),
                 }
 
         return json.dumps(schema, indent=2)
@@ -230,10 +229,7 @@ def get_model_workflow(model_name: str) -> str:
             state_meta = fields["state"]
             if state_meta.get("type") == "selection" and state_meta.get("selection"):
                 result["state_field"] = "state"
-                result["states"] = [
-                    {"value": val, "label": label}
-                    for val, label in state_meta["selection"]
-                ]
+                result["states"] = [{"value": val, "label": label} for val, label in state_meta["selection"]]
 
         # Check live doc for action/button methods
         live_doc = _get_live_doc(model_name)
@@ -253,10 +249,12 @@ def get_model_workflow(model_name: str) -> str:
             if module_info.get("model") == model_name:
                 for method_name, method_info in module_info.get("special_methods", {}).items():
                     if method_name.startswith(("action_", "button_")):
-                        result["available_methods"].append({
-                            "name": method_name,
-                            "description": method_info.get("description", ""),
-                        })
+                        result["available_methods"].append(
+                            {
+                                "name": method_name,
+                                "description": method_info.get("description", ""),
+                            }
+                        )
 
         if not result["state_field"] and not result["available_methods"]:
             result["note"] = f"No state machine detected for {model_name}. It may not have workflow transitions."
@@ -362,7 +360,7 @@ def get_record(model_name: str, record_id: str) -> str:
     """Get a specific record by ID"""
     odoo_client = get_odoo_client()
     try:
-        if not record_id or record_id == 'None':
+        if not record_id or record_id == "None":
             return json.dumps({"error": "Record ID is required"}, indent=2)
 
         record = odoo_client.read_records(model_name, [int(record_id)])
@@ -381,25 +379,71 @@ def get_methods(model_name: str) -> str:
     """Get available methods for a model, including special methods from knowledge base"""
     common_methods = {
         "read_methods": [
-            {"name": "search", "description": "Search for record IDs", "params": ["domain", "offset", "limit", "order"]},
-            {"name": "search_read", "description": "Search and read in one call", "params": ["domain", "fields", "offset", "limit", "order", "load"]},
-            {"name": "read", "description": "Read specific records by ID", "params": ["ids", "fields", "load"], "note": "load='_classic_read' (default) returns Many2one as (id, name); load=None returns raw ID for better performance"},
+            {
+                "name": "search",
+                "description": "Search for record IDs",
+                "params": ["domain", "offset", "limit", "order"],
+            },
+            {
+                "name": "search_read",
+                "description": "Search and read in one call",
+                "params": ["domain", "fields", "offset", "limit", "order", "load"],
+            },
+            {
+                "name": "read",
+                "description": "Read specific records by ID",
+                "params": ["ids", "fields", "load"],
+                "note": "load='_classic_read' (default) returns Many2one as (id, name); load=None returns raw ID for better performance",
+            },
             {"name": "search_count", "description": "Count matching records", "params": ["domain"]},
-            {"name": "read_group", "description": "Aggregation with grouping (deprecated in v19, use formatted_read_group)", "params": ["domain", "fields", "groupby", "offset", "limit", "orderby", "lazy"], "note": "Deprecated in v19. Use formatted_read_group instead. Still works for backward compatibility."},
-            {"name": "formatted_read_group", "description": "Aggregation with grouping (v19+ replacement for read_group)", "params": ["domain", "groupby", "aggregates", "having", "offset", "limit", "order"], "note": "Uses 'aggregates' param with 'field:agg' format (e.g. 'amount_total:sum', '__count'). Replaces deprecated read_group."},
+            {
+                "name": "read_group",
+                "description": "Aggregation with grouping (deprecated in v19, use formatted_read_group)",
+                "params": ["domain", "fields", "groupby", "offset", "limit", "orderby", "lazy"],
+                "note": "Deprecated in v19. Use formatted_read_group instead. Still works for backward compatibility.",
+            },
+            {
+                "name": "formatted_read_group",
+                "description": "Aggregation with grouping (v19+ replacement for read_group)",
+                "params": ["domain", "groupby", "aggregates", "having", "offset", "limit", "order"],
+                "note": "Uses 'aggregates' param with 'field:agg' format (e.g. 'amount_total:sum', '__count'). Replaces deprecated read_group.",
+            },
         ],
         "write_methods": [
-            {"name": "create", "description": "Create new record(s)", "params": ["vals_list"], "note": "Pass list of dicts for batch creation"},
+            {
+                "name": "create",
+                "description": "Create new record(s)",
+                "params": ["vals_list"],
+                "note": "Pass list of dicts for batch creation",
+            },
             {"name": "write", "description": "Update existing record(s)", "params": ["ids", "vals"]},
             {"name": "unlink", "description": "Delete record(s)", "params": ["ids"]},
             {"name": "copy", "description": "Duplicate a record", "params": ["id", "default"]},
         ],
         "introspection_methods": [
-            {"name": "fields_get", "description": "Get field definitions and metadata", "params": ["allfields", "attributes"]},
+            {
+                "name": "fields_get",
+                "description": "Get field definitions and metadata",
+                "params": ["allfields", "attributes"],
+            },
             {"name": "default_get", "description": "Get default values for fields", "params": ["fields_list"]},
-            {"name": "name_search", "description": "Search by name (autocomplete)", "params": ["name", "domain", "operator", "limit"]},
-            {"name": "check_access_rights", "description": "Check user permissions (legacy, still works)", "params": ["operation", "raise_exception"], "note": "Still works but has_access is preferred in v19+."},
-            {"name": "has_access", "description": "Check if user has access (returns boolean)", "params": ["operation"], "note": "Preferred over check_access_rights in v19+. Returns True/False without raising exceptions."},
+            {
+                "name": "name_search",
+                "description": "Search by name (autocomplete)",
+                "params": ["name", "domain", "operator", "limit"],
+            },
+            {
+                "name": "check_access_rights",
+                "description": "Check user permissions (legacy, still works)",
+                "params": ["operation", "raise_exception"],
+                "note": "Still works but has_access is preferred in v19+.",
+            },
+            {
+                "name": "has_access",
+                "description": "Check if user has access (returns boolean)",
+                "params": ["operation"],
+                "note": "Preferred over check_access_rights in v19+. Returns True/False without raising exceptions.",
+            },
         ],
         "special_methods": [],
         "warnings": [],
@@ -411,13 +455,15 @@ def get_methods(model_name: str) -> str:
         if module_info.get("model") == model_name:
             special_methods = module_info.get("special_methods", {})
             for method_name, method_info in special_methods.items():
-                common_methods["special_methods"].append({
-                    "name": method_name,
-                    "description": method_info.get("description", ""),
-                    "params": method_info.get("params", {}),
-                    "instead_of": method_info.get("instead_of"),
-                    "requires_ids": method_info.get("requires_ids", False)
-                })
+                common_methods["special_methods"].append(
+                    {
+                        "name": method_name,
+                        "description": method_info.get("description", ""),
+                        "params": method_info.get("params", {}),
+                        "instead_of": method_info.get("instead_of"),
+                        "requires_ids": method_info.get("requires_ids", False),
+                    }
+                )
 
             # Add warnings if any
             if module_info.get("notes"):
@@ -455,9 +501,7 @@ def get_methods(model_name: str) -> str:
                     if live.get("module"):
                         method_entry["module"] = live["module"]
                     if live.get("raise"):
-                        method_entry["exceptions"] = {
-                            k: _strip_html(v) for k, v in live["raise"].items()
-                        }
+                        method_entry["exceptions"] = {k: _strip_html(v) for k, v in live["raise"].items()}
                     # Enrich params with types and defaults from live data
                     if live.get("parameters"):
                         param_details = {}
@@ -491,9 +535,7 @@ def get_methods(model_name: str) -> str:
                 if live.get("module"):
                     entry["module"] = live["module"]
                 if live.get("raise"):
-                    entry["exceptions"] = {
-                        k: _strip_html(v) for k, v in live["raise"].items()
-                    }
+                    entry["exceptions"] = {k: _strip_html(v) for k, v in live["raise"].items()}
                 if live.get("parameters"):
                     entry["params"] = list(live["parameters"].keys())
                 additional.append(entry)
@@ -529,10 +571,7 @@ def get_model_docs(model_name: str) -> str:
 
         # 1. Get model info (display name, description)
         model_info = odoo_client.search_read(
-            "ir.model",
-            [["model", "=", model_name]],
-            fields=["name", "info", "modules"],
-            limit=1
+            "ir.model", [["model", "=", model_name]], fields=["name", "info", "modules"], limit=1
         )
         if model_info:
             result["model_info"] = {
@@ -546,7 +585,7 @@ def get_model_docs(model_name: str) -> str:
             "ir.model.fields",
             [["model", "=", model_name]],
             fields=["name", "field_description", "help", "ttype", "relation", "required"],
-            limit=200
+            limit=200,
         )
         for f in fields_meta:
             result["fields"][f["name"]] = {
@@ -565,7 +604,7 @@ def get_model_docs(model_name: str) -> str:
                     "ir.model.fields.selection",
                     [["field_id.model", "=", model_name], ["field_id.name", "=", field_name]],
                     fields=["value", "name", "sequence"],
-                    limit=50
+                    limit=50,
                 )
                 if selections:
                     result["selection_options"][field_name] = [
@@ -575,20 +614,14 @@ def get_model_docs(model_name: str) -> str:
 
         # 4. Get action help text (contextual documentation)
         actions = odoo_client.search_read(
-            "ir.actions.act_window",
-            [["res_model", "=", model_name]],
-            fields=["name", "help"],
-            limit=10
+            "ir.actions.act_window", [["res_model", "=", model_name]], fields=["name", "help"], limit=10
         )
         for action in actions:
             if action.get("help"):
                 # Strip HTML tags for cleaner output
-                help_text = re.sub(r'<[^>]+>', ' ', action.get("help", ""))
-                help_text = ' '.join(help_text.split())  # Normalize whitespace
-                result["actions_help"].append({
-                    "action_name": action.get("name"),
-                    "help": help_text
-                })
+                help_text = re.sub(r"<[^>]+>", " ", action.get("help", ""))
+                help_text = " ".join(help_text.split())  # Normalize whitespace
+                result["actions_help"].append({"action_name": action.get("name"), "help": help_text})
 
         return json.dumps(result, indent=2)
 
@@ -602,11 +635,14 @@ def get_model_docs(model_name: str) -> str:
 )
 def get_concept_mappings() -> str:
     """Get all known concept-to-model mappings for natural language model discovery."""
-    return json.dumps({
-        "description": "Business concept to Odoo model mappings",
-        "usage": "Use odoo://find-model/{concept} resource to search, or look up concepts here",
-        "mappings": CONCEPT_ALIASES
-    }, indent=2)
+    return json.dumps(
+        {
+            "description": "Business concept to Odoo model mappings",
+            "usage": "Use odoo://find-model/{concept} resource to search, or look up concepts here",
+            "mappings": CONCEPT_ALIASES,
+        },
+        indent=2,
+    )
 
 
 @mcp.resource(
@@ -625,66 +661,66 @@ def get_resource_templates() -> str:
         "templates": {
             "odoo://model/{model_name}/quick-schema": {
                 "description": "Ultra-compact schema: short keys (t/req/ro/rel). ~60-80% smaller than /fields.",
-                "example": "odoo://model/res.partner/quick-schema"
+                "example": "odoo://model/res.partner/quick-schema",
             },
             "odoo://model/{model_name}/workflow": {
                 "description": "State machine: transitions, methods, side effects, irreversibility",
-                "example": "odoo://model/sale.order/workflow"
+                "example": "odoo://model/sale.order/workflow",
             },
             "odoo://bundle/{models_csv}": {
                 "description": "Batch quick-schema for multiple models (comma-separated, max 10)",
-                "example": "odoo://bundle/res.partner,sale.order,stock.picking"
+                "example": "odoo://bundle/res.partner,sale.order,stock.picking",
             },
             "odoo://session-bootstrap": {
                 "description": "Bootstrap a conversation: quick-schemas + workflows for common models",
-                "example": "odoo://session-bootstrap"
+                "example": "odoo://session-bootstrap",
             },
             "odoo://model/{model_name}": {
                 "description": "Get information about a specific model including fields",
-                "example": "odoo://model/res.partner"
+                "example": "odoo://model/res.partner",
             },
             "odoo://model/{model_name}/schema": {
                 "description": "Complete schema for a model including fields, relationships, required fields",
-                "example": "odoo://model/sale.order/schema"
+                "example": "odoo://model/sale.order/schema",
             },
             "odoo://model/{model_name}/fields": {
                 "description": "Lightweight field list: names, types, labels, required flag (much smaller than /schema)",
-                "example": "odoo://model/res.partner/fields"
+                "example": "odoo://model/res.partner/fields",
             },
             "odoo://model/{model_name}/docs": {
                 "description": "Rich documentation: labels, field help, selection options, action help",
-                "example": "odoo://model/account.move/docs"
+                "example": "odoo://model/account.move/docs",
             },
             "odoo://methods/{model_name}": {
                 "description": "Available methods for a model including special methods from knowledge base",
-                "example": "odoo://methods/crm.lead"
+                "example": "odoo://methods/crm.lead",
             },
             "odoo://record/{model_name}/{record_id}": {
                 "description": "Get a specific record by ID",
-                "example": "odoo://record/res.partner/1"
+                "example": "odoo://record/res.partner/1",
             },
             "odoo://find-model/{concept}": {
                 "description": "Find Odoo model from natural language concept (customer, invoice, etc.)",
-                "example": "odoo://find-model/customer"
+                "example": "odoo://find-model/customer",
             },
             "odoo://actions/{model}": {
                 "description": "Discover all available actions, workflows, and methods for a model",
-                "example": "odoo://actions/sale.order"
+                "example": "odoo://actions/sale.order",
             },
             "odoo://tools/{query}": {
                 "description": "Search available operations by keyword",
-                "example": "odoo://tools/invoice"
+                "example": "odoo://tools/invoice",
             },
             "odoo://docs/{target}": {
                 "description": "Documentation URLs and GitHub links for any model or module",
-                "example": "odoo://docs/sale"
+                "example": "odoo://docs/sale",
             },
             "odoo://module-knowledge/{module_name}": {
                 "description": "Get knowledge for a specific module (special methods, patterns)",
-                "example": "odoo://module-knowledge/knowledge"
+                "example": "odoo://module-knowledge/knowledge",
             },
         },
-        "usage": "Read any template by replacing {param} with your value using ReadMcpResourceTool"
+        "usage": "Read any template by replacing {param} with your value using ReadMcpResourceTool",
     }
     return json.dumps(templates, indent=2)
 
@@ -725,86 +761,90 @@ def get_workflows() -> str:
     odoo_client = get_odoo_client()
     try:
         modules = odoo_client.search_read(
-            'ir.module.module',
-            [('state', '=', 'installed')],
-            fields=['name', 'shortdesc', 'application'],
-            limit=500
+            "ir.module.module", [("state", "=", "installed")], fields=["name", "shortdesc", "application"], limit=500
         )
 
-        module_names = {m['name']: m.get('shortdesc', '') for m in modules}
+        module_names = {m["name"]: m.get("shortdesc", "") for m in modules}
         workflows = {}
 
-        if 'sale' in module_names:
-            workflows['sales'] = {
+        if "sale" in module_names:
+            workflows["sales"] = {
                 "module": "sale",
                 "title": "Sales Management",
-                "workflows": [{
-                    "name": "quotation_to_order",
-                    "steps": [
-                        "Create quotation (sale.order with state='draft')",
-                        "Confirm order (method: action_confirm)",
-                        "Create invoice (method: _create_invoices)"
-                    ],
-                    "model": "sale.order"
-                }]
+                "workflows": [
+                    {
+                        "name": "quotation_to_order",
+                        "steps": [
+                            "Create quotation (sale.order with state='draft')",
+                            "Confirm order (method: action_confirm)",
+                            "Create invoice (method: _create_invoices)",
+                        ],
+                        "model": "sale.order",
+                    }
+                ],
             }
 
-        if 'crm' in module_names:
-            workflows['crm'] = {
+        if "crm" in module_names:
+            workflows["crm"] = {
                 "module": "crm",
                 "title": "CRM / Leads",
-                "workflows": [{
-                    "name": "lead_to_opportunity",
-                    "steps": [
-                        "Create lead (crm.lead)",
-                        "Convert to opportunity",
-                        "Mark as won (method: action_set_won)"
-                    ],
-                    "model": "crm.lead"
-                }]
+                "workflows": [
+                    {
+                        "name": "lead_to_opportunity",
+                        "steps": [
+                            "Create lead (crm.lead)",
+                            "Convert to opportunity",
+                            "Mark as won (method: action_set_won)",
+                        ],
+                        "model": "crm.lead",
+                    }
+                ],
             }
 
-        if 'account' in module_names:
-            workflows['accounting'] = {
+        if "account" in module_names:
+            workflows["accounting"] = {
                 "module": "account",
                 "title": "Accounting",
-                "workflows": [{
-                    "name": "create_invoice",
-                    "steps": [
-                        "Create invoice (account.move)",
-                        "Post invoice (method: action_post)",
-                        "Register payment"
-                    ],
-                    "model": "account.move"
-                }]
+                "workflows": [
+                    {
+                        "name": "create_invoice",
+                        "steps": [
+                            "Create invoice (account.move)",
+                            "Post invoice (method: action_post)",
+                            "Register payment",
+                        ],
+                        "model": "account.move",
+                    }
+                ],
             }
 
         # Get server actions
         custom_automations = []
         try:
             server_actions = odoo_client.search_read(
-                'ir.actions.server',
-                [('binding_model_id', '!=', False)],
-                fields=['name', 'model_id', 'binding_model_id', 'state'],
-                limit=100
+                "ir.actions.server",
+                [("binding_model_id", "!=", False)],
+                fields=["name", "model_id", "binding_model_id", "state"],
+                limit=100,
             )
             for action in server_actions:
-                model_id = action.get('model_id')
-                model_name = model_id[1] if isinstance(model_id, (list, tuple)) else str(model_id or '')
-                custom_automations.append({
-                    "name": action.get('name'),
-                    "model": model_name,
-                    "state": action.get('state')
-                })
+                model_id = action.get("model_id")
+                model_name = model_id[1] if isinstance(model_id, (list, tuple)) else str(model_id or "")
+                custom_automations.append(
+                    {"name": action.get("name"), "model": model_name, "state": action.get("state")}
+                )
         except Exception:
             pass
 
-        return json.dumps({
-            "installed_modules": list(module_names.keys()),
-            "available_workflows": workflows,
-            "custom_automations": custom_automations,
-            "note": "Use execute_method to call workflow methods"
-        }, indent=2)
+        return json.dumps(
+            {
+                "installed_modules": list(module_names.keys()),
+                "available_workflows": workflows,
+                "custom_automations": custom_automations,
+                "note": "Use execute_method to call workflow methods",
+            },
+            indent=2,
+        )
 
     except Exception as e:
         return json.dumps({"error": str(e)}, indent=2)
@@ -819,25 +859,22 @@ def get_server_info() -> str:
     odoo_client = get_odoo_client()
     try:
         base_module = odoo_client.search_read(
-            'ir.module.module',
-            [['state', '=', 'installed'], ['name', '=', 'base']],
-            fields=['latest_version'],
-            limit=1
+            "ir.module.module", [["state", "=", "installed"], ["name", "=", "base"]], fields=["latest_version"], limit=1
         )
 
         modules = odoo_client.search_read(
-            'ir.module.module',
-            [['state', '=', 'installed']],
-            fields=['name', 'shortdesc', 'application'],
-            limit=500
+            "ir.module.module", [["state", "=", "installed"]], fields=["name", "shortdesc", "application"], limit=500
         )
 
-        return json.dumps({
-            "database": odoo_client.db,
-            "odoo_version": base_module[0].get('latest_version', 'unknown') if base_module else 'unknown',
-            "installed_modules_count": len(modules),
-            "applications": [m['name'] for m in modules if m.get('application')],
-        }, indent=2)
+        return json.dumps(
+            {
+                "database": odoo_client.db,
+                "odoo_version": base_module[0].get("latest_version", "unknown") if base_module else "unknown",
+                "installed_modules_count": len(modules),
+                "applications": [m["name"] for m in modules if m.get("application")],
+            },
+            indent=2,
+        )
     except Exception as e:
         return json.dumps({"error": str(e)}, indent=2)
 
@@ -849,11 +886,14 @@ def get_server_info() -> str:
 def get_domain_syntax() -> str:
     """Get comprehensive domain syntax documentation."""
     domain_syntax = MODULE_KNOWLEDGE.get("domain_syntax", {})
-    return json.dumps({
-        "title": "Odoo Domain Syntax Reference",
-        "usage": "Use with execute_method search/search_read/search_count in the domain parameter",
-        **domain_syntax
-    }, indent=2)
+    return json.dumps(
+        {
+            "title": "Odoo Domain Syntax Reference",
+            "usage": "Use with execute_method search/search_read/search_count in the domain parameter",
+            **domain_syntax,
+        },
+        indent=2,
+    )
 
 
 @mcp.resource(
@@ -870,25 +910,25 @@ def get_model_limitations() -> str:
         "title": "Known Model Limitations",
         "description": "Models with known issues and recommended workarounds",
         "note": "The MCP server automatically applies fallbacks, categorizes errors, and suggests solutions",
-        "error_categories": {cat: {"cause": info["cause"], "solutions": info["solutions"]}
-                           for cat, info in ERROR_CATEGORIES.items() if cat != "unknown"},
+        "error_categories": {
+            cat: {"cause": info["cause"], "solutions": info["solutions"]}
+            for cat, info in ERROR_CATEGORIES.items()
+            if cat != "unknown"
+        },
         "static_models": {},
         "runtime_detected": {},
-        "patterns_summary": {}
+        "patterns_summary": {},
     }
 
     # Add static (verified) limitations
     for model, issues in static_limitations.items():
-        result["static_models"][model] = {
-            "source": "module_knowledge.json (verified)",
-            "methods": {}
-        }
+        result["static_models"][model] = {"source": "module_knowledge.json (verified)", "methods": {}}
         for method, info in issues.items():
             result["static_models"][model]["methods"][method] = {
                 "status": info.get("status", "unknown"),
                 "workaround": info.get("workaround"),
                 "notes": info.get("notes"),
-                "verified": info.get("verified", False)
+                "verified": info.get("verified", False),
             }
 
     # Add runtime-detected limitations with full categorization
@@ -903,7 +943,7 @@ def get_model_limitations() -> str:
             "source": "runtime detection",
             "first_seen": None,
             "total_occurrences": 0,
-            "methods": {}
+            "methods": {},
         }
 
         for method, info in methods.items():
@@ -913,7 +953,7 @@ def get_model_limitations() -> str:
             method_data = {
                 "total_count": info.get("total_count", 0),
                 "last_seen": info.get("last_seen"),
-                "by_category": {}
+                "by_category": {},
             }
 
             # Process each error category
@@ -923,7 +963,7 @@ def get_model_limitations() -> str:
                     "cause": ERROR_CATEGORIES.get(category, {}).get("cause", "Unknown"),
                     "domain_patterns_detected": cat_info.get("domain_patterns", {}),
                     "solutions": cat_info.get("solutions", []),
-                    "sample_errors": cat_info.get("sample_errors", [])[:2]  # Only 2 samples
+                    "sample_errors": cat_info.get("sample_errors", [])[:2],  # Only 2 samples
                 }
 
                 # Aggregate patterns for summary
@@ -937,7 +977,7 @@ def get_model_limitations() -> str:
     result["patterns_summary"] = {
         "by_error_category": all_categories,
         "by_domain_pattern": all_domain_patterns,
-        "recommendations": []
+        "recommendations": [],
     }
 
     # Generate global recommendations based on patterns
@@ -959,9 +999,7 @@ def get_model_limitations() -> str:
         "static_models_count": len(result["static_models"]),
         "runtime_detected_count": len(result["runtime_detected"]),
         "total_models_with_issues": len(set(result["static_models"].keys()) | set(result["runtime_detected"].keys())),
-        "total_runtime_occurrences": sum(
-            m.get("total_occurrences", 0) for m in result["runtime_detected"].values()
-        )
+        "total_runtime_occurrences": sum(m.get("total_occurrences", 0) for m in result["runtime_detected"].values()),
     }
 
     return json.dumps(result, indent=2)
@@ -974,21 +1012,21 @@ def get_model_limitations() -> str:
 def get_pagination_guide() -> str:
     """Get pagination patterns for execute_method."""
     pagination = MODULE_KNOWLEDGE.get("pagination", {})
-    return json.dumps({
-        "title": "Pagination Guide for execute_method",
-        **pagination,
-        "example_with_total": {
-            "description": "Get page 2 of 50 records with total count",
-            "step1_count": {
-                "method": "search_count",
-                "kwargs_json": '{"domain": [["is_company", "=", true]]}'
+    return json.dumps(
+        {
+            "title": "Pagination Guide for execute_method",
+            **pagination,
+            "example_with_total": {
+                "description": "Get page 2 of 50 records with total count",
+                "step1_count": {"method": "search_count", "kwargs_json": '{"domain": [["is_company", "=", true]]}'},
+                "step2_fetch": {
+                    "method": "search_read",
+                    "kwargs_json": '{"domain": [["is_company", "=", true]], "fields": ["name"], "limit": 50, "offset": 50, "order": "name asc"}',
+                },
             },
-            "step2_fetch": {
-                "method": "search_read",
-                "kwargs_json": '{"domain": [["is_company", "=", true]], "fields": ["name"], "limit": 50, "offset": 50, "order": "name asc"}'
-            }
-        }
-    }, indent=2)
+        },
+        indent=2,
+    )
 
 
 @mcp.resource(
@@ -998,29 +1036,32 @@ def get_pagination_guide() -> str:
 def get_hierarchical_guide() -> str:
     """Get hierarchical query patterns."""
     hierarchical = MODULE_KNOWLEDGE.get("hierarchical_models", {})
-    return json.dumps({
-        "title": "Hierarchical Query Guide",
-        "description": "Patterns for working with parent/child tree structures in Odoo",
-        **hierarchical,
-        "execute_method_examples": {
-            "get_category_tree": {
-                "description": "Get a category and all its descendants",
-                "call": "execute_method('product.category', 'search_read', kwargs_json='{\"domain\": [[\"id\", \"child_of\", 1]], \"fields\": [\"name\", \"parent_id\", \"parent_path\"]}')"
+    return json.dumps(
+        {
+            "title": "Hierarchical Query Guide",
+            "description": "Patterns for working with parent/child tree structures in Odoo",
+            **hierarchical,
+            "execute_method_examples": {
+                "get_category_tree": {
+                    "description": "Get a category and all its descendants",
+                    "call": 'execute_method(\'product.category\', \'search_read\', kwargs_json=\'{"domain": [["id", "child_of", 1]], "fields": ["name", "parent_id", "parent_path"]}\')',
+                },
+                "get_ancestors": {
+                    "description": "Get all ancestors of a record",
+                    "call": 'execute_method(\'product.category\', \'search_read\', kwargs_json=\'{"domain": [["id", "parent_of", 10]], "fields": ["name", "parent_id"]}\')',
+                },
+                "get_root_categories": {
+                    "description": "Get top-level categories only",
+                    "call": 'execute_method(\'product.category\', \'search_read\', kwargs_json=\'{"domain": [["parent_id", "=", false]], "fields": ["name", "child_id"]}\')',
+                },
+                "get_direct_children": {
+                    "description": "Get immediate children of a parent",
+                    "call": 'execute_method(\'hr.department\', \'search_read\', kwargs_json=\'{"domain": [["parent_id", "=", 5]], "fields": ["name", "manager_id"]}\')',
+                },
             },
-            "get_ancestors": {
-                "description": "Get all ancestors of a record",
-                "call": "execute_method('product.category', 'search_read', kwargs_json='{\"domain\": [[\"id\", \"parent_of\", 10]], \"fields\": [\"name\", \"parent_id\"]}')"
-            },
-            "get_root_categories": {
-                "description": "Get top-level categories only",
-                "call": "execute_method('product.category', 'search_read', kwargs_json='{\"domain\": [[\"parent_id\", \"=\", false]], \"fields\": [\"name\", \"child_id\"]}')"
-            },
-            "get_direct_children": {
-                "description": "Get immediate children of a parent",
-                "call": "execute_method('hr.department', 'search_read', kwargs_json='{\"domain\": [[\"parent_id\", \"=\", 5]], \"fields\": [\"name\", \"manager_id\"]}')"
-            }
-        }
-    }, indent=2)
+        },
+        indent=2,
+    )
 
 
 @mcp.resource(
@@ -1030,55 +1071,58 @@ def get_hierarchical_guide() -> str:
 def get_aggregation_guide() -> str:
     """Get aggregation reference for both formatted_read_group and read_group."""
     aggregation = MODULE_KNOWLEDGE.get("aggregation", {})
-    return json.dumps({
-        "title": "Aggregation Guide",
-        "recommendation": "Use formatted_read_group for new code (v19+). read_group still works but is deprecated.",
-        **aggregation,
-        "execute_method_examples": {
-            "_note": "Examples using both methods. Prefer formatted_read_group for new code.",
-            "formatted_read_group_examples": {
-                "sales_by_customer": {
-                    "description": "Total sales amount by customer (v19+ recommended)",
-                    "call": "execute_method('sale.order', 'formatted_read_group', kwargs_json='{\"domain\": [], \"groupby\": [\"partner_id\"], \"aggregates\": [\"amount_total:sum\"]}')"
+    return json.dumps(
+        {
+            "title": "Aggregation Guide",
+            "recommendation": "Use formatted_read_group for new code (v19+). read_group still works but is deprecated.",
+            **aggregation,
+            "execute_method_examples": {
+                "_note": "Examples using both methods. Prefer formatted_read_group for new code.",
+                "formatted_read_group_examples": {
+                    "sales_by_customer": {
+                        "description": "Total sales amount by customer (v19+ recommended)",
+                        "call": 'execute_method(\'sale.order\', \'formatted_read_group\', kwargs_json=\'{"domain": [], "groupby": ["partner_id"], "aggregates": ["amount_total:sum"]}\')',
+                    },
+                    "invoices_by_month": {
+                        "description": "Invoice count grouped by month",
+                        "call": 'execute_method(\'account.move\', \'formatted_read_group\', kwargs_json=\'{"domain": [["move_type", "=", "out_invoice"]], "groupby": ["invoice_date:month"], "aggregates": ["__count"]}\')',
+                    },
+                    "products_by_category": {
+                        "description": "Product count and total value by category",
+                        "call": 'execute_method(\'product.product\', \'formatted_read_group\', kwargs_json=\'{"domain": [], "groupby": ["categ_id"], "aggregates": ["__count", "list_price:sum"]}\')',
+                    },
+                    "leads_by_stage": {
+                        "description": "Expected revenue by CRM stage",
+                        "call": 'execute_method(\'crm.lead\', \'formatted_read_group\', kwargs_json=\'{"domain": [["type", "=", "opportunity"]], "groupby": ["stage_id"], "aggregates": ["expected_revenue:sum", "__count"]}\')',
+                    },
+                    "multi_level_grouping": {
+                        "description": "Sales by customer and state",
+                        "call": 'execute_method(\'sale.order\', \'formatted_read_group\', kwargs_json=\'{"domain": [], "groupby": ["partner_id", "state"], "aggregates": ["amount_total:sum"]}\')',
+                    },
                 },
-                "invoices_by_month": {
-                    "description": "Invoice count grouped by month",
-                    "call": "execute_method('account.move', 'formatted_read_group', kwargs_json='{\"domain\": [[\"move_type\", \"=\", \"out_invoice\"]], \"groupby\": [\"invoice_date:month\"], \"aggregates\": [\"__count\"]}')"
+                "read_group_examples_legacy": {
+                    "_note": "read_group is deprecated in v19 but still works. Use formatted_read_group above for new code.",
+                    "sales_by_customer": {
+                        "description": "Total sales amount by customer (legacy)",
+                        "call": "execute_method('sale.order', 'read_group', args_json='[[]]', kwargs_json='{\"fields\": [\"amount_total:sum\"], \"groupby\": [\"partner_id\"]}')",
+                    },
+                    "invoices_by_month": {
+                        "description": "Invoice count grouped by month (legacy)",
+                        "call": 'execute_method(\'account.move\', \'read_group\', args_json=\'[[["move_type", "=", "out_invoice"]]]\', kwargs_json=\'{"fields": ["__count"], "groupby": ["invoice_date:month"]}\')',
+                    },
                 },
-                "products_by_category": {
-                    "description": "Product count and total value by category",
-                    "call": "execute_method('product.product', 'formatted_read_group', kwargs_json='{\"domain\": [], \"groupby\": [\"categ_id\"], \"aggregates\": [\"__count\", \"list_price:sum\"]}')"
-                },
-                "leads_by_stage": {
-                    "description": "Expected revenue by CRM stage",
-                    "call": "execute_method('crm.lead', 'formatted_read_group', kwargs_json='{\"domain\": [[\"type\", \"=\", \"opportunity\"]], \"groupby\": [\"stage_id\"], \"aggregates\": [\"expected_revenue:sum\", \"__count\"]}')"
-                },
-                "multi_level_grouping": {
-                    "description": "Sales by customer and state",
-                    "call": "execute_method('sale.order', 'formatted_read_group', kwargs_json='{\"domain\": [], \"groupby\": [\"partner_id\", \"state\"], \"aggregates\": [\"amount_total:sum\"]}')"
-                }
             },
-            "read_group_examples_legacy": {
-                "_note": "read_group is deprecated in v19 but still works. Use formatted_read_group above for new code.",
-                "sales_by_customer": {
-                    "description": "Total sales amount by customer (legacy)",
-                    "call": "execute_method('sale.order', 'read_group', args_json='[[]]', kwargs_json='{\"fields\": [\"amount_total:sum\"], \"groupby\": [\"partner_id\"]}')"
-                },
-                "invoices_by_month": {
-                    "description": "Invoice count grouped by month (legacy)",
-                    "call": "execute_method('account.move', 'read_group', args_json='[[[\"move_type\", \"=\", \"out_invoice\"]]]', kwargs_json='{\"fields\": [\"__count\"], \"groupby\": [\"invoice_date:month\"]}')"
-                }
-            }
+            "lazy_parameter": {
+                "applies_to": "read_group only (formatted_read_group always returns all levels)",
+                "description": "Controls grouping behavior for multiple groupby fields",
+                "default": True,
+                "lazy_true": "Groups by first field only; remaining fields lazy-loaded (multiple queries)",
+                "lazy_false": "All groupings in single query - more efficient for multi-level reports",
+                "recommendation": "Use lazy=False when grouping by 2+ fields, or switch to formatted_read_group",
+            },
         },
-        "lazy_parameter": {
-            "applies_to": "read_group only (formatted_read_group always returns all levels)",
-            "description": "Controls grouping behavior for multiple groupby fields",
-            "default": True,
-            "lazy_true": "Groups by first field only; remaining fields lazy-loaded (multiple queries)",
-            "lazy_false": "All groupings in single query - more efficient for multi-level reports",
-            "recommendation": "Use lazy=False when grouping by 2+ fields, or switch to formatted_read_group"
-        }
-    }, indent=2)
+        indent=2,
+    )
 
 
 @mcp.resource(
@@ -1126,21 +1170,15 @@ def find_model_resource(concept: str) -> str:
     # 2. Search ir.model by display name
     try:
         ir_models = odoo_client.search_read(
-            "ir.model",
-            [["name", "ilike", concept]],
-            fields=["model", "name"],
-            limit=10
+            "ir.model", [["name", "ilike", concept]], fields=["model", "name"], limit=10
         )
 
         if ir_models:
             for m in ir_models:
                 score = 90 if concept_lower == m["name"].lower() else 70
-                result["all_matches"].append({
-                    "model": m["model"],
-                    "display_name": m["name"],
-                    "score": score,
-                    "source": "ir.model"
-                })
+                result["all_matches"].append(
+                    {"model": m["model"], "display_name": m["name"], "score": score, "source": "ir.model"}
+                )
             result["all_matches"].sort(key=lambda x: x["score"], reverse=True)
             result["best_match"] = result["all_matches"][0]["model"]
             result["source"] = "ir.model"
@@ -1150,20 +1188,15 @@ def find_model_resource(concept: str) -> str:
 
     # 3. Fuzzy match
     try:
-        all_models = odoo_client.search_read(
-            "ir.model", [], fields=["model", "name"], limit=500
-        )
+        all_models = odoo_client.search_read("ir.model", [], fields=["model", "name"], limit=500)
         for m in all_models:
             model_name = m["model"].lower()
             display_name = m["name"].lower()
             if concept_lower in model_name or concept_lower in display_name:
                 score = 80 if concept_lower in model_name.split(".") else 60
-                result["all_matches"].append({
-                    "model": m["model"],
-                    "display_name": m["name"],
-                    "score": score,
-                    "source": "fuzzy"
-                })
+                result["all_matches"].append(
+                    {"model": m["model"], "display_name": m["name"], "score": score, "source": "fuzzy"}
+                )
 
         if result["all_matches"]:
             result["all_matches"].sort(key=lambda x: x["score"], reverse=True)
@@ -1191,11 +1224,7 @@ def search_tools_resource(query: str) -> str:
     for tool_name, tool_def in TOOL_REGISTRY.items():
         searchable = f"{tool_name} {tool_def.get('description', '')} {tool_def.get('model', '')}".lower()
         if query_lower in searchable:
-            matches.append({
-                "name": tool_name,
-                "type": "workflow",
-                **tool_def
-            })
+            matches.append({"name": tool_name, "type": "workflow", **tool_def})
 
     # Search module knowledge for special methods
     special_matches = []
@@ -1203,21 +1232,26 @@ def search_tools_resource(query: str) -> str:
         for method_name, method_info in module_info.get("special_methods", {}).items():
             searchable = f"{method_name} {method_info.get('description', '')} {module_info.get('model', '')}".lower()
             if query_lower in searchable:
-                special_matches.append({
-                    "name": method_name,
-                    "type": "special_method",
-                    "model": module_info.get("model"),
-                    "description": method_info.get("description"),
-                    "params": method_info.get("params", {}),
-                })
+                special_matches.append(
+                    {
+                        "name": method_name,
+                        "type": "special_method",
+                        "model": module_info.get("model"),
+                        "description": method_info.get("description"),
+                        "params": method_info.get("params", {}),
+                    }
+                )
 
-    return json.dumps({
-        "query": query,
-        "tools_found": len(matches) + len(special_matches),
-        "workflows": matches,
-        "special_methods": special_matches,
-        "usage": "Use execute_workflow() for workflows or execute_method() for special methods"
-    }, indent=2)
+    return json.dumps(
+        {
+            "query": query,
+            "tools_found": len(matches) + len(special_matches),
+            "workflows": matches,
+            "special_methods": special_matches,
+            "usage": "Use execute_workflow() for workflows or execute_method() for special methods",
+        },
+        indent=2,
+    )
 
 
 @mcp.resource(
@@ -1240,44 +1274,45 @@ def discover_actions_resource(model: str) -> str:
     # 1. Find workflows in registry for this model
     for tool_name, tool_def in TOOL_REGISTRY.items():
         if tool_def.get("model") == model:
-            result["workflows"].append({
-                "name": tool_name,
-                "description": tool_def.get("description"),
-                "params": tool_def.get("params", {}),
-                "method": tool_def.get("method"),
-            })
+            result["workflows"].append(
+                {
+                    "name": tool_name,
+                    "description": tool_def.get("description"),
+                    "params": tool_def.get("params", {}),
+                    "method": tool_def.get("method"),
+                }
+            )
 
     # 2. Check module knowledge
     for module_name, module_info in MODULE_KNOWLEDGE.get("modules", {}).items():
         if module_info.get("model") == model:
             for method_name, method_info in module_info.get("special_methods", {}).items():
-                result["special_methods"].append({
-                    "name": method_name,
-                    "description": method_info.get("description"),
-                    "params": method_info.get("params", {}),
-                    "replaces": method_info.get("instead_of"),
-                })
+                result["special_methods"].append(
+                    {
+                        "name": method_name,
+                        "description": method_info.get("description"),
+                        "params": method_info.get("params", {}),
+                        "replaces": method_info.get("instead_of"),
+                    }
+                )
                 if method_info.get("instead_of"):
                     result["warnings"] = result.get("warnings", [])
-                    result["warnings"].append(
-                        f"Use {method_name}() instead of {method_info['instead_of']}()"
-                    )
+                    result["warnings"].append(f"Use {method_name}() instead of {method_info['instead_of']}()")
             if module_info.get("notes"):
                 result["notes"] = module_info["notes"]
 
     # 3. Get server actions from Odoo
     try:
         actions = odoo_client.search_read(
-            'ir.actions.server',
-            [('model_id.model', '=', model)],
-            fields=['name', 'state'],
-            limit=20
+            "ir.actions.server", [("model_id.model", "=", model)], fields=["name", "state"], limit=20
         )
         for action in actions:
-            result["server_actions"].append({
-                "name": action.get('name'),
-                "type": action.get('state'),
-            })
+            result["server_actions"].append(
+                {
+                    "name": action.get("name"),
+                    "type": action.get("state"),
+                }
+            )
     except Exception:
         pass
 
@@ -1285,20 +1320,23 @@ def discover_actions_resource(model: str) -> str:
     result["usage_examples"] = [
         {
             "description": "Search records",
-            "code": f'execute_method("{model}", "search_read", kwargs_json=\'{{"domain": [], "limit": 10}}\')'
+            "code": f'execute_method("{model}", "search_read", kwargs_json=\'{{"domain": [], "limit": 10}}\')',
         },
         {
             "description": "Create record",
-            "code": f'execute_method("{model}", "create", args_json=\'[{{"field": "value"}}]\')'
-        }
+            "code": f'execute_method("{model}", "create", args_json=\'[{{"field": "value"}}]\')',
+        },
     ]
 
     if result["special_methods"]:
         method = result["special_methods"][0]
-        result["usage_examples"].insert(0, {
-            "description": f"Call {method['name']}",
-            "code": f'execute_method("{model}", "{method["name"]}", args_json="[[id]]")'
-        })
+        result["usage_examples"].insert(
+            0,
+            {
+                "description": f"Call {method['name']}",
+                "code": f'execute_method("{model}", "{method["name"]}", args_json="[[id]]")',
+            },
+        )
 
     return json.dumps(result, indent=2)
 
@@ -1309,15 +1347,18 @@ def discover_actions_resource(model: str) -> str:
 )
 def get_tool_registry() -> str:
     """Get the complete tool registry for code-first pattern."""
-    return json.dumps({
-        "description": "Pre-built tools and workflows for common Odoo operations",
-        "usage": "Read odoo://tools/{query} to find tools, execute_workflow(name, params) to run",
-        "tools": TOOL_REGISTRY,
-        "categories": {
-            "sales": [k for k, v in TOOL_REGISTRY.items() if "sale" in v.get("model", "")],
-            "accounting": [k for k, v in TOOL_REGISTRY.items() if "account" in v.get("model", "")],
-            "crm": [k for k, v in TOOL_REGISTRY.items() if "crm" in v.get("model", "")],
-            "stock": [k for k, v in TOOL_REGISTRY.items() if "stock" in v.get("model", "")],
-            "hr": [k for k, v in TOOL_REGISTRY.items() if "hr" in v.get("model", "")],
-        }
-    }, indent=2)
+    return json.dumps(
+        {
+            "description": "Pre-built tools and workflows for common Odoo operations",
+            "usage": "Read odoo://tools/{query} to find tools, execute_workflow(name, params) to run",
+            "tools": TOOL_REGISTRY,
+            "categories": {
+                "sales": [k for k, v in TOOL_REGISTRY.items() if "sale" in v.get("model", "")],
+                "accounting": [k for k, v in TOOL_REGISTRY.items() if "account" in v.get("model", "")],
+                "crm": [k for k, v in TOOL_REGISTRY.items() if "crm" in v.get("model", "")],
+                "stock": [k for k, v in TOOL_REGISTRY.items() if "stock" in v.get("model", "")],
+                "hr": [k for k, v in TOOL_REGISTRY.items() if "hr" in v.get("model", "")],
+            },
+        },
+        indent=2,
+    )

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -23,118 +23,142 @@ logger = logging.getLogger(__name__)
 
 # ----- Risk Levels -----
 
+
 class RiskLevel(str, Enum):
     """Risk classification for Odoo operations."""
-    SAFE = "safe"           # Execute immediately, no confirmation
-    MEDIUM = "medium"       # Gate based on mode/volume
-    HIGH = "high"           # Always require confirmation
-    BLOCKED = "blocked"     # Always refuse
+
+    SAFE = "safe"  # Execute immediately, no confirmation
+    MEDIUM = "medium"  # Gate based on mode/volume
+    HIGH = "high"  # Always require confirmation
+    BLOCKED = "blocked"  # Always refuse
 
 
 # ----- Method Classification Sets -----
 
-SAFE_METHODS = frozenset({
-    "search_read", "read", "search", "search_count",
-    "fields_get", "name_get", "name_search", "default_get",
-    "read_group", "formatted_read_group",
-    "has_access", "check_access_rights", "export_data",
-})
+SAFE_METHODS = frozenset(
+    {
+        "search_read",
+        "read",
+        "search",
+        "search_count",
+        "fields_get",
+        "name_get",
+        "name_search",
+        "default_get",
+        "read_group",
+        "formatted_read_group",
+        "has_access",
+        "check_access_rights",
+        "export_data",
+    }
+)
 
-MEDIUM_METHODS = frozenset({
-    "create", "write", "copy", "name_create", "load",
-})
+MEDIUM_METHODS = frozenset(
+    {
+        "create",
+        "write",
+        "copy",
+        "name_create",
+        "load",
+    }
+)
 
-HIGH_METHODS = frozenset({
-    "unlink",
-    "action_confirm", "action_cancel", "action_done",
-    "action_draft", "action_validate", "action_post",
-    "action_assign", "action_set_won", "action_set_lost",
-    "button_confirm", "button_cancel", "button_draft",
-    "button_validate",
-})
+HIGH_METHODS = frozenset(
+    {
+        "unlink",
+        "action_confirm",
+        "action_cancel",
+        "action_done",
+        "action_draft",
+        "action_validate",
+        "action_post",
+        "action_assign",
+        "action_set_won",
+        "action_set_lost",
+        "button_confirm",
+        "button_cancel",
+        "button_draft",
+        "button_validate",
+    }
+)
 
 
 # ----- Model Classifications -----
 
-BLOCKED_MODELS = frozenset({
-    "ir.rule",
-    "ir.model.access",
-    "ir.module.module",
-    "ir.config_parameter",
-    "ir.model",
-    "res.users",
-    "res.groups",
-    # Odoo 19.1+ exposes programmatic API-key management via JSON-2
-    # (res.users.apikeys.generate / .revoke). A distinct model name from
-    # res.users, so it must be listed explicitly — otherwise an agent could
-    # mint a persistent, unscoped API key that outlives the MCP session
-    # (privilege escalation / backdoor). No legitimate agent flow needs it.
-    "res.users.apikeys",
-})
+BLOCKED_MODELS = frozenset(
+    {
+        "ir.rule",
+        "ir.model.access",
+        "ir.module.module",
+        "ir.config_parameter",
+        "ir.model",
+        "res.users",
+        "res.groups",
+        # Odoo 19.1+ exposes programmatic API-key management via JSON-2
+        # (res.users.apikeys.generate / .revoke). A distinct model name from
+        # res.users, so it must be listed explicitly — otherwise an agent could
+        # mint a persistent, unscoped API key that outlives the MCP session
+        # (privilege escalation / backdoor). No legitimate agent flow needs it.
+        "res.users.apikeys",
+    }
+)
 
-SENSITIVE_MODELS = frozenset({
-    "account.move",
-    "account.payment",
-    "account.bank.statement",
-    "hr.payslip",
-    "ir.cron",
-    # Studio-style schema customization: creating/editing custom fields is
-    # allowed but always requires explicit confirmation (token gate), in both
-    # strict and permissive modes. Whole-model changes (ir.model) stay BLOCKED.
-    "ir.model.fields",
-})
+SENSITIVE_MODELS = frozenset(
+    {
+        "account.move",
+        "account.payment",
+        "account.bank.statement",
+        "hr.payslip",
+        "ir.cron",
+        # Studio-style schema customization: creating/editing custom fields is
+        # allowed but always requires explicit confirmation (token gate), in both
+        # strict and permissive modes. Whole-model changes (ir.model) stay BLOCKED.
+        "ir.model.fields",
+    }
+)
 
 
 # ----- Cascade Warnings -----
 
 CASCADE_WARNINGS: dict[tuple[str, str], str] = {
     ("sale.order", "action_confirm"): (
-        "Confirming a sales order creates delivery orders and "
-        "may trigger procurement rules."
+        "Confirming a sales order creates delivery orders and " "may trigger procurement rules."
     ),
     ("account.move", "action_post"): (
         "Posting a journal entry creates accounting entries. "
         "This is generally irreversible without a reversal entry."
     ),
     ("stock.picking", "button_validate"): (
-        "Validating a transfer updates stock levels and creates "
-        "stock valuation entries."
+        "Validating a transfer updates stock levels and creates " "stock valuation entries."
     ),
     ("purchase.order", "button_confirm"): (
-        "Confirming a purchase order creates incoming receipts "
-        "and may trigger supplier notifications."
+        "Confirming a purchase order creates incoming receipts " "and may trigger supplier notifications."
     ),
     ("account.payment", "action_post"): (
-        "Posting a payment creates journal entries and triggers "
-        "automatic reconciliation."
+        "Posting a payment creates journal entries and triggers " "automatic reconciliation."
     ),
 }
 
 
 # ----- Pydantic Models -----
 
+
 class SafetyClassification(BaseModel):
     """Result of classifying an operation's risk level."""
+
     risk_level: RiskLevel = Field(description="Classified risk level")
     model: str = Field(description="Odoo model name")
     method: str = Field(description="Method name")
-    record_count: int | None = Field(
-        default=None, description="Estimated number of records affected"
-    )
-    requires_confirmation: bool = Field(
-        description="Whether the caller must re-call with confirmed=true"
-    )
+    record_count: int | None = Field(default=None, description="Estimated number of records affected")
+    requires_confirmation: bool = Field(description="Whether the caller must re-call with confirmed=true")
     reason: str = Field(description="Human-readable reason for the classification")
-    cascade_warning: str | None = Field(
-        default=None, description="Warning about side effects"
-    )
-    blocked_reason: str | None = Field(
-        default=None, description="Reason when operation is blocked"
-    )
+    cascade_warning: str | None = Field(default=None, description="Warning about side effects")
+    blocked_reason: str | None = Field(default=None, description="Reason when operation is blocked")
 
 
 class WorkflowStepClassification(BaseModel):
     """Classification for a single workflow step."""
+
     step: str = Field(description="Step name")
     model: str = Field(description="Model involved")
     method: str = Field(description="Method called")
@@ -144,11 +168,10 @@ class WorkflowStepClassification(BaseModel):
 
 class WorkflowSafetyPreview(BaseModel):
     """Safety preview for a complete workflow."""
+
     pending_confirmation: bool = Field(default=True)
     workflow: str = Field(description="Workflow name")
-    steps: list[WorkflowStepClassification] = Field(
-        description="Classification for each step"
-    )
+    steps: list[WorkflowStepClassification] = Field(description="Classification for each step")
     overall_risk: RiskLevel = Field(description="Highest risk across all steps")
     message: str = Field(description="User-facing summary")
 
@@ -163,39 +186,63 @@ _RISK_ORDER: dict[RiskLevel, int] = {
 
 # ----- Helpers -----
 
+
 def _get_safety_mode() -> str:
     """Get the configured safety mode (read from env on each call)."""
     return os.environ.get("MCP_SAFETY_MODE", "strict").lower()
 
 
+# Which argument carries the payload whose size determines the record count,
+# given as (positional index, JSON-2 named form). Both spellings must be
+# consulted: the v2 API is named-args-only (see arg_mapping), so an agent can
+# express the same call either positionally in args_json or by name in
+# kwargs_json. Counting only the positional form would let a bulk operation
+# slip past the strict-mode confirmation gate by moving ids into kwargs_json.
+_COUNTED_ARG: dict[str, tuple[int, str]] = {
+    "write": (0, "ids"),
+    "unlink": (0, "ids"),
+    "copy": (0, "ids"),
+    "create": (0, "vals_list"),
+    "load": (1, "data"),
+}
+
+# action_* / button_* run on a recordset passed the same way (arg_mapping
+# routes position 0 to "ids" for them, including the generic fallback).
+_RECORD_BOUND_ARG: tuple[int, str] = (0, "ids")
+
+
+def _counted_argument(method: str, args: list, kwargs: dict) -> Any:
+    """Return the argument whose size determines the operation's record count."""
+    spec = _COUNTED_ARG.get(method)
+    if spec is None and method.startswith(("action_", "button_")):
+        spec = _RECORD_BOUND_ARG
+    if spec is None:
+        return None
+    position, name = spec
+    if position < len(args):
+        return args[position]
+    return kwargs.get(name)
+
+
 def _estimate_record_count(method: str, args: list, kwargs: dict) -> int | None:
-    """Estimate the number of records affected by an operation."""
-    try:
-        if method in ("unlink", "write"):
-            # First arg is list of IDs
-            if args and isinstance(args[0], list):
-                return len(args[0])
-        elif method == "create":
-            # First arg is vals dict or list of vals dicts
-            if args:
-                val = args[0]
-                if isinstance(val, list):
-                    return len(val)
-                return 1
-        elif method.startswith("action_") or method.startswith("button_"):
-            # First arg is list of IDs
-            if args and isinstance(args[0], list):
-                return len(args[0])
-            elif args and isinstance(args[0], int):
-                return 1
-        elif method == "copy":
-            return 1
-    except (IndexError, TypeError):
-        pass
+    """Estimate the number of records affected by an operation.
+
+    Reads the recordset from args_json or kwargs_json — both are valid ways to
+    express the same JSON-2 call, so counting only one of them would leave the
+    strict-mode batch gate bypassable by choosing the other form.
+    """
+    payload = _counted_argument(method, args, kwargs)
+    if isinstance(payload, list):
+        return len(payload)
+    # A bare id or a single vals dict is one record. bool is an int subclass,
+    # so exclude it rather than counting True as a record.
+    if isinstance(payload, (dict, int)) and not isinstance(payload, bool):
+        return 1
     return None
 
 
 # ----- Core Classification -----
+
 
 def classify_operation(
     model: str,
@@ -283,10 +330,7 @@ def classify_operation(
                 method=method,
                 record_count=record_count,
                 requires_confirmation=True,
-                reason=(
-                    f"'{method}' on sensitive model '{model}' "
-                    f"requires confirmation."
-                ),
+                reason=(f"'{method}' on sensitive model '{model}' " f"requires confirmation."),
                 cascade_warning=cascade_warning,
             )
 
@@ -333,6 +377,7 @@ def classify_operation(
 
 
 # ----- Batch Classification -----
+
 
 def classify_batch(
     operations: list[dict[str, Any]],
@@ -439,10 +484,7 @@ def classify_workflow(
             overall_risk = classification.risk_level
 
     # Build human-readable message
-    high_steps = [
-        s for s in step_classifications
-        if s.risk_level in (RiskLevel.HIGH, RiskLevel.BLOCKED)
-    ]
+    high_steps = [s for s in step_classifications if s.risk_level in (RiskLevel.HIGH, RiskLevel.BLOCKED)]
     warnings = [s.cascade_warning for s in step_classifications if s.cascade_warning]
 
     message_parts = [
@@ -450,9 +492,7 @@ def classify_workflow(
         f"with overall risk level: {overall_risk.value}."
     ]
     if high_steps:
-        message_parts.append(
-            f"High-risk steps: {', '.join(s.step for s in high_steps)}."
-        )
+        message_parts.append(f"High-risk steps: {', '.join(s.step for s in high_steps)}.")
     if warnings:
         message_parts.append("Side effects: " + " | ".join(warnings))
 
@@ -465,6 +505,7 @@ def classify_workflow(
 
 
 # ----- Audit Logger -----
+
 
 def _is_audit_enabled() -> bool:
     """Check if audit logging is enabled (read from env on each call)."""

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -846,18 +846,20 @@ async def configure_odoo(ctx: Context) -> Dict[str, Any]:
 @mcp.tool(
     description="""Execute a multi-step workflow in a single call with progress tracking.
 
-    This is the KEY TOOL for Code-First Pattern - combines multiple
-    operations into one call, dramatically reducing tokens.
+    Combines several operations into one call, which costs far fewer tokens than
+    driving the same steps with individual execute_method calls.
 
     Supported workflows:
-    - lead_to_won: Create lead -> Convert to opportunity -> Mark won
-    - create_and_post_invoice: Create invoice -> Post it
-    - stock_transfer: Create transfer -> Confirm -> Validate
+    - lead_to_won (aliases: crm_workflow, opportunity_won)
+      Convert a lead to an opportunity -> mark it won. Requires lead_id.
+    - create_and_post_invoice (alias: quick_invoice)
+      Create a customer invoice -> post it. Requires partner_id and invoice_lines.
 
-    Or describe a custom workflow in natural language.
+    Any other name returns "Unknown workflow" with the list above — describe the
+    steps you need with execute_method or batch_execute instead.
 
-    SAFETY: Workflows with dangerous steps return pending_confirmation=true.
-    Add confirmed=true to proceed after reviewing the safety preview.
+    SAFETY: Workflows with dangerous steps return pending_confirmation=true with a
+    single-use confirmation_token. Re-call with confirmed=true AND that token.
     """,
     annotations={
         "title": "Execute Workflow",

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -26,15 +26,15 @@ logger = logging.getLogger(__name__)
 from fastmcp import Context
 from fastmcp.dependencies import Progress
 
-from .app import ODOO_ICON, mcp  # noqa: F401 -- mcp import triggers FastMCP setup
-from . import resources as _resources  # noqa: F401 -- import triggers resource registration
 from . import prompts as _prompts  # noqa: F401 -- import triggers prompt registration
+from . import resources as _resources  # noqa: F401 -- import triggers resource registration
 from . import skill_prompts as _skill_prompts  # noqa: F401 -- import triggers skill prompt registration
+from .app import ODOO_ICON, mcp  # noqa: F401 -- mcp import triggers FastMCP setup
 from .constants import (
+    _READ_RESOURCE_MAX_CHARS,
     DEFAULT_LIMIT,
     MAX_LIMIT,
     PRIVATE_METHOD_HINTS,
-    _READ_RESOURCE_MAX_CHARS,
     _merge_context,
     _validate_method,
     _validate_model,
@@ -47,7 +47,6 @@ from .models import (
     IssueAnalysis,
     WorkflowStepResult,
 )
-from .user_clients import current_role  # noqa: E402
 from .odoo_client import get_odoo_client
 from .safety import (
     BLOCKED_MODELS,
@@ -58,12 +57,12 @@ from .safety import (
     classify_operation,
     classify_workflow,
 )
+from .user_clients import current_role  # noqa: E402
 from .utils import (
     _get_live_doc,
     _track_model_issue,
     get_error_suggestion,
 )
-
 
 # ----- Confirmation Token Store -----
 # Stateful nonces that tie a confirmed=True re-call to the original safety classification
@@ -100,9 +99,7 @@ def _issue_confirmation_token(model: str, method: str, payload_digest: str) -> s
     return token
 
 
-def _validate_confirmation_token(
-    token: str | None, model: str, method: str, payload_digest: str
-) -> str | None:
+def _validate_confirmation_token(token: str | None, model: str, method: str, payload_digest: str) -> str | None:
     """Validate and consume a confirmation token. Returns error message or None if valid."""
     if not token:
         return "confirmed=true requires a confirmation_token from the safety gate response."
@@ -148,7 +145,7 @@ _tool_icons = [ODOO_ICON] if ODOO_ICON else None
 
     Common patterns:
     - search_read: kwargs_json='{"domain": [...], "fields": [...], "limit": 100}'
-    - create: kwargs_json='{"values": {"field": "value"}}'
+    - create: kwargs_json='{"vals_list": [{"field": "value"}]}'
     - write: args_json='[[ids], {"field": "value"}]'
     - unlink: args_json='[[ids]]'
     - formatted_read_group (v19): kwargs_json='{"domain": [...], "groupby": ["field"], "aggregates": ["field:sum"]}'
@@ -191,7 +188,7 @@ _tool_icons = [ODOO_ICON] if ODOO_ICON else None
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
-        "openWorldHint": True
+        "openWorldHint": True,
     },
     icons=_tool_icons,
 )
@@ -305,9 +302,7 @@ def execute_method(
                         error=f"resolve_json['{field_name}']: model '{target_model}' is blocked for safety.",
                     )
                 try:
-                    matches = odoo.execute_method(
-                        target_model, "name_search", name=search_term, limit=5
-                    )
+                    matches = odoo.execute_method(target_model, "name_search", name=search_term, limit=5)
                     if not matches:
                         elapsed_ms = (time.time() - start_time) * 1000
                         return ExecuteMethodResponse(
@@ -322,7 +317,9 @@ def execute_method(
                         return ExecuteMethodResponse(
                             success=False,
                             error=f"resolve_json: Ambiguous match for '{search_term}' in {target_model} ({len(matches)} results)",
-                            hint="Multiple matches found:\n" + "\n".join(options) + "\nUse the numeric ID directly instead.",
+                            hint="Multiple matches found:\n"
+                            + "\n".join(options)
+                            + "\nUse the numeric ID directly instead.",
                             execution_time_ms=round(elapsed_ms, 2),
                         )
                     resolved_values[field_name] = matches[0][0]  # Use the ID
@@ -418,15 +415,15 @@ def execute_method(
             audit_log(classification, confirmed=confirmed, executed=True)
 
         # Apply smart limits for search methods
-        if method in ["search", "search_read"] and 'limit' not in kwargs:
-            kwargs['limit'] = DEFAULT_LIMIT
+        if method in ["search", "search_read"] and "limit" not in kwargs:
+            kwargs["limit"] = DEFAULT_LIMIT
             logger.debug("Applied default limit=%d", DEFAULT_LIMIT)
-        elif method in ["search", "search_read"] and kwargs.get('limit', 0) > MAX_LIMIT:
-            kwargs['limit'] = MAX_LIMIT
+        elif method in ["search", "search_read"] and kwargs.get("limit", 0) > MAX_LIMIT:
+            kwargs["limit"] = MAX_LIMIT
             logger.debug("Capped limit to %d", MAX_LIMIT)
 
         # Normalize domain if needed
-        if method in ['search', 'search_read', 'search_count'] and args:
+        if method in ["search", "search_read", "search_count"] and args:
             domain = args[0]
             # Handle double-wrapped domains [[domain]]
             if isinstance(domain, list) and len(domain) == 1 and isinstance(domain[0], list):
@@ -530,7 +527,7 @@ def execute_method(
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
-        "openWorldHint": True
+        "openWorldHint": True,
     },
     icons=_tool_icons,
     task=True,  # Enable background task execution with progress
@@ -631,23 +628,23 @@ async def batch_execute(
 
     try:
         for idx, op in enumerate(operations):
-            model = op.get('model', 'unknown')
-            method = op.get('method', 'unknown')
+            model = op.get("model", "unknown")
+            method = op.get("method", "unknown")
             await progress.set_message(f"Operation {idx + 1}/{len(operations)}: {model}.{method}")
 
             try:
-                if not op.get('model') or not op.get('method'):
+                if not op.get("model") or not op.get("method"):
                     raise ValueError(f"Operation {idx}: 'model' and 'method' required")
 
-                model_err = _validate_model(op['model'])
+                model_err = _validate_model(op["model"])
                 if model_err:
                     raise ValueError(f"Operation {idx}: {model_err}")
-                method_err = _validate_method(op['method'])
+                method_err = _validate_method(op["method"])
                 if method_err:
                     raise ValueError(f"Operation {idx}: {method_err}")
 
-                args_json = op.get('args_json')
-                kwargs_json = op.get('kwargs_json')
+                args_json = op.get("args_json")
+                kwargs_json = op.get("kwargs_json")
 
                 args = json.loads(args_json) if args_json else []
                 if not isinstance(args, list):
@@ -717,6 +714,7 @@ async def batch_execute(
 @dataclass
 class OdooConnectionConfig:
     """Configuration collected from user elicitation."""
+
     url: str
     database: str
     auth_method: str
@@ -738,7 +736,7 @@ class OdooConnectionConfig:
         "readOnlyHint": True,
         "destructiveHint": False,
         "idempotentHint": True,
-        "openWorldHint": False
+        "openWorldHint": False,
     },
     icons=_tool_icons,
 )
@@ -749,7 +747,7 @@ async def configure_odoo(ctx: Context) -> Dict[str, Any]:
     Returns:
         Configuration summary with environment variable instructions
     """
-    from fastmcp.server.elicitation import AcceptedElicitation, DeclinedElicitation, CancelledElicitation
+    from fastmcp.server.elicitation import AcceptedElicitation, CancelledElicitation, DeclinedElicitation
 
     results = {
         "success": False,
@@ -825,9 +823,8 @@ async def configure_odoo(ctx: Context) -> Dict[str, Any]:
             results["env_vars"]["ODOO_PASSWORD"] = "<your-password>"
             results["note"] = "Using password authentication. API keys are recommended for production."
 
-        results["instructions"] = (
-            "Set these environment variables to configure the Odoo MCP server:\n"
-            + "\n".join(f"export {k}='{v}'" for k, v in results["env_vars"].items())
+        results["instructions"] = "Set these environment variables to configure the Odoo MCP server:\n" + "\n".join(
+            f"export {k}='{v}'" for k, v in results["env_vars"].items()
         )
 
         return results
@@ -866,7 +863,7 @@ async def configure_odoo(ctx: Context) -> Dict[str, Any]:
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
-        "openWorldHint": True
+        "openWorldHint": True,
     },
     icons=_tool_icons,
     task=True,  # Enable background task execution with progress
@@ -967,10 +964,16 @@ async def execute_workflow(
             try:
                 lead = odoo.search_read("crm.lead", [["id", "=", lead_id]], fields=["type"], limit=1)
                 if lead and lead[0].get("type") == "lead":
-                    odoo.execute_method("crm.lead", "convert_opportunity", [lead_id], partner_id=params.get("partner_id", False))
+                    odoo.execute_method(
+                        "crm.lead", "convert_opportunity", [lead_id], partner_id=params.get("partner_id", False)
+                    )
                     steps.append(WorkflowStepResult(step="convert_to_opportunity", success=True))
                 else:
-                    steps.append(WorkflowStepResult(step="convert_to_opportunity", success=True, skipped=True, reason="Already an opportunity"))
+                    steps.append(
+                        WorkflowStepResult(
+                            step="convert_to_opportunity", success=True, skipped=True, reason="Already an opportunity"
+                        )
+                    )
             except Exception as e:
                 steps.append(WorkflowStepResult(step="convert_to_opportunity", success=False, error=str(e)))
             await progress.increment()
@@ -1016,12 +1019,18 @@ async def execute_workflow(
             # Build invoice lines
             invoice_lines = []
             for line in lines:
-                invoice_lines.append((0, 0, {
-                    "product_id": line.get("product_id"),
-                    "quantity": line.get("quantity", 1),
-                    "price_unit": line.get("price_unit"),
-                    "name": line.get("name", "Product"),
-                }))
+                invoice_lines.append(
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": line.get("product_id"),
+                            "quantity": line.get("quantity", 1),
+                            "price_unit": line.get("price_unit"),
+                            "name": line.get("name", "Product"),
+                        },
+                    )
+                )
 
             # Step 1: Create invoice
             await progress.set_message("Creating invoice...")
@@ -1174,25 +1183,30 @@ def read_resource(uri: str, max_chars: int = _READ_RESOURCE_MAX_CHARS) -> str:
             result = handler(**args)
             if max_chars and len(result) > max_chars:
                 truncated = result[:max_chars]
-                warning = json.dumps({
-                    "_truncated": True,
-                    "_total_chars": len(result),
-                    "_returned_chars": max_chars,
-                    "_hint": f"Output truncated from {len(result):,} to {max_chars:,} chars. "
-                             f"Use max_chars=0 for full output, or use narrower queries "
-                             f"(e.g. odoo://model/{{model}}/fields instead of /schema)."
-                })
+                warning = json.dumps(
+                    {
+                        "_truncated": True,
+                        "_total_chars": len(result),
+                        "_returned_chars": max_chars,
+                        "_hint": f"Output truncated from {len(result):,} to {max_chars:,} chars. "
+                        f"Use max_chars=0 for full output, or use narrower queries "
+                        f"(e.g. odoo://model/{{model}}/fields instead of /schema).",
+                    }
+                )
                 return truncated + "\n\n" + warning
             return result
 
-    return json.dumps({
-        "error": f"Unknown resource URI: {uri}",
-        "hint": "Use odoo://templates to list all available resource URIs",
-        "examples": [
-            "odoo://model/res.partner/schema",
-            "odoo://model/sale.order/fields",
-            "odoo://methods/res.partner",
-            "odoo://find-model/invoice",
-            "odoo://domain-syntax",
-        ]
-    }, indent=2)
+    return json.dumps(
+        {
+            "error": f"Unknown resource URI: {uri}",
+            "hint": "Use odoo://templates to list all available resource URIs",
+            "examples": [
+                "odoo://model/res.partner/schema",
+                "odoo://model/sale.order/fields",
+                "odoo://methods/res.partner",
+                "odoo://find-model/invoice",
+                "odoo://domain-syntax",
+            ],
+        },
+        indent=2,
+    )

--- a/src/odoo_mcp/skill_prompts.py
+++ b/src/odoo_mcp/skill_prompts.py
@@ -37,7 +37,7 @@ def load_skill(name: str) -> str:
     if text.startswith("---"):
         end = text.find("\n---", 3)
         if end != -1:
-            text = text[end + len("\n---"):]
+            text = text[end + len("\n---") :]
     return text.strip()
 
 
@@ -48,8 +48,7 @@ def _skill_message(skill: str, request: str) -> list[Message]:
         content += f"\n\n---\n\n**User request:** {request.strip()}"
     else:
         content += (
-            "\n\n---\n\n**User request:** (none provided — "
-            "ask the user what they need, then follow the workflow)"
+            "\n\n---\n\n**User request:** (none provided — " "ask the user what they need, then follow the workflow)"
         )
     return [Message(content)]
 

--- a/src/odoo_mcp/skill_visibility.py
+++ b/src/odoo_mcp/skill_visibility.py
@@ -51,11 +51,7 @@ class SkillVisibilityMiddleware(Middleware):
         allowed = await asyncio.to_thread(self._allowed_skills)
         if allowed is None:
             return prompts
-        return [
-            p
-            for p in prompts
-            if not p.name.startswith(CYANVIEW_PREFIX) or p.name in allowed
-        ]
+        return [p for p in prompts if not p.name.startswith(CYANVIEW_PREFIX) or p.name in allowed]
 
     async def on_get_prompt(
         self,

--- a/src/odoo_mcp/token_crypto.py
+++ b/src/odoo_mcp/token_crypto.py
@@ -32,8 +32,7 @@ def _read_encryption_password() -> str:
     if file_path and Path(file_path).is_file():
         return Path(file_path).read_text().strip()
     raise RuntimeError(
-        "TOKEN_ENCRYPTION_KEY (or TOKEN_ENCRYPTION_KEY_FILE) is required to"
-        " decrypt registry credentials."
+        "TOKEN_ENCRYPTION_KEY (or TOKEN_ENCRYPTION_KEY_FILE) is required to" " decrypt registry credentials."
     )
 
 
@@ -70,8 +69,7 @@ def decrypt_secret(encrypted: str, db_path: Path) -> dict[str, object]:
         decrypted = fernet.decrypt(encrypted.encode())
     except InvalidToken as exc:
         raise RuntimeError(
-            "TOKEN_ENCRYPTION_KEY mismatch with registry — the secret must"
-            " hold the same value as the CLORAG one."
+            "TOKEN_ENCRYPTION_KEY mismatch with registry — the secret must" " hold the same value as the CLORAG one."
         ) from exc
     result = json.loads(decrypted)
     if not isinstance(result, dict):

--- a/src/odoo_mcp/user_clients.py
+++ b/src/odoo_mcp/user_clients.py
@@ -95,8 +95,7 @@ def get_client_for_current_user() -> OdooClient | None:
             username=creds.odoo_username,
             api_key=str(secret["api_key"]),
             timeout=int(os.environ.get("ODOO_TIMEOUT", "30")),
-            verify_ssl=os.environ.get("ODOO_VERIFY_SSL", "1").lower()
-            in ("1", "true", "yes"),
+            verify_ssl=os.environ.get("ODOO_VERIFY_SSL", "1").lower() in ("1", "true", "yes"),
         )
         _cache[user_id] = _Entry(client, creds.updated_at, now)
         return client

--- a/src/odoo_mcp/users_db.py
+++ b/src/odoo_mcp/users_db.py
@@ -64,9 +64,7 @@ class UsersDb:
             ).fetchone()
         if row is None:
             return None
-        return ApiKeyIdentity(
-            user_id=row["id"], name=row["name"], email=row["email"], role=row["role"]
-        )
+        return ApiKeyIdentity(user_id=row["id"], name=row["name"], email=row["email"], role=row["role"])
 
     def get_odoo_credentials(self, user_id: str) -> OdooCredentials | None:
         with self._connect() as conn:
@@ -86,9 +84,7 @@ class UsersDb:
 
     def get_skills(self, user_id: str) -> frozenset[str]:
         with self._connect() as conn:
-            rows = conn.execute(
-                "SELECT skill_name FROM user_skills WHERE user_id = ?", (user_id,)
-            ).fetchall()
+            rows = conn.execute("SELECT skill_name FROM user_skills WHERE user_id = ?", (user_id,)).fetchall()
         return frozenset(row["skill_name"] for row in rows)
 
 

--- a/src/odoo_mcp/utils.py
+++ b/src/odoo_mcp/utils.py
@@ -19,13 +19,12 @@ from .constants import (
     _DOC_CACHE_LOCK,
     _DOC_CACHE_MAX_ENTRIES,
     _DOC_CACHE_TTL,
+    _RUNTIME_ISSUES_LOCK,
     ERROR_CATEGORIES,
     MODULE_KNOWLEDGE,
     RUNTIME_MODEL_ISSUES,
-    _RUNTIME_ISSUES_LOCK,
 )
 from .odoo_client import get_odoo_client
-
 
 # ----- Compact Schema Builder -----
 
@@ -63,8 +62,8 @@ def _strip_html(html_str: str) -> str:
     """Strip HTML tags and normalize whitespace for plain text display."""
     if not html_str:
         return ""
-    text = re.sub(r'<[^>]+>', '', html_str)
-    return ' '.join(text.split()).strip()
+    text = re.sub(r"<[^>]+>", "", html_str)
+    return " ".join(text.split()).strip()
 
 
 def _get_live_doc(model_name: str) -> Optional[Dict[str, Any]]:
@@ -117,7 +116,10 @@ def _detect_domain_pattern(domain: List, model: str = None) -> List[str]:
     domain_str = str(domain)
 
     # Detect dot notation (relational filters)
-    if "." in domain_str and any(f".{field}" in domain_str for field in ["id", "name", "code", "state", "type", "partner", "company", "user", "product", "location"]):
+    if "." in domain_str and any(
+        f".{field}" in domain_str
+        for field in ["id", "name", "code", "state", "type", "partner", "company", "user", "product", "location"]
+    ):
         patterns.append("dot_notation")
 
     # Detect complex OR conditions
@@ -140,7 +142,7 @@ def _detect_domain_pattern(domain: List, model: str = None) -> List[str]:
     if model == "stock.move.line":
         # picking_type_id with negative operators causes NotImplemented error
         if "picking_type_id" in domain_str:
-            if any(op in domain_str for op in ["'!='", "'not in'", "'not like'", "\"!=\"", "\"not in\""]):
+            if any(op in domain_str for op in ["'!='", "'not in'", "'not like'", '"!="', '"not in"']):
                 patterns.append("computed_field_negative_operator")
         # Deep related fields that cause issues
         if any(field in domain_str for field in ["product_category_name", "picking_code"]):
@@ -160,7 +162,7 @@ def _detect_problematic_fields(fields: List, model: str = None) -> List[str]:
         "stock.move.line": {
             "non_stored_computed": ["lots_visible", "allowed_uom_ids"],
             "deep_related": ["product_category_name", "picking_code"],
-            "computed_with_search": ["picking_type_id"]
+            "computed_with_search": ["picking_type_id"],
         }
     }
 
@@ -173,7 +175,9 @@ def _detect_problematic_fields(fields: List, model: str = None) -> List[str]:
     return problematic
 
 
-def _track_model_issue(model: str, method: str, error_msg: str, domain: List = None, fields: List = None) -> Dict[str, Any]:
+def _track_model_issue(
+    model: str, method: str, error_msg: str, domain: List = None, fields: List = None
+) -> Dict[str, Any]:
     """
     Track a model/method issue with error categorization and pattern detection.
     Returns analysis with suggested solutions.
@@ -188,11 +192,7 @@ def _track_model_issue(model: str, method: str, error_msg: str, domain: List = N
             RUNTIME_MODEL_ISSUES[model] = {}
 
         if method not in RUNTIME_MODEL_ISSUES[model]:
-            RUNTIME_MODEL_ISSUES[model][method] = {
-                "categories": {},
-                "first_seen": now,
-                "total_count": 0
-            }
+            RUNTIME_MODEL_ISSUES[model][method] = {"categories": {}, "first_seen": now, "total_count": 0}
 
         model_issues = RUNTIME_MODEL_ISSUES[model][method]
         model_issues["total_count"] += 1
@@ -204,7 +204,7 @@ def _track_model_issue(model: str, method: str, error_msg: str, domain: List = N
                 "count": 0,
                 "domain_patterns": {},
                 "sample_errors": [],
-                "solutions": ERROR_CATEGORIES[category]["solutions"]
+                "solutions": ERROR_CATEGORIES[category]["solutions"],
             }
 
         cat_info = model_issues["categories"][category]
@@ -261,7 +261,7 @@ def _track_model_issue(model: str, method: str, error_msg: str, domain: List = N
         "problematic_fields": problematic_fields,
         "solutions": ERROR_CATEGORIES[category]["solutions"],
         "model_specific_advice": model_specific_advice,
-        "occurrences": cat_info["count"]
+        "occurrences": cat_info["count"],
     }
 
 
@@ -331,16 +331,12 @@ def _get_module_knowledge_by_name(module_name: str) -> str:
     """Get specific module knowledge"""
     modules = MODULE_KNOWLEDGE.get("modules", {})
     if module_name in modules:
-        return json.dumps({
-            "module": module_name,
-            **modules[module_name]
-        }, indent=2)
+        return json.dumps({"module": module_name, **modules[module_name]}, indent=2)
     else:
         available = list(modules.keys())
-        return json.dumps({
-            "error": f"Module '{module_name}' not found in knowledge base",
-            "available_modules": available
-        }, indent=2)
+        return json.dumps(
+            {"error": f"Module '{module_name}' not found in knowledge base", "available_modules": available}, indent=2
+        )
 
 
 def _get_documentation_urls(target: str) -> str:
@@ -381,7 +377,7 @@ def _get_documentation_urls(target: str) -> str:
         "documentation": {},
         "github": {},
         "search_queries": [],
-        "special_methods": []
+        "special_methods": [],
     }
 
     # Get module documentation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,9 +52,9 @@ class RegistrySeed:
     def __init__(self, db_path: Path, salt: bytes):
         self.db_path = db_path
         self.salt = salt
-        self.keys: dict[str, str] = {}      # label -> full key
+        self.keys: dict[str, str] = {}  # label -> full key
         self.user_ids: dict[str, str] = {}  # label -> user id
-        self.key_ids: dict[str, str] = {}   # label -> key id
+        self.key_ids: dict[str, str] = {}  # label -> key id
 
     def add_user(self, conn, label, name, role, is_active=True):
         user_id = str(uuid.uuid4())
@@ -72,9 +72,15 @@ class RegistrySeed:
         now = datetime.now().isoformat()
         conn.execute(
             "INSERT INTO api_keys VALUES (?, ?, ?, ?, ?, ?, NULL, ?)",
-            (key_id, user_id, server,
-             hashlib.sha256(full_key.encode()).hexdigest(),
-             full_key[:12], now, now if revoked else None),
+            (
+                key_id,
+                user_id,
+                server,
+                hashlib.sha256(full_key.encode()).hexdigest(),
+                full_key[:12],
+                now,
+                now if revoked else None,
+            ),
         )
         self.keys[label] = full_key
         self.key_ids[label] = key_id
@@ -109,9 +115,12 @@ def users_db_seed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> RegistrySe
     now = datetime.now().isoformat()
     conn.execute(
         "INSERT INTO user_odoo_credentials VALUES (?, ?, ?, ?)",
-        (member_id, "thierry@cyanview.com",
-         encrypt_with_contract({"api_key": "thierry-odoo-key"}, salt, TEST_ENCRYPTION_KEY),
-         now),
+        (
+            member_id,
+            "thierry@cyanview.com",
+            encrypt_with_contract({"api_key": "thierry-odoo-key"}, salt, TEST_ENCRYPTION_KEY),
+            now,
+        ),
     )
     conn.executemany(
         "INSERT INTO user_skills VALUES (?, ?)",

--- a/tests/live/test_safety_live.py
+++ b/tests/live/test_safety_live.py
@@ -19,6 +19,7 @@ import sys
 
 # Load .env
 from dotenv import load_dotenv
+
 load_dotenv()
 
 from odoo_mcp.odoo_client import get_odoo_client
@@ -32,7 +33,7 @@ def header(msg):
 
 def result_summary(resp):
     """Extract key fields from the response model."""
-    d = resp.model_dump() if hasattr(resp, 'model_dump') else resp
+    d = resp.model_dump() if hasattr(resp, "model_dump") else resp
     out = {
         "success": d.get("success"),
         "pending_confirmation": d.get("pending_confirmation"),
@@ -42,7 +43,9 @@ def result_summary(resp):
     if d.get("safety"):
         s = d["safety"]
         out["safety.risk_level"] = s.get("risk_level") if isinstance(s, dict) else s.risk_level
-        out["safety.requires_confirmation"] = s.get("requires_confirmation") if isinstance(s, dict) else s.requires_confirmation
+        out["safety.requires_confirmation"] = (
+            s.get("requires_confirmation") if isinstance(s, dict) else s.requires_confirmation
+        )
         out["safety.cascade_warning"] = s.get("cascade_warning") if isinstance(s, dict) else s.cascade_warning
         out["safety.blocked_reason"] = s.get("blocked_reason") if isinstance(s, dict) else s.blocked_reason
     return {k: v for k, v in out.items() if v is not None}
@@ -53,8 +56,11 @@ async def run_tests():
     # Instead, test the safety module directly with real classification + a real Odoo call.
 
     from odoo_mcp.safety import (
-        classify_operation, classify_batch, classify_workflow,
-        audit_log, RiskLevel,
+        RiskLevel,
+        audit_log,
+        classify_batch,
+        classify_operation,
+        classify_workflow,
     )
 
     passed = 0
@@ -133,7 +139,7 @@ async def run_tests():
     ops = [
         {"model": "res.partner", "method": "search_read"},
         {"model": "sale.order", "method": "action_confirm", "args_json": "[[1]]"},
-        {"model": "res.partner", "method": "write", "args_json": "[[1], {\"name\": \"x\"}]"},
+        {"model": "res.partner", "method": "write", "args_json": '[[1], {"name": "x"}]'},
     ]
     classifications, overall, needs_confirm = classify_batch(ops)
     print(f"  overall_risk={overall.value}, needs_confirm={needs_confirm}")

--- a/tests/live/test_v1110_live.py
+++ b/tests/live/test_v1110_live.py
@@ -15,18 +15,19 @@ import time
 
 # Load .env
 from dotenv import load_dotenv
+
 load_dotenv()
 
-from odoo_mcp.utils import _build_compact_schema, get_error_suggestion
-from odoo_mcp.constants import _merge_context, MODEL_STATE_MACHINES
+from odoo_mcp import constants as _constants
+from odoo_mcp.constants import MODEL_STATE_MACHINES, _merge_context
+from odoo_mcp.odoo_client import get_odoo_client
 from odoo_mcp.resources import (
+    get_bundle,
     get_model_quick_schema,
     get_model_workflow,
-    get_bundle,
     get_session_bootstrap,
 )
-from odoo_mcp import constants as _constants
-from odoo_mcp.odoo_client import get_odoo_client
+from odoo_mcp.utils import _build_compact_schema, get_error_suggestion
 
 
 def header(msg):
@@ -60,7 +61,12 @@ def run_tests():
     fake_fields = {
         "name": {"type": "char", "required": True, "readonly": False},
         "partner_id": {"type": "many2one", "required": False, "readonly": False, "relation": "res.partner"},
-        "state": {"type": "selection", "required": False, "readonly": True, "selection": [("draft", "Draft"), ("done", "Done")]},
+        "state": {
+            "type": "selection",
+            "required": False,
+            "readonly": True,
+            "selection": [("draft", "Draft"), ("done", "Done")],
+        },
         "line_ids": {"type": "one2many", "required": False, "readonly": False, "relation": "sale.order.line"},
         "amount": {"type": "float", "required": False, "readonly": True},
     }
@@ -92,7 +98,10 @@ def run_tests():
     # Test with defaults
     _constants._DEFAULT_CONTEXT = {"lang": "en_US", "tz": "UTC"}
     check("defaults + no explicit = copy of defaults", _merge_context(None) == {"lang": "en_US", "tz": "UTC"})
-    check("defaults + explicit = merged (explicit wins)", _merge_context({"lang": "fr_FR"}) == {"lang": "fr_FR", "tz": "UTC"})
+    check(
+        "defaults + explicit = merged (explicit wins)",
+        _merge_context({"lang": "fr_FR"}) == {"lang": "fr_FR", "tz": "UTC"},
+    )
 
     # Restore
     _constants._DEFAULT_CONTEXT = original_default
@@ -103,14 +112,15 @@ def run_tests():
     header("TEST 3: get_error_suggestion — template substitution")
     # Many2one error (should match fallback pattern)
     suggestion = get_error_suggestion(
-        "422: ValidationError - Expected int for Many2one field",
-        model="sale.order",
-        method="create"
+        "422: ValidationError - Expected int for Many2one field", model="sale.order", method="create"
     )
     if suggestion:
         check("Many2one pattern matched", True)
-        check("{model} substituted", "sale.order" in suggestion or "many2one" in suggestion.lower(),
-              f"suggestion: {suggestion}")
+        check(
+            "{model} substituted",
+            "sale.order" in suggestion or "many2one" in suggestion.lower(),
+            f"suggestion: {suggestion}",
+        )
     else:
         check("Many2one pattern matched", False, "No suggestion returned")
 
@@ -161,8 +171,7 @@ def run_tests():
     check(f"field_count > 10 (got {field_count})", field_count > 10)
     # Check compactness
     # res.partner has ~278 fields, so compact schema is ~13KB (still 60-80% less than full /fields ~50KB)
-    check(f"response size ({len(result_str)} bytes) < 20000", len(result_str) < 20000,
-          f"got {len(result_str)} bytes")
+    check(f"response size ({len(result_str)} bytes) < 20000", len(result_str) < 20000, f"got {len(result_str)} bytes")
     check(f"response time: {elapsed:.2f}s", elapsed < 15, f"took {elapsed:.2f}s")
     # Verify a known field
     if "name" in result.get("fields", {}):
@@ -197,8 +206,11 @@ def run_tests():
     has_state = result.get("state_field") is not None
     has_methods = len(result.get("available_methods", [])) > 0
     has_note = "note" in result
-    check("either has state/methods or a note", has_state or has_methods or has_note,
-          f"state={has_state}, methods={has_methods}, note={has_note}")
+    check(
+        "either has state/methods or a note",
+        has_state or has_methods or has_note,
+        f"state={has_state}, methods={has_methods}, note={has_note}",
+    )
 
     # ================================================================
     # TEST 8: bundle resource (LIVE)
@@ -276,8 +288,11 @@ def run_tests():
     try:
         # Search for a common name that should return multiple results
         matches = odoo.execute_method("res.partner", "name_search", name="a", limit=5)
-        check("broad search returns results", isinstance(matches, list) and len(matches) > 0,
-              f"got {len(matches) if matches else 0} matches")
+        check(
+            "broad search returns results",
+            isinstance(matches, list) and len(matches) > 0,
+            f"got {len(matches) if matches else 0} matches",
+        )
         if matches and len(matches) > 1:
             check(f"multiple matches detected ({len(matches)})", len(matches) > 1)
         else:
@@ -291,7 +306,8 @@ def run_tests():
     header("TEST 13: search_read with context (LIVE)")
     try:
         result = odoo.execute_method(
-            "res.partner", "search_read",
+            "res.partner",
+            "search_read",
             domain=[["is_company", "=", True]],
             fields=["name"],
             limit=2,
@@ -311,7 +327,7 @@ def run_tests():
     s = get_error_suggestion("422: Expected singleton: res.partner(1, 2)")
     check("422 singleton pattern", s is not None)
 
-    s = get_error_suggestion("422: null value in column \"name\" violates not-null constraint")
+    s = get_error_suggestion('422: null value in column "name" violates not-null constraint')
     check("422 null value pattern", s is not None)
 
     s = get_error_suggestion("422: Invalid field 'nonexistent' on model 'res.partner'", model="res.partner")
@@ -341,6 +357,7 @@ def run_tests():
     # ================================================================
     header("TEST 15: Resource route smoke test")
     from odoo_mcp.server import _RESOURCE_ROUTES
+
     # Verify new routes are registered
     route_patterns = [r[0] if isinstance(r, tuple) else r for r in _RESOURCE_ROUTES]
     route_str = str(route_patterns)

--- a/tests/test_auth_verifier.py
+++ b/tests/test_auth_verifier.py
@@ -51,9 +51,7 @@ def test_unknown_token_rejected(users_db_seed):
 
 
 def test_static_fallback_maps_to_env_admin(users_db_seed):
-    verifier = DbTokenVerifier(
-        UsersDb(users_db_seed.db_path), static_api_key="shared-static"
-    )
+    verifier = DbTokenVerifier(UsersDb(users_db_seed.db_path), static_api_key="shared-static")
     token = _verify(verifier, "shared-static")
     assert token is not None
     assert token.client_id == ENV_ADMIN_CLIENT_ID

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -21,6 +21,7 @@ See ``docs/mcp-2026-07-28-migration.md`` before raising either bound.
 """
 
 import importlib.metadata as metadata
+import re
 import sys
 from pathlib import Path
 
@@ -35,6 +36,7 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+DOCKERFILE = Path(__file__).resolve().parent.parent / "Dockerfile"
 
 MIGRATION_DOC = "docs/mcp-2026-07-28-migration.md"
 
@@ -113,4 +115,64 @@ class TestDeclaredConstraint:
             f"pyproject.toml allows fastmcp {older}, older than the tested"
             f" baseline {installed}. Raise the floor so a fresh install gets"
             " the version this suite actually verified."
+        )
+
+
+def _dockerfile_instructions() -> str:
+    """The Dockerfile with comment lines stripped.
+
+    Comments legitimately *name* dependencies while explaining the rule, so
+    they must not be mistaken for an install instruction.
+    """
+    lines = DOCKERFILE.read_text(encoding="utf-8").splitlines()
+    return "\n".join(ln for ln in lines if not ln.lstrip().startswith("#"))
+
+
+def _pip_install_commands(instructions: str) -> list[str]:
+    """Every `pip install` invocation, with backslash continuations joined.
+
+    Joining matters: the drifted list this module guards against lived on
+    continuation lines under a single ``pip install \\``, where a per-line
+    scan would never see the package names next to the command.
+    """
+    joined = instructions.replace("\\\n", " ")
+    return [line for line in joined.splitlines() if "pip install" in line]
+
+
+class TestDockerfileUsesDeclaredDependencies:
+    """The image must inherit pyproject's constraints, not restate them.
+
+    The Dockerfile used to `pip install` a hand-copied requirement list and
+    then `pip install --no-deps .`, so pyproject's `dependencies` never applied
+    inside the image. That list had already drifted: it carried
+    `fastmcp[tasks]>=3.2.0`, silently discarding the `<4` ceiling every other
+    test in this module defends, and it omitted `cryptography>=42` entirely —
+    token_crypto imported only because Authlib, a transitive FastMCP
+    dependency, happens to pull cryptography in. Both are the same defect: a
+    second, unchecked source of truth for the dependency set.
+    """
+
+    def test_dockerfile_does_not_restate_dependency_constraints(self):
+        commands = _pip_install_commands(_dockerfile_instructions())
+        restated = [
+            req.name
+            for req in map(Requirement, _declared_dependencies())
+            if any(re.search(rf"\b{re.escape(req.name)}\b", command) for command in commands)
+        ]
+        assert not restated, (
+            f"Dockerfile pins {', '.join(restated)} itself instead of taking"
+            " them from pyproject.toml. A duplicated list drifts silently —"
+            " that is how cryptography went missing and how the fastmcp <"
+            f"{FASTMCP_MAJOR + 1} ceiling was lost. Install the project"
+            " (`pip install .`) so the declared constraints apply."
+        )
+
+    def test_dockerfile_installs_the_project_with_dependencies(self):
+        """At least one `pip install` must resolve deps from the project."""
+        commands = _pip_install_commands(_dockerfile_instructions())
+        installs_with_deps = [command for command in commands if "--no-deps" not in command]
+        assert installs_with_deps, (
+            "Dockerfile never runs a dependency-resolving `pip install`."
+            " Every install is --no-deps, so the image would ship without"
+            " fastmcp, requests, python-dotenv or cryptography."
         )

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -1,0 +1,116 @@
+"""Guard the FastMCP / MCP SDK major versions this server is written against.
+
+This repo is deliberately **not** on PyPI: the documented install path is
+``pip install git+https://github.com/AlanOgic/odoo-mcp-19.git``, which resolves
+dependencies fresh and ignores ``uv.lock``. An unbounded ``fastmcp`` requirement
+therefore drifts silently on every install — and FastMCP 4.x is not a drop-in:
+
+  - it targets MCP spec 2026-07-28 (stateless core, no server-initiated
+    requests), so ``ctx.elicit()`` in ``configure_odoo`` raises at runtime;
+  - it moves to MCP SDK v2 (``mcp>=2.0`` + the split-out ``mcp-types``), which
+    changes the ``mcp.types`` imports in ``app.py`` / ``skill_visibility.py``;
+  - the ``[tasks]`` extra becomes the separate ``fastmcp-tasks`` package and
+    task-enabled tools need an explicit ``TasksExtension``, so ``batch_execute``
+    and ``execute_workflow`` fail to register without it.
+
+Two independent assertions, because they catch different failures: the runtime
+check catches a stale or bypassed lock, the declared check catches somebody
+widening the constraint without doing the migration.
+
+See ``docs/mcp-2026-07-28-migration.md`` before raising either bound.
+"""
+
+import importlib.metadata as metadata
+import sys
+from pathlib import Path
+
+import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - only exercised on 3.10
+    tomllib = pytest.importorskip("tomli", reason="3.10 needs tomli to read pyproject")
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+MIGRATION_DOC = "docs/mcp-2026-07-28-migration.md"
+
+# Majors this codebase is written against.
+FASTMCP_MAJOR = 3
+MCP_SDK_MAJOR = 1
+
+
+def _declared_dependencies() -> list[str]:
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)["project"]["dependencies"]
+
+
+def _fastmcp_requirement() -> Requirement:
+    for raw in _declared_dependencies():
+        req = Requirement(raw)
+        if req.name == "fastmcp":
+            return req
+    raise AssertionError("pyproject.toml declares no 'fastmcp' dependency")
+
+
+class TestInstalledVersions:
+    """The environment actually in use must match the supported majors."""
+
+    def test_fastmcp_major_is_supported(self):
+        installed = Version(metadata.version("fastmcp"))
+        assert installed.major == FASTMCP_MAJOR, (
+            f"fastmcp {installed} is installed but this server targets"
+            f" {FASTMCP_MAJOR}.x. FastMCP 4.x breaks elicitation, background"
+            f" tasks, and the mcp.types imports — see {MIGRATION_DOC}."
+        )
+
+    def test_mcp_sdk_major_is_supported(self):
+        installed = Version(metadata.version("mcp"))
+        assert installed.major == MCP_SDK_MAJOR, (
+            f"mcp SDK {installed} is installed but this server targets"
+            f" {MCP_SDK_MAJOR}.x. SDK v2 moves the wire types to the mcp-types"
+            f" package and renames attributes to snake_case, which changes"
+            f" app.py and skill_visibility.py — see {MIGRATION_DOC}."
+        )
+
+    def test_tasks_extra_is_installed(self):
+        """``fastmcp[tasks]`` pulls pydocket on the 3.x line."""
+        metadata.version("pydocket")
+
+
+class TestDeclaredConstraint:
+    """pyproject.toml must keep the ceiling that makes the above true."""
+
+    def test_fastmcp_requirement_declares_tasks_extra(self):
+        req = _fastmcp_requirement()
+        assert "tasks" in req.extras, (
+            "fastmcp must be requested as fastmcp[tasks]: batch_execute and"
+            " execute_workflow are declared with task=True and will not"
+            " register without the extra."
+        )
+
+    def test_fastmcp_requirement_excludes_next_major(self):
+        req = _fastmcp_requirement()
+        next_major = Version(f"{FASTMCP_MAJOR + 1}.0.0")
+        assert not req.specifier.contains(next_major, prereleases=True), (
+            f"pyproject.toml allows fastmcp {next_major}; the declared"
+            f" constraint is {req.specifier or '(none)'}. Restore the '<"
+            f"{FASTMCP_MAJOR + 1}' bound, or complete the migration in"
+            f" {MIGRATION_DOC} first."
+        )
+
+    def test_fastmcp_floor_matches_tested_baseline(self):
+        """The floor must not fall below the version the suite is run against."""
+        req = _fastmcp_requirement()
+        installed = Version(metadata.version("fastmcp"))
+        older = Version(f"{installed.major}.{installed.minor}.0")
+        if older >= installed:  # installed is an x.y.0 release
+            older = Version(f"{installed.major}.{max(installed.minor - 1, 0)}.0")
+        assert not req.specifier.contains(older), (
+            f"pyproject.toml allows fastmcp {older}, older than the tested"
+            f" baseline {installed}. Raise the floor so a fresh install gets"
+            " the version this suite actually verified."
+        )

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -24,7 +24,6 @@ from odoo_mcp.safety import (
     classify_workflow,
 )
 
-
 # =====================================================
 # Test: SAFE methods
 # =====================================================
@@ -149,9 +148,7 @@ class TestMediumMethodsStrict:
         assert result.record_count == 1
 
     def test_batch_create_requires_confirm(self):
-        result = classify_operation(
-            "res.partner", "create", [[{"name": "a"}, {"name": "b"}]]
-        )
+        result = classify_operation("res.partner", "create", [[{"name": "a"}, {"name": "b"}]])
         assert result.risk_level == RiskLevel.MEDIUM
         assert result.requires_confirmation is True
         assert result.record_count == 2
@@ -177,9 +174,7 @@ class TestMediumMethodsPermissive:
         assert result.requires_confirmation is False
 
     def test_batch_create_no_confirm(self):
-        result = classify_operation(
-            "res.partner", "create", [[{"name": "a"}, {"name": "b"}]]
-        )
+        result = classify_operation("res.partner", "create", [[{"name": "a"}, {"name": "b"}]])
         assert result.risk_level == RiskLevel.MEDIUM
         assert result.requires_confirmation is False
 
@@ -231,7 +226,8 @@ class TestRecordCounting:
 
     def test_create_batch(self):
         result = classify_operation(
-            "res.partner", "create",
+            "res.partner",
+            "create",
             [[{"name": "a"}, {"name": "b"}, {"name": "c"}]],
         )
         assert result.record_count == 3
@@ -244,12 +240,73 @@ class TestRecordCounting:
         result = classify_operation("sale.order", "action_confirm", [1])
         assert result.record_count == 1
 
-    def test_copy_always_one(self):
+    def test_copy_single_id(self):
         result = classify_operation("res.partner", "copy", [1])
         assert result.record_count == 1
 
     def test_no_args(self):
         result = classify_operation("res.partner", "write")
+        assert result.record_count is None
+
+
+# =====================================================
+# Test: Record counting via named (kwargs) arguments
+# =====================================================
+
+
+class TestNamedArgRecordCounting:
+    """The recordset may arrive in args_json OR kwargs_json.
+
+    JSON-2 is named-args-only, so `write(ids=[1,2,3], vals={...})` and
+    `write([1,2,3], {...})` are the same call. Counting only the positional
+    form let a bulk operation slip past the strict-mode confirmation gate by
+    simply moving the ids into kwargs_json.
+    """
+
+    def test_write_ids_in_kwargs_counts(self):
+        result = classify_operation("res.partner", "write", [], {"ids": [1, 2, 3], "vals": {"name": "x"}})
+        assert result.record_count == 3
+
+    def test_write_batch_in_kwargs_requires_confirmation(self):
+        with patch.dict(os.environ, {"MCP_SAFETY_MODE": "strict"}):
+            result = classify_operation("res.partner", "write", [], {"ids": [1, 2, 3], "vals": {"name": "x"}})
+        assert result.requires_confirmation is True
+
+    def test_positional_and_named_forms_agree(self):
+        """Both spellings of the same call must classify identically."""
+        with patch.dict(os.environ, {"MCP_SAFETY_MODE": "strict"}):
+            positional = classify_operation("res.partner", "write", [[1, 2, 3], {"name": "x"}])
+            named = classify_operation("res.partner", "write", [], {"ids": [1, 2, 3], "vals": {"name": "x"}})
+        assert positional.record_count == named.record_count
+        assert positional.requires_confirmation == named.requires_confirmation
+
+    def test_create_vals_list_in_kwargs_counts(self):
+        result = classify_operation("res.partner", "create", [], {"vals_list": [{"name": "a"}, {"name": "b"}]})
+        assert result.record_count == 2
+
+    def test_action_ids_in_kwargs_counts(self):
+        result = classify_operation("sale.order", "action_confirm", [], {"ids": [1, 2, 3, 4]})
+        assert result.record_count == 4
+
+    def test_load_data_rows_count(self):
+        """`load` bulk-imports rows; its payload is the `data` argument."""
+        rows = [["1", f"name{i}"] for i in range(50)]
+        with patch.dict(os.environ, {"MCP_SAFETY_MODE": "strict"}):
+            result = classify_operation("res.partner", "load", [], {"fields": ["id", "name"], "data": rows})
+        assert result.record_count == 50
+        assert result.requires_confirmation is True
+
+    def test_copy_batch_in_kwargs_counts(self):
+        result = classify_operation("res.partner", "copy", [], {"ids": [1, 2, 3]})
+        assert result.record_count == 3
+
+    def test_positional_wins_over_named(self):
+        """A positional recordset is what arg_mapping forwards; prefer it."""
+        result = classify_operation("res.partner", "write", [[1, 2], {"name": "x"}], {"ids": [1, 2, 3, 4, 5]})
+        assert result.record_count == 2
+
+    def test_unrelated_kwargs_do_not_count(self):
+        result = classify_operation("res.partner", "search_read", [], {"domain": [], "fields": ["a", "b", "c"]})
         assert result.record_count is None
 
 

--- a/tests/test_skill_prompts.py
+++ b/tests/test_skill_prompts.py
@@ -9,8 +9,8 @@ import asyncio
 
 import pytest
 
-from odoo_mcp.skill_prompts import _SKILLS_DIR, load_skill
 from odoo_mcp.app import mcp
+from odoo_mcp.skill_prompts import _SKILLS_DIR, load_skill
 
 EXPECTED_SKILLS = [
     "quote",
@@ -70,9 +70,7 @@ def test_skill_prompts_registered():
 
 
 def test_skill_prompt_renders_with_variables():
-    result = asyncio.run(
-        mcp.render_prompt("cyanview-serial-tracker", {"serial": "CY-RIO-15-042"})
-    )
+    result = asyncio.run(mcp.render_prompt("cyanview-serial-tracker", {"serial": "CY-RIO-15-042"}))
     text = result.messages[0].content.text
     assert "CY-RIO-15-042" in text
     assert "User request:" in text

--- a/tests/test_skill_visibility.py
+++ b/tests/test_skill_visibility.py
@@ -73,9 +73,7 @@ def test_no_token_fails_closed(users_db_seed, patched_context):
 
 
 def test_member_sees_only_allowed_skills(users_db_seed, patched_context):
-    patched_context["token"] = SimpleNamespace(
-        client_id=users_db_seed.user_ids["member"], claims={"role": "support"}
-    )
+    patched_context["token"] = SimpleNamespace(client_id=users_db_seed.user_ids["member"], claims={"role": "support"})
     result = _list(_middleware(users_db_seed), "http", None)
     names = {p.name for p in result}
     assert names == {
@@ -87,25 +85,19 @@ def test_member_sees_only_allowed_skills(users_db_seed, patched_context):
 
 
 def test_admin_sees_everything(users_db_seed, patched_context):
-    patched_context["token"] = SimpleNamespace(
-        client_id=users_db_seed.user_ids["admin"], claims={"role": "admin"}
-    )
+    patched_context["token"] = SimpleNamespace(client_id=users_db_seed.user_ids["admin"], claims={"role": "admin"})
     result = _list(_middleware(users_db_seed), "http", None)
     assert len(result) == len(ALL_PROMPTS)
 
 
 def test_env_admin_sees_everything(users_db_seed, patched_context):
-    patched_context["token"] = SimpleNamespace(
-        client_id="env-admin", claims={"role": "admin"}
-    )
+    patched_context["token"] = SimpleNamespace(client_id="env-admin", claims={"role": "admin"})
     result = _list(_middleware(users_db_seed), "http", None)
     assert len(result) == len(ALL_PROMPTS)
 
 
 def test_render_forbidden_skill_raises(users_db_seed, patched_context):
-    patched_context["token"] = SimpleNamespace(
-        client_id=users_db_seed.user_ids["member"], claims={"role": "support"}
-    )
+    patched_context["token"] = SimpleNamespace(client_id=users_db_seed.user_ids["member"], claims={"role": "support"})
     mw = _middleware(users_db_seed)
 
     async def run():
@@ -120,9 +112,7 @@ def test_render_forbidden_skill_raises(users_db_seed, patched_context):
 
 
 def test_render_allowed_skill_passes(users_db_seed, patched_context):
-    patched_context["token"] = SimpleNamespace(
-        client_id=users_db_seed.user_ids["member"], claims={"role": "support"}
-    )
+    patched_context["token"] = SimpleNamespace(client_id=users_db_seed.user_ids["member"], claims={"role": "support"})
     mw = _middleware(users_db_seed)
 
     async def run():

--- a/tests/test_token_crypto.py
+++ b/tests/test_token_crypto.py
@@ -7,17 +7,13 @@ from tests.conftest import TEST_ENCRYPTION_KEY, encrypt_with_contract
 
 
 def test_decrypt_round_trip(users_db_seed):
-    encrypted = encrypt_with_contract(
-        {"api_key": "secret-123"}, users_db_seed.salt, TEST_ENCRYPTION_KEY
-    )
+    encrypted = encrypt_with_contract({"api_key": "secret-123"}, users_db_seed.salt, TEST_ENCRYPTION_KEY)
     result = decrypt_secret(encrypted, db_path=users_db_seed.db_path)
     assert result == {"api_key": "secret-123"}
 
 
 def test_decrypt_wrong_password(users_db_seed, monkeypatch):
-    encrypted = encrypt_with_contract(
-        {"api_key": "x"}, users_db_seed.salt, TEST_ENCRYPTION_KEY
-    )
+    encrypted = encrypt_with_contract({"api_key": "x"}, users_db_seed.salt, TEST_ENCRYPTION_KEY)
     monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", "wrong-password")
     _fernet.cache_clear()
     with pytest.raises(RuntimeError, match="mismatch"):
@@ -32,18 +28,14 @@ def test_decrypt_missing_salt(tmp_path, monkeypatch):
 
 
 def test_missing_key_env(users_db_seed, monkeypatch):
-    encrypted = encrypt_with_contract(
-        {"api_key": "x"}, users_db_seed.salt, TEST_ENCRYPTION_KEY
-    )
+    encrypted = encrypt_with_contract({"api_key": "x"}, users_db_seed.salt, TEST_ENCRYPTION_KEY)
     monkeypatch.delenv("TOKEN_ENCRYPTION_KEY")
     with pytest.raises(RuntimeError, match="TOKEN_ENCRYPTION_KEY"):
         decrypt_secret(encrypted, db_path=users_db_seed.db_path)
 
 
 def test_key_file_fallback(users_db_seed, tmp_path, monkeypatch):
-    encrypted = encrypt_with_contract(
-        {"api_key": "from-file"}, users_db_seed.salt, TEST_ENCRYPTION_KEY
-    )
+    encrypted = encrypt_with_contract({"api_key": "from-file"}, users_db_seed.salt, TEST_ENCRYPTION_KEY)
     key_file = tmp_path / "key_secret"
     key_file.write_text(TEST_ENCRYPTION_KEY + "\n")
     monkeypatch.delenv("TOKEN_ENCRYPTION_KEY")

--- a/tests/test_token_gate.py
+++ b/tests/test_token_gate.py
@@ -150,9 +150,7 @@ class TestTokenExpiry:
 
         # Fast-forward time past the TTL by patching time.time used in server module
         original = time.time()
-        monkeypatch.setattr(
-            server.time, "time", lambda: original + server._CONFIRMATION_TTL + 1
-        )
+        monkeypatch.setattr(server.time, "time", lambda: original + server._CONFIRMATION_TTL + 1)
 
         err = server._validate_confirmation_token(token, "res.partner", "unlink", digest)
         assert err is not None

--- a/tests/test_user_clients.py
+++ b/tests/test_user_clients.py
@@ -37,7 +37,8 @@ def test_no_token_returns_none(monkeypatch, users_db_seed):
 
 def test_env_admin_returns_none(monkeypatch, users_db_seed):
     monkeypatch.setattr(
-        user_clients, "_safe_get_access_token",
+        user_clients,
+        "_safe_get_access_token",
         lambda: _fake_token("env-admin", role="admin"),
     )
     assert user_clients.get_client_for_current_user() is None
@@ -46,9 +47,7 @@ def test_env_admin_returns_none(monkeypatch, users_db_seed):
 
 def test_registry_user_gets_personal_client(monkeypatch, users_db_seed):
     member_id = users_db_seed.user_ids["member"]
-    monkeypatch.setattr(
-        user_clients, "_safe_get_access_token", lambda: _fake_token(member_id)
-    )
+    monkeypatch.setattr(user_clients, "_safe_get_access_token", lambda: _fake_token(member_id))
     client = user_clients.get_client_for_current_user()
     assert client is not None
     assert client.username == "thierry@cyanview.com"
@@ -59,9 +58,7 @@ def test_registry_user_gets_personal_client(monkeypatch, users_db_seed):
 
 def test_client_is_cached(monkeypatch, users_db_seed):
     member_id = users_db_seed.user_ids["member"]
-    monkeypatch.setattr(
-        user_clients, "_safe_get_access_token", lambda: _fake_token(member_id)
-    )
+    monkeypatch.setattr(user_clients, "_safe_get_access_token", lambda: _fake_token(member_id))
     first = user_clients.get_client_for_current_user()
     second = user_clients.get_client_for_current_user()
     assert first is second
@@ -69,20 +66,15 @@ def test_client_is_cached(monkeypatch, users_db_seed):
 
 def test_credential_rotation_rebuilds_client(monkeypatch, users_db_seed):
     member_id = users_db_seed.user_ids["member"]
-    monkeypatch.setattr(
-        user_clients, "_safe_get_access_token", lambda: _fake_token(member_id)
-    )
+    monkeypatch.setattr(user_clients, "_safe_get_access_token", lambda: _fake_token(member_id))
     first = user_clients.get_client_for_current_user()
 
     # Rotate credentials in the registry (as CLORAG would)
     conn = sqlite3.connect(users_db_seed.db_path)
     conn.execute(
-        "UPDATE user_odoo_credentials SET encrypted_secret = ?, updated_at = ?"
-        " WHERE user_id = ?",
+        "UPDATE user_odoo_credentials SET encrypted_secret = ?, updated_at = ?" " WHERE user_id = ?",
         (
-            encrypt_with_contract(
-                {"api_key": "rotated-key"}, users_db_seed.salt, TEST_ENCRYPTION_KEY
-            ),
+            encrypt_with_contract({"api_key": "rotated-key"}, users_db_seed.salt, TEST_ENCRYPTION_KEY),
             datetime.now().isoformat() + "-rotated",
             member_id,
         ),
@@ -100,7 +92,8 @@ def test_credential_rotation_rebuilds_client(monkeypatch, users_db_seed):
 def test_missing_credentials_raises_permission_error(monkeypatch, users_db_seed):
     admin_id = users_db_seed.user_ids["admin"]  # admin has no stored credentials
     monkeypatch.setattr(
-        user_clients, "_safe_get_access_token",
+        user_clients,
+        "_safe_get_access_token",
         lambda: _fake_token(admin_id, role="admin", name="Alan Admin"),
     )
     with pytest.raises(PermissionError, match="Alan Admin"):
@@ -121,8 +114,6 @@ def test_dispatcher_prefers_user_client(monkeypatch, users_db_seed):
     import odoo_mcp.odoo_client as odoo_client_module
 
     member_id = users_db_seed.user_ids["member"]
-    monkeypatch.setattr(
-        user_clients, "_safe_get_access_token", lambda: _fake_token(member_id)
-    )
+    monkeypatch.setattr(user_clients, "_safe_get_access_token", lambda: _fake_token(member_id))
     client = odoo_client_module.get_odoo_client()
     assert client.username == "thierry@cyanview.com"


### PR DESCRIPTION
## Summary

FastMCP 4.x targets MCP spec 2026-07-28 and is not a drop-in upgrade for this server: it breaks `ctx.elicit()` in `configure_odoo`, changes the `mcp.types` imports, and splits the `[tasks]` extra (needed by `batch_execute`/`execute_workflow`) into a separate package requiring an explicit `TasksExtension`. This branch pins `fastmcp>=3.4.6,<4` and makes that bound real in every place dependencies are declared or installed.

- **chore(deps)**: bound FastMCP to `>=3.4.6,<4` in `pyproject.toml`, wrote `docs/mcp-2026-07-28-migration.md` describing what a 4.x migration entails, and added `tests/test_dependency_pins.py` so widening the bound without doing the migration fails the suite.
- **Dockerfile**: the image installed a hand-copied dependency list that had already drifted — it carried `fastmcp[tasks]>=3.2.0` (silently discarding the `<4` ceiling) and omitted `cryptography>=42` entirely (it only imported via a transitive Authlib dependency). The image now resolves dependencies from `pyproject.toml` via a stub-package install in its own cached layer; new tests fail if a restated pin reappears or every install goes `--no-deps`.
- **fix(safety)**: found during review — `_estimate_record_count` only read positional args, so a bulk `write`/`unlink` could dodge the strict-mode batch confirmation by moving `ids` into `kwargs_json` (both spellings are the same JSON-2 call). Counting now consults both forms via `_COUNTED_ARG`, positional winning since that is what `arg_mapping` forwards; `load` is newly counted. Also corrects the `create` docstring example (`vals_list`, not `values`).
- **chore: format**: repo-wide black 26.3.1 + isort pass (the committed tree predated this black version's style), kept as its own commit so the substantive diffs stay reviewable.
- **docs**: OSP writing pass over README/CHANGELOG/tool descriptions; CLAUDE.md documents the batch-counting rule and the Dockerfile no-restated-pins invariant.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/live` — 243 passed
- [x] `uv run black --check .` / `uv run isort --check-only .` — clean
- [x] `uv run ruff check` clean on touched `safety.py` / `test_dependency_pins.py` (pre-existing `server.py` warnings untouched)
- [x] `uv run mypy src/odoo_mcp` — same 75 pre-existing errors as `master`, none introduced
- [x] Restatement detector verified against a reconstruction of the old drifted Dockerfile (quoted, unquoted, and continuation-line forms all caught)
- [ ] `docker build -t odoo-mcp-19 .` — verify image builds and `pip show fastmcp` reports a 3.x version