### PR TITLE
ci: run the unit suite on every push and PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
-      # --frozen fails if uv.lock has drifted from pyproject.toml, so lock
-      # rot is caught here rather than on someone's machine.
+      # No --frozen: uv.lock is deliberately gitignored (see .gitignore:58 —
+      # the project ships via pip + pyproject.toml). Resolving fresh here is
+      # the point: it mirrors what `pip install git+...` actually gives a
+      # user, so a dependency that drifts out from under the declared bounds
+      # surfaces as a CI failure.
       - name: Install dependencies
-        run: uv sync --extra dev --frozen
+        run: uv sync --extra dev
 
       # tests/live/ is deliberately excluded: those are script-style runners
       # that need real Odoo credentials and mutate env state. Everything under
@@ -43,7 +46,7 @@ jobs:
       # purpose, so a unit test that quietly needs a live server shows up as a
       # failure instead of passing on a developer machine that has a .env.
       - name: Run unit tests
-        run: uv run --frozen pytest tests/ --ignore=tests/live -q
+        run: uv run pytest tests/ --ignore=tests/live -q
 
   quality:
     name: format / lint / types
@@ -59,21 +62,21 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --extra dev --frozen
+        run: uv sync --extra dev
 
       - name: black
-        run: uv run --frozen black --check .
+        run: uv run black --check .
 
       - name: isort
-        run: uv run --frozen isort --check-only .
+        run: uv run isort --check-only .
 
       # ruff and mypy carry a pre-existing backlog (49 and 75 findings on
       # master as of this workflow landing), so they report without blocking.
       # Flip continue-on-error off once the respective backlog reaches zero.
       - name: ruff
         continue-on-error: true
-        run: uv run --frozen ruff check .
+        run: uv run ruff check .
 
       - name: mypy
         continue-on-error: true
-        run: uv run --frozen mypy src/odoo_mcp
+        run: uv run mypy src/odoo_mcp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,77 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# A newer push to the same branch makes the in-flight run obsolete.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirrors the classifiers in pyproject.toml — if a version is claimed
+        # as supported it gets exercised here.
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      # --frozen fails if uv.lock has drifted from pyproject.toml, so lock
+      # rot is caught here rather than on someone's machine.
+      - name: Install dependencies
+        run: uv sync --extra dev --frozen
+
+      # tests/live/ is deliberately excluded: those are script-style runners
+      # that need real Odoo credentials and mutate env state. Everything under
+      # tests/ must pass with no ODOO_* config present — CI provides none on
+      # purpose, so a unit test that quietly needs a live server shows up as a
+      # failure instead of passing on a developer machine that has a .env.
+      - name: Run unit tests
+        run: uv run --frozen pytest tests/ --ignore=tests/live -q
+
+  quality:
+    name: format / lint / types
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: black
+        run: uv run --frozen black --check .
+
+      - name: isort
+        run: uv run --frozen isort --check-only .
+
+      # ruff and mypy carry a pre-existing backlog (49 and 75 findings on
+      # master as of this workflow landing), so they report without blocking.
+      # Flip continue-on-error off once the respective backlog reaches zero.
+      - name: ruff
+        continue-on-error: true
+        run: uv run --frozen ruff check .
+
+      - name: mypy
+        continue-on-error: true
+        run: uv run --frozen mypy src/odoo_mcp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # setup-uv stopped publishing floating major tags after v7, so this is
+      # pinned exactly. Bump deliberately.
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -51,7 +53,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: "3.13"
           enable-cache: true

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ wiki/
 # Claude Code / tooling scratch
 .claude/
 .superpowers/
+.omc/
 
 # uv lockfile (project uses pip + pyproject.toml)
 uv.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development commands
 
 ```bash
-# Install (local workflow — repo is uv-managed: uv.lock + .venv)
+# Install (local workflow — uv-managed .venv; uv.lock is deliberately gitignored, the project ships via pip + pyproject.toml)
 uv sync --extra dev
 # then prefix commands with `uv run`, e.g.:
 uv run pytest tests/test_safety.py
@@ -59,7 +59,11 @@ Note: live tests under `tests/live/` are **script-style runners**, not pytest mo
 - **Unit (no Odoo)**: everything in `tests/` except `tests/live/` — run with `pytest --ignore=tests/live`. Highlights: `test_resources.py` patches `get_odoo_client` with a stub (pins resource-layer validation/error handling); `test_arg_mapping.py` pins the positional → JSON-2 named-arg contract; `test_odoo_client.py` pins bearer auth + no `result`-envelope unwrap; `test_token_gate.py` / `test_safety.py` / `test_safety_role.py` cover the gate and role-based classification; the multi-user tests (`test_auth_verifier.py`, `test_token_crypto.py`, `test_user_clients.py`, `test_skill_visibility.py`, `test_skill_prompts.py`) use the `users_db_seed` fixture in `tests/conftest.py`, which builds a temp registry with the **exact CLORAG DDL and crypto contract** — keep that fixture contract-true.
 - **Live (need `.env`)**: anything under `tests/live/` — run with `python <file>`, not pytest.
 
-**CI**: the only workflow is `.github/workflows/claude-code-review.yml` — an automated Claude code review on every PR. There is **no build/test CI**; run the unit tests, lint, and typecheck locally before pushing.
+**CI**: two workflows in `.github/workflows/`:
+- `tests.yml` — on every PR and push to master: the unit suite (`pytest tests/ --ignore=tests/live`) across Python 3.10–3.13 (matrix mirrors the pyproject classifiers), plus a quality job where `black --check` and `isort --check-only` **block** while `ruff` and `mypy` run `continue-on-error` (pre-existing backlog — flip them blocking once their counts hit zero). CI deliberately provides no `ODOO_*` env and no lockfile (`uv sync` resolves fresh, mirroring what `pip install git+…` gives a user), so unit tests that quietly need a live server or drifting dependencies surface as failures.
+- `claude-code-review.yml` — automated Claude code review on every PR.
+
+Run `black . && isort .` before pushing — CI enforces formatting.
 
 ## High-level architecture
 

--- a/tests/test_user_clients.py
+++ b/tests/test_user_clients.py
@@ -1,6 +1,7 @@
 """Unit tests for per-user OdooClient resolution (user_clients.py)."""
 
 import sqlite3
+import time
 from datetime import datetime
 from types import SimpleNamespace
 
@@ -82,8 +83,12 @@ def test_credential_rotation_rebuilds_client(monkeypatch, users_db_seed):
     conn.commit()
     conn.close()
 
-    # Expire the TTL
-    user_clients._cache[member_id].checked_at = 0.0
+    # Expire the TTL. checked_at is a time.monotonic() reading, which counts
+    # from boot — so 0.0 is only "long ago" on a machine that has been up for
+    # more than _TTL_SECONDS. On a freshly booted CI runner monotonic() is
+    # still in the tens of seconds and 0.0 reads as recent, leaving the entry
+    # valid. Offset from the current reading instead.
+    user_clients._cache[member_id].checked_at = time.monotonic() - user_clients._TTL_SECONDS - 1
     second = user_clients.get_client_for_current_user()
     assert second is not first
     assert second.auth_credential == "rotated-key"


### PR DESCRIPTION
## Why

`.github/workflows/` only had `claude-code-review.yml` — it reviews code but never executes it. Both PRs merged this month (#5, #3) went green without a single test running.

That blind spot was not theoretical: it had already hidden a broken FastMCP install locally, and this PR's own first run caught a genuine bug (below).

## What

**`test` job** — pytest across Python 3.10–3.13.

- The matrix mirrors the classifiers in `pyproject.toml`, so a version claimed as supported is a version actually exercised.
- `tests/live/` stays excluded: script-style runners that need real Odoo credentials and mutate env state.
- **No `ODOO_*` config is provided, deliberately.** A unit test that quietly needs a live server should fail here instead of passing on a dev machine that happens to have a `.env`.
- No `--frozen`: `uv.lock` is gitignored on purpose (`.gitignore:58` — the project ships via pip + `pyproject.toml`). Resolving fresh mirrors what `pip install git+...` actually hands a user, so a dependency drifting out from under the declared bounds fails here rather than in someone's install.

**`quality` job** — `black` and `isort` block, since both are green on master. `ruff` (49 findings) and `mypy` (75) report without blocking; flip `continue-on-error` off per tool once its backlog reaches zero.

## The bug it caught on its first run

`test_credential_rotation_rebuilds_client` failed on all four Python versions while passing on any developer machine.

It expired the client cache with `checked_at = 0.0`. `checked_at` holds a `time.monotonic()` reading, which counts **from boot** — so `0.0` only reads as "long ago" on a machine that has been up longer than `_TTL_SECONDS` (300s). A CI runner is seconds old: `monotonic()` is still in the tens, `0.0` looks recent, the entry stays valid, and the cached client comes back.

Reproduced locally by forcing `monotonic()` to ~20s, then fixed by offsetting from the current reading. **`user_clients.py` is unchanged** — the production logic was never wrong, only the test's assumption about the clock.

## Verification

| Check | Result |
|---|---|
| pytest 3.10 / 3.11 / 3.12 / 3.13 | 243 passed each |
| black, isort | pass |
| ruff / mypy | reported, non-blocking |

Also verified locally with `.env` moved aside, and under a simulated fresh boot.

## Known follow-up

`tests/test_read_only_guard.py` on `feat/safety-locked-mode` (#3) has 3 tests that reach a real `OdooClient` and raise an uncaught `FileNotFoundError` without config. They pass locally only because a `.env` is present. **They will fail this workflow once #3 merges** — same class of bug as the one above, and the fix belongs in those tests.