### PR TITLE
perf: run Odoo calls off the event loop, narrow fields_get, split execute_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Odoo round-trips no longer block the event loop.** FastMCP 3.x calls a sync
+  *template* resource body (`odoo://model/{model}/…`, `odoo://bundle/…`, …) inline
+  on the loop thread, and `batch_execute` / `execute_workflow` are `async def`
+  around the synchronous `requests` client — so one slow `fields_get` or a 100-op
+  batch froze every session (pings included) for the duration of the Odoo calls.
+  Every parameterized resource is now registered through `_threaded_resource`
+  (an `async` wrapper that offloads the body via `anyio.to_thread`; the sync body
+  is still what `read_resource` and the tests call), and the two async tools run
+  their client calls through `_run_blocking`. `tests/test_event_loop_offload.py`
+  fails if a template is ever registered without the wrapper. `anyio` is now a
+  declared dependency (it was already a transitive one via FastMCP).
+- **Compact schema views request only the attributes they use.** `quick-schema`,
+  `/fields`, `odoo://bundle`, `session-bootstrap`, the dynamic `/workflow`
+  fallback and the locked-mode payload pre-flight now call
+  `fields_get(attributes=COMPACT_FIELD_ATTRIBUTES)` — six keys instead of the
+  full ~300 KB-per-model definition — and share one TTL+LRU cache entry per
+  `(client, model, attributes)`. A 10-model bundle previously transferred ~3 MB
+  to emit 15 KB; a quick-schema read followed by a gated write cost two
+  `fields_get`. The cache key includes the client identity, so multi-user
+  callers never share a definition filtered by someone else's access rights.
+  `/schema` and `odoo://model/{model}` still fetch the full definition.
+- **`execute_method` split into phases** (`server.py`): JSON parsing,
+  `resolve_json` lookup + injection, private-method rejection,
+  classify-and-gate, search defaults, `search_read` fallback and error
+  enrichment are now separate helpers (cyclomatic complexity 71 → 14, 359 → 86
+  lines). The confirmation gate (`_confirmation_gate`) and the read-only
+  rejection text (`_read_only_error`) are shared by `execute_method`,
+  `batch_execute` and `execute_workflow` instead of being copied three times.
+  `resolve_json` injection now returns new arg lists instead of mutating the
+  parsed payload in place, and a non-dict `resolve_json` entry gets the clear
+  "requires 'model' and 'search' keys" message instead of an `AttributeError`
+  text. The read-only rejection wording is now identical across the three
+  tools ("… Set MCP_READ_ONLY=false to enable writes …"); `execute_workflow`
+  previously said "enable workflows". Behaviour is pinned by
+  `tests/test_tool_execution_paths.py`, which covers the previously untested
+  `resolve_json`, fallback, search-default, workflow and non-atomic batch paths
+  (unit coverage 50 % → 66 %; `server.py` 25 % → 74 %).
+
 ### Fixed
 - **Positional arguments past the first were silently dropped** (`arg_mapping.py`).
   `convert_args_to_v2` iterated the `V2_ARG_MAPPING` table rather than the supplied

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **odoo-mcp-19** — Standalone MCP server for Odoo 19+ using the **v2 JSON-2 API** (`POST /json/2/{model}/{method}`, Bearer token auth, named args only). No v1 fallback.
 
-- **Version**: 1.16.0 · **Python**: 3.10+ · **MCP**: 2025-11-25 (FastMCP `>=3.4.6,<4`; `cryptography>=42` is a *direct* dependency of `token_crypto`, not just a transitive Authlib one)
+- **Version**: 1.16.0 · **Python**: 3.10+ · **MCP**: 2025-11-25 (FastMCP `>=3.4.6,<4`; `cryptography>=42` is a *direct* dependency of `token_crypto`, not just a transitive Authlib one; `anyio>=4` is a direct dependency of the event-loop offload in `server.py` / `resources.py`)
 - **The `<4` ceiling is deliberate.** FastMCP 4.x targets MCP spec 2026-07-28 and is not a drop-in — see `docs/mcp-2026-07-28-migration.md` and `tests/test_dependency_pins.py`, which fails the build if the bound is widened or the environment drifts. **`uv.lock` is gitignored** (`.gitignore`: *"project uses pip + pyproject.toml"*) — it pins only your local `.venv`, never the documented `pip install git+…` path, so `pyproject.toml` is the only thing between a fresh install and FastMCP 4.x. Do not relax the ceiling on the strength of the lockfile.
 - **Surface**: 5 tools, 28 `odoo://` resources, 19 prompts (12 generic + 7 `cyanview-*` workflow skill prompts)
 - **Discovery is via resources, action is via tools** — there is no `list_models` tool, agents read `odoo://models` instead.
@@ -47,8 +47,8 @@ python tests/live/test_locked_mode_live.py
 
 # Format + lint + typecheck
 black . && isort .   # both clean; isort has skip_gitignore=true so it skips venvs like black does
-ruff check .         # known baseline: 33 errors (27 E501, 6 E402) — see below
-mypy src/odoo_mcp    # known baseline: 75 errors, mostly [index]/[assignment] in resources.py + server.py
+ruff check .         # known baseline: 29 errors (23 E501, 6 E402) — see below
+mypy src/odoo_mcp    # known baseline: 76 errors, mostly [index]/[assignment] in resources.py + server.py
 
 # If `uv run pytest` reports ModuleNotFoundError: No module named 'odoo_mcp' (17 collection
 # errors), the dev extras are not installed — run `uv sync --extra dev` first. uv also ignores a
@@ -64,7 +64,7 @@ docker compose -f docker-compose.yml -f docker-compose.multiuser.yml up -d
 
 Note: live tests under `tests/live/` are **script-style runners**, not pytest modules — invoke them directly with `python`. They mutate environment state.
 
-- **Unit (no Odoo)**: everything in `tests/` except `tests/live/` — run with `pytest --ignore=tests/live`. Highlights: `test_resources.py` patches `get_odoo_client` with a stub (pins resource-layer validation/error handling); `test_arg_mapping.py` pins the positional → JSON-2 named-arg contract; `test_odoo_client.py` pins bearer auth + no `result`-envelope unwrap; `test_token_gate.py` / `test_safety.py` / `test_safety_role.py` cover the gate and role-based classification; the multi-user tests (`test_auth_verifier.py`, `test_token_crypto.py`, `test_user_clients.py`, `test_skill_visibility.py`, `test_skill_prompts.py`) use the `users_db_seed` fixture in `tests/conftest.py`, which builds a temp registry with the **exact CLORAG DDL and crypto contract** — keep that fixture contract-true. Locked mode (v1.16.0) is pinned by `test_safety_profile.py` (env → profile resolution), `test_read_only_guard.py`, `test_write_allowlist.py`, `test_payload_validation.py`, `test_side_effect_predicate.py`, `test_fields_cache.py`, `test_main_bind_default.py`, and `test_server_status_resource.py`.
+- **Unit (no Odoo)**: everything in `tests/` except `tests/live/` — run with `pytest --ignore=tests/live`. Highlights: `test_resources.py` patches `get_odoo_client` with a stub (pins resource-layer validation/error handling); `test_arg_mapping.py` pins the positional → JSON-2 named-arg contract; `test_odoo_client.py` pins bearer auth + no `result`-envelope unwrap; `test_token_gate.py` / `test_safety.py` / `test_safety_role.py` cover the gate and role-based classification; the multi-user tests (`test_auth_verifier.py`, `test_token_crypto.py`, `test_user_clients.py`, `test_skill_visibility.py`, `test_skill_prompts.py`) use the `users_db_seed` fixture in `tests/conftest.py`, which builds a temp registry with the **exact CLORAG DDL and crypto contract** — keep that fixture contract-true. Locked mode (v1.16.0) is pinned by `test_safety_profile.py` (env → profile resolution), `test_read_only_guard.py`, `test_write_allowlist.py`, `test_payload_validation.py`, `test_side_effect_predicate.py`, `test_fields_cache.py`, `test_main_bind_default.py`, and `test_server_status_resource.py`. `test_event_loop_offload.py` pins that every template resource is registered as a coroutine and that `batch_execute` / `execute_workflow` run their Odoo calls off the loop thread; `test_tool_execution_paths.py` is the characterization suite for `resolve_json`, the `search_read` fallback, search defaults, both workflows and non-atomic batches — extend it before touching those phases.
 - **Live (need `.env`)**: anything under `tests/live/` — run with `python <file>`, not pytest.
 
 **CI**: two workflows in `.github/workflows/`:
@@ -73,7 +73,7 @@ Note: live tests under `tests/live/` are **script-style runners**, not pytest mo
 
 Run `black . && isort .` before pushing — CI enforces formatting.
 
-**Lint and typecheck are not clean gates.** Baseline as of v1.16.0: `pytest --ignore=tests/live` → **374 passed**; `black --check .` and `isort --check-only .` → **clean**; `ruff check .` → **33 errors** (27 E501, 6 E402); `mypy src/odoo_mcp` → **75 errors** (38 `resources.py`, 24 `server.py`, 10 `utils.py`, 1 each in `prompts.py` / `constants.py` / `user_clients.py`; counts drift slightly with the mypy version — 2.1.0 here). Judge a change by *no new errors against that baseline*, not by a zero exit code. All 6 remaining E402s are in `tests/live/`, where `load_dotenv()` must run before the `odoo_mcp` imports — inherent to those script-style runners, not a defect. None of them come from the deliberate "import `app.py` first" ordering in `server.py`/`resources.py`, so do not reorder module imports to chase them.
+**Lint and typecheck are not clean gates.** Baseline as of the post-1.16.0 perf/quality pass: `pytest --ignore=tests/live` → **423 passed** (unit coverage 66 %); `black --check .` and `isort --check-only .` → **clean**; `ruff check .` → **29 errors** (23 E501, 6 E402); `mypy src/odoo_mcp` → **76 errors** (38 `resources.py`, 24 `server.py`, 10 `utils.py`, 1 each in `prompts.py` / `constants.py` / `user_clients.py`, plus 1 `import-untyped` in `odoo_client.py` when `types-requests` is absent from the venv; counts drift slightly with the mypy version — 2.1.0 here). Judge a change by *no new errors against that baseline*, not by a zero exit code. All 6 remaining E402s are in `tests/live/`, where `load_dotenv()` must run before the `odoo_mcp` imports — inherent to those script-style runners, not a defect. None of them come from the deliberate "import `app.py` first" ordering in `server.py`/`resources.py`, so do not reorder module imports to chase them.
 
 ## High-level architecture
 
@@ -83,8 +83,14 @@ The package was split in v1.14.0 (commit `ea10d79`) from a 3762-line `server.py`
 src/odoo_mcp/
 ├── __main__.py        CLI entry: STDIO/HTTP bootstrap, --setup wizard, HTTP auth preflight
 ├── app.py             FastMCP instance + icon + auth provider selection + middleware wiring — imported first
-├── server.py          5 tools + _RESOURCE_ROUTES table + search_read fallback + safety integration
-├── resources.py       28 odoo:// resource handlers
+├── server.py          5 tools + _RESOURCE_ROUTES table + safety integration; execute_method is an
+│                      orchestrator over phase helpers (_parse_json_args, _resolve_many2one_names,
+│                      _reject_private_method, _classify_and_gate, _apply_search_defaults,
+│                      _search_read_fallback, _failure_response); _confirmation_gate and
+│                      _read_only_error are shared by all three write-capable tools; _run_blocking
+│                      offloads client calls from the async tools
+├── resources.py       28 odoo:// resource handlers; parameterized ones registered via
+│                      _threaded_resource so the blocking body runs off the event loop
 ├── prompts.py         12 generic guided prompts
 ├── skill_prompts.py   7 cyanview-* workflow prompts, bodies loaded from skills/*.md (frontmatter stripped)
 ├── safety.py          Risk classification + token gate + role-based blocking + read-only/
@@ -104,8 +110,10 @@ src/odoo_mcp/
 ├── constants.py       Limits, regex validators, MODEL_STATE_MACHINES, default context
 ├── models.py          Pydantic response schemas (structured output)
 ├── utils.py           Compact schema builder, error suggestions, and two TTL+LRU caches:
-│                      `_DOC_CACHE` (/doc-bearer, 300s) and `_FIELDS_CACHE` (live fields_get via
-│                      `get_fields_for_model()`, 60s — shorter, it backs the locked-mode payload pre-flight)
+│                      `_DOC_CACHE` (/doc-bearer, 300s) and `_FIELDS_CACHE` (live fields_get, 60s,
+│                      keyed by (client url, username, model, attributes) — shared by the compact
+│                      schema resources and the locked-mode payload pre-flight via
+│                      `fields_cache_key/get/put` and `get_fields_for_model()`)
 ├── skills/*.md        Packaged Cyanview skill bodies (copied from curated ~/.claude/skills/cyanview-*)
 └── module_knowledge.json   Special methods for 13 modules + the static `model_limitations` block
                             (loaded at startup, shipped as package data)
@@ -125,6 +133,10 @@ src/odoo_mcp/
 9. On any error: match against ~25 patterns in `utils.get_error_suggestion` (with `{model}` templating). Server tracebacks are logged to stderr, **never** forwarded to clients.
 
 **2. Resource bridge** — `read_resource(uri)` exists because some clients (Claude Desktop) don't speak resource templates. The `_RESOURCE_ROUTES` table in `server.py` maps URIs to the same handlers `resources.py` registers, so the same `odoo://...` URI works either way. Two properties nothing tests: **parity** — 28 routes ↔ 28 `@mcp.resource` handlers today, and adding a resource without adding a route silently 404s the bridge while the template client keeps working; and **order** — the list is matched top-down, so `odoo://module-knowledge/{name}` must stay above `odoo://module-knowledge`, and the specific `odoo://model/{m}/…` variants above the catch-all `odoo://model/{m}`. `read_resource` also **truncates at 15 000 chars** (`_READ_RESOURCE_MAX_CHARS`), appending a `_truncated` JSON marker — so `odoo://model/{m}/schema` (~300 KB) returns a fragment unless the caller passes `max_chars=0`.
+
+**Event-loop rule (post-1.16.0).** FastMCP 3.x runs sync tools and *static* resources in the anyio threadpool, but calls a sync *template* resource body inline on the loop and, of course, runs `async def` tools on the loop. `OdooClient` is synchronous `requests`, so: every parameterized `odoo://…/{x}` resource must be registered with `resources._threaded_resource` (not bare `@mcp.resource`), and any Odoo call inside an `async def` tool must go through `server._run_blocking`. `tests/test_event_loop_offload.py` enforces both. Contextvars propagate through `anyio.to_thread`, so per-user client resolution is unaffected.
+
+**Schema fetch rule.** Compact views (quick-schema, /fields, bundle, session-bootstrap, dynamic /workflow) and the payload pre-flight must request `fields_get(attributes=COMPACT_FIELD_ATTRIBUTES)` through `_fetch_model_fields(..., attributes=…)` / `get_fields_for_model(..., attributes=…)` so they share one cache entry per model; only `/schema` and `odoo://model/{model}` fetch the full definition.
 
 **3. Live doc enrichment** — `odoo://methods/{model}` and `@api.private` detection both consult `/doc-bearer/<model>.json` (provided by Odoo's `api_doc` module, requires `api_doc.group_allow_doc` on the API user). Cached in `_DOC_CACHE`: 5-min TTL, 100-entry LRU, `threading.Lock`. Falls back silently to static data if unavailable.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "requests>=2.32.4",
     "python-dotenv>=1.0.0",
     "cryptography>=42",
+    "anyio>=4",
 ]
 
 [project.urls]

--- a/src/odoo_mcp/constants.py
+++ b/src/odoo_mcp/constants.py
@@ -426,6 +426,14 @@ CONCEPT_ALIASES: Dict[str, List[str]] = {
 
 # ----- Bootstrap Models -----
 
+# Attribute subset requested from ``fields_get`` by the compact schema views
+# (quick-schema, /fields, bundle, session-bootstrap) and by the locked-mode
+# payload pre-flight. A full definition of a big model is ~300 KB (help text,
+# translations, domains, contexts…); these six attributes are all the compact
+# views and the validator read, and requesting them explicitly cuts the
+# transfer to a few KB. One shared tuple = one shared cache entry per model.
+COMPACT_FIELD_ATTRIBUTES: tuple[str, ...] = ("type", "string", "required", "readonly", "relation", "selection")
+
 _DEFAULT_BOOTSTRAP_MODELS = "res.partner,sale.order,account.move,product.product,stock.picking"
 
 

--- a/src/odoo_mcp/odoo_client.py
+++ b/src/odoo_mcp/odoo_client.py
@@ -10,7 +10,7 @@ import os
 import re
 import threading
 import urllib.parse
-from typing import Any, cast
+from typing import Any, Sequence, cast
 
 import requests
 from dotenv import load_dotenv
@@ -202,10 +202,17 @@ class OdooClient:
         except Exception as e:
             return {"error": str(e)}
 
-    def get_model_fields(self, model_name: str) -> dict[str, Any]:
-        """Get field definitions for a model."""
+    def get_model_fields(self, model_name: str, attributes: Sequence[str] | None = None) -> dict[str, Any]:
+        """Get field definitions for a model.
+
+        ``attributes`` narrows the per-field payload to the named keys (Odoo's
+        ``fields_get(attributes=...)``). A full definition of a large model is
+        ~300 KB; the compact schema views only need a handful of attributes.
+        ``None`` requests the complete definition.
+        """
+        kwargs: dict[str, Any] = {"attributes": list(attributes)} if attributes else {}
         try:
-            return cast(dict[str, Any], self._execute(model_name, "fields_get"))
+            return cast(dict[str, Any], self._execute(model_name, "fields_get", **kwargs))
         except Exception as e:
             return {"error": str(e)}
 

--- a/src/odoo_mcp/resources.py
+++ b/src/odoo_mcp/resources.py
@@ -1,20 +1,27 @@
 """
 MCP Resource handlers for the Odoo MCP Server.
 
-All 28 @mcp.resource decorated functions. Importing this module
-registers all resources with the FastMCP instance.
+All 28 resource handlers. Importing this module registers them with the
+FastMCP instance: static URIs via ``@mcp.resource``, parameterized URIs via
+``_threaded_resource`` (same registration, but the blocking body is offloaded
+to the worker threadpool — see the decorator's docstring).
 """
 
+import functools
+import inspect
 import json
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict
+from typing import Any, Callable, Dict, Sequence, TypeVar
+
+import anyio
 
 from .app import mcp
 from .constants import (
     _DEFAULT_BOOTSTRAP_MODELS,
     _RUNTIME_ISSUES_LOCK,
+    COMPACT_FIELD_ATTRIBUTES,
     CONCEPT_ALIASES,
     ERROR_CATEGORIES,
     MODEL_STATE_MACHINES,
@@ -31,19 +38,64 @@ from .utils import (
     _get_module_knowledge,
     _get_module_knowledge_by_name,
     _strip_html,
+    fields_cache_get,
+    fields_cache_key,
+    fields_cache_put,
 )
 
 # ----- Internal helpers -----
+
+_F = TypeVar("_F", bound=Callable[..., str])
+
+
+def _threaded_resource(uri: str, **resource_kwargs: Any) -> Callable[[_F], _F]:
+    """Register a *parameterized* resource whose sync body runs off the event loop.
+
+    FastMCP 3.x runs sync ``@mcp.tool`` bodies and *static* ``@mcp.resource``
+    bodies in the anyio worker threadpool, but ``FunctionResourceTemplate.read``
+    calls a sync template body inline on the loop thread. Every ``odoo://…/{x}``
+    handler does a blocking ``requests`` round-trip, so registering it directly
+    would stall all sessions (pings included) for the duration of the Odoo call.
+
+    This decorator registers an ``async`` wrapper that offloads the body via
+    ``anyio.to_thread`` (contextvars propagate, so ``get_odoo_client()`` still
+    resolves the per-user client), and returns the *sync* body unchanged so the
+    ``read_resource`` bridge in ``server.py`` and the unit tests keep calling it
+    directly. ``tests/test_event_loop_offload.py`` fails if any template is
+    registered without it.
+    """
+
+    def decorator(fn: _F) -> _F:
+        @functools.wraps(fn)
+        async def _offloaded(**params: Any) -> str:
+            return await anyio.to_thread.run_sync(functools.partial(fn, **params))
+
+        # ``functools.wraps`` copies annotations; the explicit signature keeps
+        # FastMCP's template-parameter matching on the body's parameter names.
+        _offloaded.__signature__ = inspect.signature(fn)  # type: ignore[attr-defined]
+        mcp.resource(uri, **resource_kwargs)(_offloaded)
+        return fn
+
+    return decorator
+
 
 # Hint appended to model-resolution errors so agents know where to look next.
 _MODEL_LOOKUP_HINT = "Use odoo://models or odoo://find-model/{concept} to find the right model."
 
 
-def _fetch_model_fields(model_name: str) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None]:
+def _fetch_model_fields(
+    model_name: str, attributes: Sequence[str] | None = None
+) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None]:
     """Validate a model name and fetch its ``fields_get`` definition.
 
     Returns ``(fields, None)`` on success or ``(None, error_dict)`` when the
     name is malformed or the model does not exist / is inaccessible.
+
+    ``attributes`` narrows the request to that subset (pass
+    ``COMPACT_FIELD_ATTRIBUTES`` for the compact views). Results go through the
+    shared TTL+LRU cache in ``utils`` keyed by (client, model, attributes), so
+    quick-schema, /fields, bundle, session-bootstrap and the locked-mode payload
+    pre-flight all reuse one fetch per model.
 
     Centralizing this guard keeps the schema builders from ever receiving the
     ``{"error": ...}`` sentinel that ``OdooClient.get_model_fields`` returns on
@@ -55,7 +107,12 @@ def _fetch_model_fields(model_name: str) -> tuple[Dict[str, Any] | None, Dict[st
     err = _validate_model(model_name)
     if err:
         return None, {"error": err, "hint": _MODEL_LOOKUP_HINT}
-    fields = get_odoo_client().get_model_fields(model_name)
+    client = get_odoo_client()
+    key = fields_cache_key(client, model_name, attributes)
+    cached = fields_cache_get(key)
+    if cached is not None:
+        return cached, None
+    fields = client.get_model_fields(model_name, attributes=list(attributes) if attributes else None)
     # get_model_fields returns {"error": "<msg>"} on failure. A real field can
     # be named "error", but its value is always a dict, never a str — so an
     # str-valued "error" key unambiguously identifies the failure sentinel.
@@ -64,6 +121,7 @@ def _fetch_model_fields(model_name: str) -> tuple[Dict[str, Any] | None, Dict[st
             "error": f"Model '{model_name}' not found or inaccessible: {fields['error']}",
             "hint": _MODEL_LOOKUP_HINT,
         }
+    fields_cache_put(key, fields)
     return fields, None
 
 
@@ -81,7 +139,7 @@ def get_models() -> str:
     return json.dumps(models, indent=2)
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://model/{model_name}",
     description="Get information about a specific model including fields",
 )
@@ -97,7 +155,7 @@ def get_model_info(model_name: str) -> str:
         return json.dumps({"error": str(e)}, indent=2)
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://model/{model_name}/schema",
     description="Complete schema for a model including fields and relationships",
 )
@@ -139,7 +197,7 @@ def get_model_schema(model_name: str) -> str:
         return json.dumps({"error": str(e)}, indent=2)
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://model/{model_name}/fields",
     description="Lightweight field list: names, types, labels (much smaller than /schema)",
 )
@@ -150,7 +208,7 @@ def get_model_fields_light(model_name: str) -> str:
     relation model (for relational fields), and selection values.
     Much smaller than /schema; use /quick-schema for the densest form.
     """
-    fields, error = _fetch_model_fields(model_name)
+    fields, error = _fetch_model_fields(model_name, attributes=COMPACT_FIELD_ATTRIBUTES)
     if fields is None:
         return json.dumps(error, indent=2)
     try:
@@ -171,7 +229,7 @@ def get_model_fields_light(model_name: str) -> str:
         return json.dumps({"error": str(e)}, indent=2)
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://model/{model_name}/quick-schema",
     description="Ultra-compact schema: short keys, no labels/help. ~60-80% smaller than /fields, best for tokens.",
 )
@@ -181,7 +239,7 @@ def get_model_quick_schema(model_name: str) -> str:
     Returns minimal field info with short keys (t=type, req=required, ro=readonly, rel=relation).
     No indentation, no labels, no help text. Typically 60-80% smaller than /fields.
     """
-    fields, error = _fetch_model_fields(model_name)
+    fields, error = _fetch_model_fields(model_name, attributes=COMPACT_FIELD_ATTRIBUTES)
     if fields is None:
         return json.dumps(error)
     try:
@@ -193,7 +251,7 @@ def get_model_quick_schema(model_name: str) -> str:
         return json.dumps({"error": str(e)})
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://model/{model_name}/workflow",
     description="State machine transitions for a model: states, methods, side effects, irreversibility",
 )
@@ -213,9 +271,10 @@ def get_model_workflow(model_name: str) -> str:
         return json.dumps(result, indent=2)
 
     # Dynamic fallback: try to infer workflow from model metadata
-    odoo_client = get_odoo_client()
     try:
-        fields = odoo_client.get_model_fields(model_name)
+        fields, error = _fetch_model_fields(model_name, attributes=COMPACT_FIELD_ATTRIBUTES)
+        if fields is None:
+            return json.dumps(error, indent=2)
         result = {
             "model": model_name,
             "source": "dynamic",
@@ -264,7 +323,7 @@ def get_model_workflow(model_name: str) -> str:
         return json.dumps({"error": str(e)}, indent=2)
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://bundle/{models_csv}",
     description="Batch quick-schema for multiple models in one call (comma-separated, max 10)",
 )
@@ -284,7 +343,7 @@ def get_bundle(models_csv: str) -> str:
     bundle: Dict[str, Any] = {"models": {}, "errors": {}}
 
     def _fetch(name: str) -> tuple[str, Any]:
-        fields, error = _fetch_model_fields(name)
+        fields, error = _fetch_model_fields(name, attributes=COMPACT_FIELD_ATTRIBUTES)
         if fields is None:
             return name, error
         try:
@@ -317,7 +376,6 @@ def get_session_bootstrap() -> str:
     Configure via MCP_BOOTSTRAP_MODELS env var (comma-separated model names).
     Default: res.partner,sale.order,account.move,product.product,stock.picking
     """
-    odoo_client = get_odoo_client()
     models_csv = os.environ.get("MCP_BOOTSTRAP_MODELS", _DEFAULT_BOOTSTRAP_MODELS)
     model_names = [m.strip() for m in models_csv.split(",") if m.strip()][:20]
 
@@ -325,7 +383,9 @@ def get_session_bootstrap() -> str:
 
     def _fetch(name: str) -> tuple[str, Any]:
         try:
-            fields = odoo_client.get_model_fields(name)
+            fields, error = _fetch_model_fields(name, attributes=COMPACT_FIELD_ATTRIBUTES)
+            if fields is None:
+                return name, RuntimeError(str((error or {}).get("error", "unknown error")))
             schema = _build_compact_schema(fields)
             schema["field_count"] = len(schema["fields"])
             return name, schema
@@ -352,7 +412,7 @@ def get_session_bootstrap() -> str:
     return json.dumps(result, separators=(",", ":"))
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://record/{model_name}/{record_id}",
     description="Get a specific record by ID",
 )
@@ -371,7 +431,7 @@ def get_record(model_name: str, record_id: str) -> str:
         return json.dumps({"error": str(e)}, indent=2)
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://methods/{model_name}",
     description="Available methods for a model including module-specific special methods",
 )
@@ -552,7 +612,7 @@ def get_methods(model_name: str) -> str:
     return json.dumps(common_methods, indent=2)
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://model/{model_name}/docs",
     description="Rich documentation for a model: labels, field help, selection options, action help",
 )
@@ -734,7 +794,7 @@ def get_module_knowledge() -> str:
     return _get_module_knowledge()
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://module-knowledge/{module_name}",
     description="Get knowledge for a specific module (sale, crm, account, etc.)",
 )
@@ -743,7 +803,7 @@ def get_module_knowledge_by_name(module_name: str) -> str:
     return _get_module_knowledge_by_name(module_name)
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://docs/{target}",
     description="Documentation URLs and GitHub links for any Odoo model or module",
 )
@@ -1125,7 +1185,7 @@ def get_aggregation_guide() -> str:
     )
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://find-model/{concept}",
     description="Find Odoo model from natural language concept (contact, invoice, quote, etc.)",
 )
@@ -1211,7 +1271,7 @@ def find_model_resource(concept: str) -> str:
     return json.dumps(result, indent=2)
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://tools/{query}",
     description="Search available operations by keyword (invoice, sales, stock, etc.)",
 )
@@ -1254,7 +1314,7 @@ def search_tools_resource(query: str) -> str:
     )
 
 
-@mcp.resource(
+@_threaded_resource(
     "odoo://actions/{model}",
     description="Discover all available actions for a specific model",
 )

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -680,6 +680,7 @@ def validate_payload_against_schema(
     Empty fields_get response counts as a failure: a silent connection
     drop must not grant a write token.
     """
+    from .constants import COMPACT_FIELD_ATTRIBUTES
     from .utils import get_fields_for_model
 
     args = args or []
@@ -687,7 +688,9 @@ def validate_payload_against_schema(
     if vals is None:
         return PayloadValidationResult(ok=True, errors=[])
 
-    fields = get_fields_for_model(client, model)
+    # Same attribute subset as the compact schema resources, so a quick-schema
+    # read followed by a gated write costs one fields_get, not two.
+    fields = get_fields_for_model(client, model, attributes=COMPACT_FIELD_ATTRIBUTES)
     if not fields:
         return PayloadValidationResult(
             ok=False,

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -11,6 +11,7 @@ MCP 2025-11-25 Features:
 """
 
 import asyncio
+import functools
 import hashlib
 import json
 import logging
@@ -19,8 +20,9 @@ import secrets
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List, TypeVar
 
+import anyio
 from fastmcp import Context
 from fastmcp.dependencies import Progress
 
@@ -65,6 +67,22 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+
+async def _run_blocking(fn: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
+    """Run a synchronous OdooClient call in the anyio worker threadpool.
+
+    ``batch_execute`` and ``execute_workflow`` are ``async def`` (they report
+    progress), but ``OdooClient`` is built on synchronous ``requests``. Calling
+    it inline would block the event loop for the whole round-trip — in HTTP
+    multi-user mode a 100-op batch would freeze every session for 100 × RTT.
+    Contextvars propagate through ``anyio.to_thread``, so ``get_odoo_client()``
+    and the current access token resolve exactly as on the loop thread.
+    """
+    return await anyio.to_thread.run_sync(functools.partial(fn, *args, **kwargs))
+
 
 # ----- Confirmation Token Store -----
 # Stateful nonces that tie a confirmed=True re-call to the original safety classification
@@ -121,6 +139,356 @@ def _validate_confirmation_token(token: str | None, model: str, method: str, pay
             "confirmed=true to get a new token for the current payload."
         )
     return None
+
+
+# ----- Shared guards for the write-capable tools -----
+
+
+def _elapsed_ms(start_time: float) -> float:
+    return round((time.time() - start_time) * 1000, 2)
+
+
+def _read_only_error(subject: str) -> str:
+    """Uniform rejection text for the MCP_READ_ONLY / locked-mode kill-switch."""
+    return (
+        f"read-only mode is active: {subject}. Set MCP_READ_ONLY=false to enable "
+        f"writes (or change MCP_SAFETY_MODE away from 'locked' if MCP_READ_ONLY "
+        f"is not set explicitly)."
+    )
+
+
+@dataclass(frozen=True)
+class _GateDecision:
+    """Outcome of the confirmation gate for one gated operation.
+
+    ``outcome`` is ``"issue"`` (first call — hand ``token`` back to the caller),
+    ``"reject"`` (confirmed re-call with a bad token — surface ``error``) or
+    ``"proceed"`` (token validated and consumed).
+    """
+
+    outcome: str
+    token: str | None = None
+    error: str | None = None
+
+
+def _confirmation_gate(
+    model_key: str,
+    method_key: str,
+    payload: Any,
+    confirmed: bool,
+    confirmation_token: str | None,
+) -> _GateDecision:
+    """Issue a token on the first call; validate and consume it on the confirmed re-call.
+
+    ``payload`` is the exact operation content the token must be bound to —
+    post-resolve args/kwargs for ``execute_method``, the operations list for
+    ``batch_execute``, the params dict for ``execute_workflow``. Its digest is
+    what stops a re-call from substituting arguments after the gate was shown.
+    """
+    digest = _payload_digest(payload)
+    if not confirmed:
+        return _GateDecision("issue", token=_issue_confirmation_token(model_key, method_key, digest))
+    error = _validate_confirmation_token(confirmation_token, model_key, method_key, digest)
+    if error:
+        return _GateDecision("reject", error=f"Confirmation rejected: {error}")
+    return _GateDecision("proceed")
+
+
+# ----- execute_method phases -----
+
+
+def _parse_json_args(args_json: str | None, kwargs_json: str | None) -> tuple[list, dict, str | None]:
+    """Decode the JSON-string parameters and merge MCP_DEFAULT_CONTEXT.
+
+    Returns ``(args, kwargs, error)``; ``error`` is set on malformed input.
+    """
+    args: list = []
+    kwargs: dict = {}
+    if args_json:
+        try:
+            args = json.loads(args_json)
+        except json.JSONDecodeError as e:
+            return [], {}, f"Invalid args_json: {e}"
+        if not isinstance(args, list):
+            return [], {}, "args_json must be a JSON array"
+    if kwargs_json:
+        try:
+            kwargs = json.loads(kwargs_json)
+        except json.JSONDecodeError as e:
+            return [], {}, f"Invalid kwargs_json: {e}"
+        if not isinstance(kwargs, dict):
+            return [], {}, "kwargs_json must be a JSON object"
+    merged_ctx = _merge_context(kwargs.get("context"))
+    if merged_ctx is not None:
+        kwargs = {**kwargs, "context": merged_ctx}
+    return args, kwargs, None
+
+
+def _lookup_resolve_target(
+    odoo: Any, field_name: str, spec: Any, start_time: float
+) -> tuple[int | None, ExecuteMethodResponse | None]:
+    """Resolve one ``resolve_json`` entry to a record id via ``name_search``."""
+    target_model = spec.get("model") if isinstance(spec, dict) else None
+    search_term = spec.get("search") if isinstance(spec, dict) else None
+    if not target_model or not search_term:
+        return None, ExecuteMethodResponse(
+            success=False, error=f"resolve_json['{field_name}'] requires 'model' and 'search' keys"
+        )
+    model_err = _validate_model(target_model)
+    if model_err:
+        return None, ExecuteMethodResponse(success=False, error=f"resolve_json['{field_name}']: {model_err}")
+    # Block reads against security-critical models
+    if target_model in BLOCKED_MODELS:
+        return None, ExecuteMethodResponse(
+            success=False, error=f"resolve_json['{field_name}']: model '{target_model}' is blocked for safety."
+        )
+    # The lookup *and* the unpacking of its result share one boundary: a malformed
+    # name_search tuple must surface as a resolve_json failure, not as a generic error.
+    try:
+        matches = odoo.execute_method(target_model, "name_search", name=search_term, limit=5)
+        if not matches:
+            return None, ExecuteMethodResponse(
+                success=False,
+                error=f"resolve_json: No match for '{search_term}' in {target_model}",
+                hint=f"Search {target_model} manually to find the correct record",
+                execution_time_ms=_elapsed_ms(start_time),
+            )
+        if len(matches) > 1:
+            options = [f"  {m[0]}: {m[1]}" for m in matches[:5]]
+            return None, ExecuteMethodResponse(
+                success=False,
+                error=f"resolve_json: Ambiguous match for '{search_term}' in {target_model} ({len(matches)} results)",
+                hint="Multiple matches found:\n" + "\n".join(options) + "\nUse the numeric ID directly instead.",
+                execution_time_ms=_elapsed_ms(start_time),
+            )
+        return matches[0][0], None
+    except Exception as e:
+        return None, ExecuteMethodResponse(
+            success=False,
+            error=f"resolve_json: Failed to resolve '{field_name}': {e}",
+            execution_time_ms=_elapsed_ms(start_time),
+        )
+
+
+def _inject_resolved_values(method: str, args: list, resolved: dict[str, int]) -> list:
+    """Return a copy of ``args`` with the resolved ids merged into the vals dict(s)."""
+    if not resolved or not args:
+        return args
+    if method == "write" and len(args) >= 2 and isinstance(args[1], dict):
+        return [args[0], {**args[1], **resolved}, *args[2:]]
+    if method == "create":
+        if isinstance(args[0], dict):
+            return [{**args[0], **resolved}, *args[1:]]
+        if isinstance(args[0], list):
+            vals_list = [{**vals, **resolved} if isinstance(vals, dict) else vals for vals in args[0]]
+            return [vals_list, *args[1:]]
+    return args
+
+
+def _resolve_many2one_names(
+    odoo: Any, resolve_json: str, method: str, args: list, start_time: float
+) -> tuple[list, ExecuteMethodResponse | None]:
+    """Apply ``resolve_json``: name_search every entry and inject the ids into the payload."""
+    try:
+        resolves = json.loads(resolve_json)
+    except json.JSONDecodeError as e:
+        return args, ExecuteMethodResponse(success=False, error=f"Invalid resolve_json: {e}")
+    if not isinstance(resolves, dict):
+        return args, ExecuteMethodResponse(success=False, error="resolve_json must be a JSON object")
+    resolved: dict[str, int] = {}
+    for field_name, spec in resolves.items():
+        record_id, failure = _lookup_resolve_target(odoo, field_name, spec, start_time)
+        if failure:
+            return args, failure
+        resolved[field_name] = record_id  # type: ignore[assignment]
+    return _inject_resolved_values(method, args, resolved), None
+
+
+def _reject_private_method(model: str, method: str, start_time: float) -> ExecuteMethodResponse | None:
+    """Refuse ``@api.private`` methods: static hint table first, then the live /doc-bearer/ check."""
+    if method in PRIVATE_METHOD_HINTS:
+        return ExecuteMethodResponse(
+            success=False,
+            error=f"Method '{method}' is @api.private and cannot be called via RPC.",
+            hint=PRIVATE_METHOD_HINTS[method],
+            execution_time_ms=_elapsed_ms(start_time),
+        )
+    if method.startswith("_"):
+        live_doc = _get_live_doc(model)
+        if live_doc and method not in live_doc.get("methods", {}):
+            return ExecuteMethodResponse(
+                success=False,
+                error=f"Method '{method}' is not a public method on {model}. It may be @api.private or doesn't exist.",
+                hint=f"Use odoo://methods/{model} to see available public methods.",
+                execution_time_ms=_elapsed_ms(start_time),
+            )
+    return None
+
+
+def _classify_and_gate(
+    odoo: Any,
+    model: str,
+    method: str,
+    args: list,
+    kwargs: dict,
+    confirmed: bool,
+    confirmation_token: str | None,
+    start_time: float,
+) -> ExecuteMethodResponse | None:
+    """Run the safety classifier, the payload pre-flight and the confirmation gate.
+
+    Returns the response to send when the call must stop here (blocked, token
+    issued, token rejected, payload invalid), or ``None`` when execution may proceed.
+    """
+    classification = classify_operation(model, method, args, kwargs, role=current_role())
+
+    if classification.risk_level == RiskLevel.BLOCKED:
+        audit_log(classification, confirmed=confirmed, executed=False)
+        return ExecuteMethodResponse(
+            success=False,
+            pending_confirmation=True,
+            safety=classification,
+            error=classification.blocked_reason,
+            hint="Use the Odoo web interface instead.",
+            execution_time_ms=_elapsed_ms(start_time),
+        )
+
+    if classification.requires_confirmation:
+        # Payload pre-flight against live fields_get — only when the profile asks
+        # for it AND this is a write-shaped call — so a typo'd field fails before
+        # a gate round-trip is spent on it.
+        if get_profile().validate_payloads and is_side_effect_method(method):
+            from .safety import validate_payload_against_schema as _validate_payload
+
+            validation = _validate_payload(odoo, model, method, args=args, kwargs=kwargs)
+            if not validation.ok:
+                return ExecuteMethodResponse(
+                    success=False,
+                    error="Payload validation failed:\n  - " + "\n  - ".join(validation.errors),
+                    hint=f"Read odoo://model/{model}/quick-schema for the field list.",
+                    execution_time_ms=_elapsed_ms(start_time),
+                )
+
+        # Args/kwargs are post-resolve_json and post-context-merge, so the digest
+        # captures what would actually be sent to Odoo.
+        decision = _confirmation_gate(model, method, {"args": args, "kwargs": kwargs}, confirmed, confirmation_token)
+        if decision.outcome == "issue":
+            audit_log(classification, confirmed=False, executed=False)
+            message = classification.reason
+            if classification.cascade_warning:
+                message += f"\n\nWARNING: {classification.cascade_warning}"
+            return ExecuteMethodResponse(
+                success=False,
+                pending_confirmation=True,
+                safety=classification,
+                error=message,
+                hint=(
+                    f"Re-call execute_method with confirmed=true and "
+                    f"confirmation_token='{decision.token}' to proceed."
+                ),
+                execution_time_ms=_elapsed_ms(start_time),
+            )
+        if decision.outcome == "reject":
+            return ExecuteMethodResponse(success=False, error=decision.error, execution_time_ms=_elapsed_ms(start_time))
+
+    if classification.risk_level != RiskLevel.SAFE:
+        audit_log(classification, confirmed=confirmed, executed=True)
+    return None
+
+
+def _apply_search_defaults(method: str, args: list, kwargs: dict) -> tuple[list, dict]:
+    """Default/cap the search limit and unwrap a double-wrapped ``[[domain]]``."""
+    if method in ("search", "search_read"):
+        if "limit" not in kwargs:
+            kwargs = {**kwargs, "limit": DEFAULT_LIMIT}
+            logger.debug("Applied default limit=%d", DEFAULT_LIMIT)
+        elif kwargs.get("limit", 0) > MAX_LIMIT:
+            kwargs = {**kwargs, "limit": MAX_LIMIT}
+            logger.debug("Capped limit to %d", MAX_LIMIT)
+    if method in ("search", "search_read", "search_count") and args:
+        domain = args[0]
+        if isinstance(domain, list) and len(domain) == 1 and isinstance(domain[0], list):
+            if domain[0] and isinstance(domain[0][0], list):
+                args = [domain[0], *args[1:]]
+    return args, kwargs
+
+
+def _search_read_fallback(
+    odoo: Any, model: str, kwargs: dict, error_msg: str, start_time: float
+) -> ExecuteMethodResponse:
+    """Retry a failed ``search_read`` as ``search`` + ``read`` and record the runtime issue."""
+    domain = kwargs.get("domain", [])
+    fields = kwargs.get("fields", [])
+    context = kwargs.get("context")
+    try:
+        search_kwargs: dict[str, Any] = {
+            "domain": domain,
+            "limit": kwargs.get("limit", 100),
+            "offset": kwargs.get("offset", 0),
+        }
+        if kwargs.get("order"):
+            search_kwargs["order"] = kwargs["order"]
+        if context:
+            search_kwargs["context"] = context
+        ids = odoo.execute_method(model, "search", **search_kwargs)
+
+        result: Any = []
+        if ids:
+            read_kwargs: dict[str, Any] = {}
+            if fields:
+                read_kwargs["fields"] = fields
+            if context:
+                read_kwargs["context"] = context
+            result = odoo.execute_method(model, "read", ids, **read_kwargs)
+
+        analysis = _track_model_issue(model, "search_read", error_msg, domain=domain, fields=fields)
+        return ExecuteMethodResponse(
+            success=True,
+            result=result,
+            fallback_used=True,
+            issue_analysis=IssueAnalysis(
+                category=analysis["category"],
+                cause=analysis["cause"],
+                domain_patterns=analysis["domain_patterns"],
+                problematic_fields=analysis.get("problematic_fields", []),
+                suggested_solutions=analysis["solutions"][:2],
+                model_specific_advice=analysis.get("model_specific_advice", []),
+            ),
+            note=f"Fallback search+read used. Cause: {analysis['cause']}",
+            execution_time_ms=_elapsed_ms(start_time),
+        )
+    except Exception as fallback_error:
+        return ExecuteMethodResponse(
+            success=False,
+            error=f"{error_msg}; Fallback also failed: {fallback_error}",
+            suggestion=(
+                "Both search_read and fallback search+read failed. " "Check odoo://model-limitations for known issues."
+            ),
+            execution_time_ms=_elapsed_ms(start_time),
+        )
+
+
+_FIELD_ERROR_PATTERNS = ("invalid field", "unknown field", "field_get", "keyerror", "no field", "does not exist")
+
+
+def _failure_response(model: str, method: str, error_msg: str, start_time: float) -> ExecuteMethodResponse:
+    """Wrap an Odoo error with a pattern-matched suggestion and a schema hint."""
+    suggestion = get_error_suggestion(error_msg, model, method)
+    hint = None
+    if any(p in error_msg.lower() for p in _FIELD_ERROR_PATTERNS):
+        hint = (
+            f"Field name error detected. Read odoo://model/{model}/fields to get exact field names, "
+            f"or odoo://model/{model}/schema for full details."
+        )
+    elif suggestion:
+        hint = f"Check odoo://methods/{model} or odoo://module-knowledge for special methods"
+    return ExecuteMethodResponse(
+        success=False,
+        error=error_msg,
+        suggestion=suggestion,
+        hint=hint,
+        execution_time_ms=_elapsed_ms(start_time),
+    )
 
 
 # ----- MCP Tools (execute_method, batch_execute, execute_workflow, configure_odoo, read_resource) -----
@@ -237,7 +605,6 @@ def execute_method(
     """
     start_time = time.time()
 
-    # Validate model and method names
     model_err = _validate_model(model)
     if model_err:
         return ExecuteMethodResponse(success=False, error=model_err, execution_time_ms=0)
@@ -245,314 +612,45 @@ def execute_method(
     if method_err:
         return ExecuteMethodResponse(success=False, error=method_err, execution_time_ms=0)
 
-    # Read-only kill-switch (MCP_READ_ONLY / MCP_SAFETY_MODE=locked).
-    # Runs before the classifier — cheap pattern match, no Odoo round-trip.
-    profile = get_profile()
-    if profile.read_only and is_side_effect_method(method):
+    # Read-only kill-switch — cheap set lookup, runs before the classifier and any round-trip.
+    if get_profile().read_only and is_side_effect_method(method):
         return ExecuteMethodResponse(
             success=False,
-            error=(
-                f"read-only mode is active: '{method}' on '{model}' is a "
-                f"side-effect operation. Set MCP_READ_ONLY=false to enable "
-                f"writes (or change MCP_SAFETY_MODE away from 'locked' if "
-                f"MCP_READ_ONLY is not set explicitly)."
-            ),
-            execution_time_ms=int((time.time() - start_time) * 1000),
+            error=_read_only_error(f"'{method}' on '{model}' is a side-effect operation"),
+            execution_time_ms=_elapsed_ms(start_time),
         )
 
     odoo = get_odoo_client()
+    # Runs outside the try below on purpose: _parse_json_args reports malformed input
+    # as a response and must never raise (json errors are caught inside it and
+    # _merge_context swallows its own). Keep that invariant if you touch either.
+    args, kwargs, parse_err = _parse_json_args(args_json, kwargs_json)
+    if parse_err:
+        return ExecuteMethodResponse(success=False, error=parse_err)
 
     try:
-        args = []
-        kwargs = {}
-
-        if args_json:
-            try:
-                args = json.loads(args_json)
-                if not isinstance(args, list):
-                    return ExecuteMethodResponse(success=False, error="args_json must be a JSON array")
-            except json.JSONDecodeError as e:
-                return ExecuteMethodResponse(success=False, error=f"Invalid args_json: {e}")
-
-        if kwargs_json:
-            try:
-                kwargs = json.loads(kwargs_json)
-                if not isinstance(kwargs, dict):
-                    return ExecuteMethodResponse(success=False, error="kwargs_json must be a JSON object")
-            except json.JSONDecodeError as e:
-                return ExecuteMethodResponse(success=False, error=f"Invalid kwargs_json: {e}")
-
-        # Merge default context if configured (no-op when env var unset)
-        merged_ctx = _merge_context(kwargs.get("context"))
-        if merged_ctx is not None:
-            kwargs["context"] = merged_ctx
-
-        # --- resolve_json: auto-resolve Many2one names to IDs ---
         if resolve_json:
-            try:
-                resolves = json.loads(resolve_json)
-                if not isinstance(resolves, dict):
-                    return ExecuteMethodResponse(success=False, error="resolve_json must be a JSON object")
-            except json.JSONDecodeError as e:
-                return ExecuteMethodResponse(success=False, error=f"Invalid resolve_json: {e}")
+            args, failure = _resolve_many2one_names(odoo, resolve_json, method, args, start_time)
+            if failure:
+                return failure
 
-            resolved_values = {}
-            for field_name, spec in resolves.items():
-                target_model = spec.get("model")
-                search_term = spec.get("search")
-                if not target_model or not search_term:
-                    return ExecuteMethodResponse(
-                        success=False,
-                        error=f"resolve_json['{field_name}'] requires 'model' and 'search' keys",
-                    )
-                # Validate target model name format
-                model_err = _validate_model(target_model)
-                if model_err:
-                    return ExecuteMethodResponse(
-                        success=False,
-                        error=f"resolve_json['{field_name}']: {model_err}",
-                    )
-                # Block reads against security-critical models
-                if target_model in BLOCKED_MODELS:
-                    return ExecuteMethodResponse(
-                        success=False,
-                        error=f"resolve_json['{field_name}']: model '{target_model}' is blocked for safety.",
-                    )
-                try:
-                    matches = odoo.execute_method(target_model, "name_search", name=search_term, limit=5)
-                    if not matches:
-                        elapsed_ms = (time.time() - start_time) * 1000
-                        return ExecuteMethodResponse(
-                            success=False,
-                            error=f"resolve_json: No match for '{search_term}' in {target_model}",
-                            hint=f"Search {target_model} manually to find the correct record",
-                            execution_time_ms=round(elapsed_ms, 2),
-                        )
-                    if len(matches) > 1:
-                        options = [f"  {m[0]}: {m[1]}" for m in matches[:5]]
-                        elapsed_ms = (time.time() - start_time) * 1000
-                        return ExecuteMethodResponse(
-                            success=False,
-                            error=f"resolve_json: Ambiguous match for '{search_term}' in {target_model} ({len(matches)} results)",
-                            hint="Multiple matches found:\n"
-                            + "\n".join(options)
-                            + "\nUse the numeric ID directly instead.",
-                            execution_time_ms=round(elapsed_ms, 2),
-                        )
-                    resolved_values[field_name] = matches[0][0]  # Use the ID
-                except Exception as e:
-                    elapsed_ms = (time.time() - start_time) * 1000
-                    return ExecuteMethodResponse(
-                        success=False,
-                        error=f"resolve_json: Failed to resolve '{field_name}': {e}",
-                        execution_time_ms=round(elapsed_ms, 2),
-                    )
+        rejected = _reject_private_method(model, method, start_time)
+        if rejected:
+            return rejected
 
-            # Inject resolved IDs into args (for write/create methods)
-            if resolved_values and args:
-                if method == "write" and len(args) >= 2 and isinstance(args[1], dict):
-                    args[1].update(resolved_values)
-                elif method == "create":
-                    if isinstance(args[0], dict):
-                        args[0].update(resolved_values)
-                    elif isinstance(args[0], list):
-                        for vals in args[0]:
-                            if isinstance(vals, dict):
-                                vals.update(resolved_values)
+        gated = _classify_and_gate(odoo, model, method, args, kwargs, confirmed, confirmation_token, start_time)
+        if gated:
+            return gated
 
-        # Static fallback check for known private methods
-        if method in PRIVATE_METHOD_HINTS:
-            elapsed_ms = (time.time() - start_time) * 1000
-            return ExecuteMethodResponse(
-                success=False,
-                error=f"Method '{method}' is @api.private and cannot be called via RPC.",
-                hint=PRIVATE_METHOD_HINTS[method],
-                execution_time_ms=round(elapsed_ms, 2),
-            )
-
-        # Dynamic check: if method starts with _ and live doc confirms it's not public
-        if method.startswith("_"):
-            live_doc = _get_live_doc(model)
-            if live_doc and method not in live_doc.get("methods", {}):
-                elapsed_ms = (time.time() - start_time) * 1000
-                return ExecuteMethodResponse(
-                    success=False,
-                    error=f"Method '{method}' is not a public method on {model}. It may be @api.private or doesn't exist.",
-                    hint=f"Use odoo://methods/{model} to see available public methods.",
-                    execution_time_ms=round(elapsed_ms, 2),
-                )
-
-        # --- Safety Classification ---
-        classification = classify_operation(model, method, args, kwargs, role=current_role())
-
-        if classification.risk_level == RiskLevel.BLOCKED:
-            audit_log(classification, confirmed=confirmed, executed=False)
-            elapsed_ms = (time.time() - start_time) * 1000
-            return ExecuteMethodResponse(
-                success=False,
-                pending_confirmation=True,
-                safety=classification,
-                error=classification.blocked_reason,
-                hint="Use the Odoo web interface instead.",
-                execution_time_ms=round(elapsed_ms, 2),
-            )
-
-        if classification.requires_confirmation:
-            # Phase 2: payload pre-flight against live fields_get.
-            # Only when the profile asks for it AND this is a write-shaped call.
-            if get_profile().validate_payloads and is_side_effect_method(method):
-                from .safety import validate_payload_against_schema as _validate_payload
-
-                _validation = _validate_payload(
-                    odoo,
-                    model,
-                    method,
-                    args=args,
-                    kwargs=kwargs,
-                )
-                if not _validation.ok:
-                    elapsed_ms = (time.time() - start_time) * 1000
-                    return ExecuteMethodResponse(
-                        success=False,
-                        error="Payload validation failed:\n  - " + "\n  - ".join(_validation.errors),
-                        hint=f"Read odoo://model/{model}/quick-schema for the field list.",
-                        execution_time_ms=round(elapsed_ms, 2),
-                    )
-
-            # Bind the token to the exact (model, method, args, kwargs) seen here.
-            # Args/kwargs are post-resolve_json and post-context-merge, so the digest
-            # captures what would actually be sent to Odoo.
-            payload = _payload_digest({"args": args, "kwargs": kwargs})
-            if not confirmed:
-                token = _issue_confirmation_token(model, method, payload)
-                audit_log(classification, confirmed=False, executed=False)
-                message = classification.reason
-                if classification.cascade_warning:
-                    message += f"\n\nWARNING: {classification.cascade_warning}"
-                elapsed_ms = (time.time() - start_time) * 1000
-                return ExecuteMethodResponse(
-                    success=False,
-                    pending_confirmation=True,
-                    safety=classification,
-                    error=message,
-                    hint=f"Re-call execute_method with confirmed=true and confirmation_token='{token}' to proceed.",
-                    execution_time_ms=round(elapsed_ms, 2),
-                )
-            else:
-                # Validate the confirmation token (must match model+method+payload digest)
-                token_err = _validate_confirmation_token(confirmation_token, model, method, payload)
-                if token_err:
-                    elapsed_ms = (time.time() - start_time) * 1000
-                    return ExecuteMethodResponse(
-                        success=False,
-                        error=f"Confirmation rejected: {token_err}",
-                        execution_time_ms=round(elapsed_ms, 2),
-                    )
-
-        if classification.risk_level != RiskLevel.SAFE:
-            audit_log(classification, confirmed=confirmed, executed=True)
-
-        # Apply smart limits for search methods
-        if method in ["search", "search_read"] and "limit" not in kwargs:
-            kwargs["limit"] = DEFAULT_LIMIT
-            logger.debug("Applied default limit=%d", DEFAULT_LIMIT)
-        elif method in ["search", "search_read"] and kwargs.get("limit", 0) > MAX_LIMIT:
-            kwargs["limit"] = MAX_LIMIT
-            logger.debug("Capped limit to %d", MAX_LIMIT)
-
-        # Normalize domain if needed
-        if method in ["search", "search_read", "search_count"] and args:
-            domain = args[0]
-            # Handle double-wrapped domains [[domain]]
-            if isinstance(domain, list) and len(domain) == 1 and isinstance(domain[0], list):
-                if domain[0] and isinstance(domain[0][0], list):
-                    args[0] = domain[0]
-
+        args, kwargs = _apply_search_defaults(method, args, kwargs)
         result = odoo.execute_method(model, method, *args, **kwargs)
-        elapsed_ms = (time.time() - start_time) * 1000
-        return ExecuteMethodResponse(success=True, result=result, execution_time_ms=round(elapsed_ms, 2))
+        return ExecuteMethodResponse(success=True, result=result, execution_time_ms=_elapsed_ms(start_time))
 
     except Exception as e:
         error_msg = str(e)
-
-        # Fallback for search_read failures (500 errors): try search + read
         if method == "search_read" and ("500" in error_msg or "Internal Server Error" in error_msg):
-            try:
-                # Extract parameters from kwargs
-                domain = kwargs.get("domain", [])
-                fields = kwargs.get("fields", [])
-                limit = kwargs.get("limit", 100)
-                offset = kwargs.get("offset", 0)
-                order = kwargs.get("order")
-                context = kwargs.get("context")
-
-                # Step 1: search for IDs
-                search_kwargs = {"domain": domain, "limit": limit, "offset": offset}
-                if order:
-                    search_kwargs["order"] = order
-                if context:
-                    search_kwargs["context"] = context
-                ids = odoo.execute_method(model, "search", **search_kwargs)
-
-                # Step 2: read the records
-                if ids:
-                    read_kwargs = {}
-                    if fields:
-                        read_kwargs["fields"] = fields
-                    if context:
-                        read_kwargs["context"] = context
-                    result = odoo.execute_method(model, "read", ids, **read_kwargs)
-                else:
-                    result = []
-
-                # Track this model/method as problematic (runtime detection)
-                analysis = _track_model_issue(model, method, error_msg, domain=domain, fields=fields)
-
-                elapsed_ms = (time.time() - start_time) * 1000
-                return ExecuteMethodResponse(
-                    success=True,
-                    result=result,
-                    fallback_used=True,
-                    issue_analysis=IssueAnalysis(
-                        category=analysis["category"],
-                        cause=analysis["cause"],
-                        domain_patterns=analysis["domain_patterns"],
-                        problematic_fields=analysis.get("problematic_fields", []),
-                        suggested_solutions=analysis["solutions"][:2],
-                        model_specific_advice=analysis.get("model_specific_advice", []),
-                    ),
-                    note=f"Fallback search+read used. Cause: {analysis['cause']}",
-                    execution_time_ms=round(elapsed_ms, 2),
-                )
-            except Exception as fallback_error:
-                # If fallback also fails, include both errors
-                elapsed_ms = (time.time() - start_time) * 1000
-                return ExecuteMethodResponse(
-                    success=False,
-                    error=f"{error_msg}; Fallback also failed: {fallback_error}",
-                    suggestion="Both search_read and fallback search+read failed. Check odoo://model-limitations for known issues.",
-                    execution_time_ms=round(elapsed_ms, 2),
-                )
-
-        suggestion = get_error_suggestion(error_msg, model, method)
-        elapsed_ms = (time.time() - start_time) * 1000
-
-        # Auto-suggest schema introspection for field-related errors
-        hint = None
-        field_error_patterns = ["invalid field", "unknown field", "field_get", "keyerror", "no field", "does not exist"]
-        error_lower = error_msg.lower()
-        if any(p in error_lower for p in field_error_patterns):
-            hint = f"Field name error detected. Read odoo://model/{model}/fields to get exact field names, or odoo://model/{model}/schema for full details."
-        elif suggestion:
-            hint = f"Check odoo://methods/{model} or odoo://module-knowledge for special methods"
-
-        return ExecuteMethodResponse(
-            success=False,
-            error=error_msg,
-            suggestion=suggestion,
-            hint=hint,
-            execution_time_ms=round(elapsed_ms, 2),
-        )
+            return _search_read_fallback(odoo, model, kwargs, error_msg, start_time)
+        return _failure_response(model, method, error_msg, start_time)
 
 
 @mcp.tool(
@@ -600,12 +698,8 @@ async def batch_execute(
             if is_side_effect_method(method):
                 return BatchExecuteResponse(
                     success=False,
-                    error=(
-                        f"read-only mode is active: batch contains side-effect "
-                        f"operation '{method}' on '{op.get('model', '?')}'. "
-                        f"Set MCP_READ_ONLY=false to enable writes (or change "
-                        f"MCP_SAFETY_MODE away from 'locked' if MCP_READ_ONLY "
-                        f"is not set explicitly)."
+                    error=_read_only_error(
+                        f"batch contains side-effect operation '{method}' on '{op.get('model', '?')}'"
                     ),
                     results=[],
                     total_operations=len(operations),
@@ -649,9 +743,8 @@ async def batch_execute(
     if any_needs_confirmation:
         # Bind the token to the exact list of operations. Substituting any op (or even
         # a single arg within an op) on the re-call produces a different digest.
-        batch_payload = _payload_digest(operations)
-        if not confirmed:
-            token = _issue_confirmation_token("__batch__", "batch", batch_payload)
+        decision = _confirmation_gate("__batch__", "batch", operations, confirmed, confirmation_token)
+        if decision.outcome == "issue":
             for c in classifications:
                 if c.requires_confirmation:
                     audit_log(c, confirmed=False, executed=False)
@@ -662,25 +755,22 @@ async def batch_execute(
                 total_operations=len(operations),
                 successful_operations=0,
                 failed_operations=0,
-                error=f"Batch contains operations that require confirmation. Review safety_preview and re-call with confirmed=true and confirmation_token='{token}'.",
+                error=f"Batch contains operations that require confirmation. Review safety_preview and re-call with confirmed=true and confirmation_token='{decision.token}'.",
                 pending_confirmation=True,
                 safety_preview=classifications,
                 overall_risk=overall_risk.value,
                 execution_time_ms=round(elapsed_ms, 2),
             )
-        else:
-            token_err = _validate_confirmation_token(confirmation_token, "__batch__", "batch", batch_payload)
-            if token_err:
-                elapsed_ms = (time.time() - start_time) * 1000
-                return BatchExecuteResponse(
-                    success=False,
-                    results=[],
-                    total_operations=len(operations),
-                    successful_operations=0,
-                    failed_operations=0,
-                    error=f"Confirmation rejected: {token_err}",
-                    execution_time_ms=round(elapsed_ms, 2),
-                )
+        if decision.outcome == "reject":
+            return BatchExecuteResponse(
+                success=False,
+                results=[],
+                total_operations=len(operations),
+                successful_operations=0,
+                failed_operations=0,
+                error=decision.error,
+                execution_time_ms=_elapsed_ms(start_time),
+            )
 
     # Audit non-safe operations that will proceed
     for c in classifications:
@@ -719,7 +809,7 @@ async def batch_execute(
                 if merged_ctx is not None:
                     kwargs["context"] = merged_ctx
 
-                result = odoo.execute_method(model, method, *args, **kwargs)
+                result = await _run_blocking(odoo.execute_method, model, method, *args, **kwargs)
                 results.append(BatchOperationResult(operation_index=idx, success=True, result=result))
                 successful += 1
 
@@ -950,18 +1040,11 @@ async def execute_workflow(
     start_time = time.time()
 
     # Read-only kill-switch — workflows are by definition multi-step actions.
-    profile = get_profile()
-    if profile.read_only:
+    if get_profile().read_only:
         return ExecuteWorkflowResponse(
             workflow=workflow,
             success=False,
-            error=(
-                f"read-only mode is active: workflow '{workflow}' is a "
-                f"multi-step action and is rejected under MCP_READ_ONLY=true. "
-                f"Set MCP_READ_ONLY=false to enable workflows (or change "
-                f"MCP_SAFETY_MODE away from 'locked' if MCP_READ_ONLY is "
-                f"not set explicitly)."
-            ),
+            error=_read_only_error(f"workflow '{workflow}' is a multi-step action"),
         )
 
     # Get Odoo client directly (works in both sync and background task modes)
@@ -982,9 +1065,8 @@ async def execute_workflow(
         # Bind the token to (workflow_name, params). A different order_id or partner_id
         # on the re-call produces a different digest and is rejected.
         workflow_key = workflow.lower().strip()
-        wf_payload = _payload_digest(params)
-        if not confirmed:
-            token = _issue_confirmation_token("__workflow__", workflow_key, wf_payload)
+        decision = _confirmation_gate("__workflow__", workflow_key, params, confirmed, confirmation_token)
+        if decision.outcome == "issue":
             elapsed_ms = (time.time() - start_time) * 1000
             return ExecuteWorkflowResponse(
                 workflow=workflow,
@@ -1004,19 +1086,19 @@ async def execute_workflow(
                 ],
                 overall_risk=safety_preview.overall_risk.value,
                 error=safety_preview.message,
-                tip=f"Re-call execute_workflow with confirmed=true and confirmation_token='{token}' to proceed.",
+                tip=(
+                    f"Re-call execute_workflow with confirmed=true and "
+                    f"confirmation_token='{decision.token}' to proceed."
+                ),
                 execution_time_ms=round(elapsed_ms, 2),
             )
-        else:
-            token_err = _validate_confirmation_token(confirmation_token, "__workflow__", workflow_key, wf_payload)
-            if token_err:
-                elapsed_ms = (time.time() - start_time) * 1000
-                return ExecuteWorkflowResponse(
-                    workflow=workflow,
-                    success=False,
-                    error=f"Confirmation rejected: {token_err}",
-                    execution_time_ms=round(elapsed_ms, 2),
-                )
+        if decision.outcome == "reject":
+            return ExecuteWorkflowResponse(
+                workflow=workflow,
+                success=False,
+                error=decision.error,
+                execution_time_ms=_elapsed_ms(start_time),
+            )
 
     workflow_lower = workflow.lower().strip()
     steps: List[WorkflowStepResult] = []
@@ -1039,10 +1121,16 @@ async def execute_workflow(
             # Step 1: Convert to opportunity (if still a lead)
             await progress.set_message("Converting lead to opportunity...")
             try:
-                lead = odoo.search_read("crm.lead", [["id", "=", lead_id]], fields=["type"], limit=1)
+                lead = await _run_blocking(
+                    odoo.search_read, "crm.lead", [["id", "=", lead_id]], fields=["type"], limit=1
+                )
                 if lead and lead[0].get("type") == "lead":
-                    odoo.execute_method(
-                        "crm.lead", "convert_opportunity", [lead_id], partner_id=params.get("partner_id", False)
+                    await _run_blocking(
+                        odoo.execute_method,
+                        "crm.lead",
+                        "convert_opportunity",
+                        [lead_id],
+                        partner_id=params.get("partner_id", False),
                     )
                     steps.append(WorkflowStepResult(step="convert_to_opportunity", success=True))
                 else:
@@ -1058,7 +1146,7 @@ async def execute_workflow(
             # Step 2: Mark as won
             await progress.set_message("Marking opportunity as won...")
             try:
-                odoo.execute_method("crm.lead", "action_set_won", [lead_id])
+                await _run_blocking(odoo.execute_method, "crm.lead", "action_set_won", [lead_id])
                 steps.append(WorkflowStepResult(step="mark_won", success=True))
             except Exception as e:
                 steps.append(WorkflowStepResult(step="mark_won", success=False, error=str(e)))
@@ -1118,7 +1206,7 @@ async def execute_workflow(
                     "partner_id": partner_id,
                     "invoice_line_ids": invoice_lines,
                 }
-                invoice_id = odoo.execute_method("account.move", "create", [invoice_vals])
+                invoice_id = await _run_blocking(odoo.execute_method, "account.move", "create", [invoice_vals])
                 steps.append(WorkflowStepResult(step="create_invoice", success=True, result={"invoice_id": invoice_id}))
             except Exception as e:
                 steps.append(WorkflowStepResult(step="create_invoice", success=False, error=str(e)))
@@ -1135,7 +1223,7 @@ async def execute_workflow(
             await progress.set_message("Posting invoice...")
             if params.get("post", True):
                 try:
-                    odoo.execute_method("account.move", "action_post", [invoice_id])
+                    await _run_blocking(odoo.execute_method, "account.move", "action_post", [invoice_id])
                     steps.append(WorkflowStepResult(step="post_invoice", success=True))
                 except Exception as e:
                     steps.append(WorkflowStepResult(step="post_invoice", success=False, error=str(e)))

--- a/src/odoo_mcp/utils.py
+++ b/src/odoo_mcp/utils.py
@@ -12,7 +12,7 @@ import threading
 import time
 from collections import OrderedDict
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, cast
 
 from .constants import (
     _DOC_CACHE,
@@ -426,35 +426,74 @@ def _get_documentation_urls(target: str) -> str:
     return json.dumps(result, indent=2)
 
 
-# ----- Live fields_get cache (used by payload pre-flight) -----
+# ----- Live fields_get cache (shared by the schema resources and the payload pre-flight) -----
 
-_FIELDS_CACHE: "OrderedDict[str, tuple[float, dict]]" = OrderedDict()
+# key: (client url, client username, model, attributes tuple | None) → (fetched_at, fields)
+# The client identity is part of the key because fields_get is filtered by the
+# caller's access rights — in multi-user mode two users must never share an entry.
+_FieldsCacheKey = tuple[Any, Any, str, tuple[str, ...] | None]
+_FIELDS_CACHE: "OrderedDict[_FieldsCacheKey, tuple[float, dict]]" = OrderedDict()
 _FIELDS_CACHE_LOCK = threading.Lock()
 _FIELDS_CACHE_TTL = 60  # seconds — shorter than _DOC_CACHE since model
 # schemas can change with module updates
 _FIELDS_CACHE_MAX = 100
 
 
-def get_fields_for_model(client, model: str) -> dict:
+def fields_cache_key(client: Any, model: str, attributes: Sequence[str] | None = None) -> _FieldsCacheKey:
+    """Build the cache key for one (client, model, attribute subset) fetch."""
+    return (
+        getattr(client, "url", None),
+        getattr(client, "username", None),
+        model,
+        tuple(attributes) if attributes else None,
+    )
+
+
+def fields_cache_get(key: _FieldsCacheKey) -> dict | None:
+    """Return the cached fields for ``key`` if present and fresh, else ``None``."""
+    now = time.time()
+    with _FIELDS_CACHE_LOCK:
+        cached = _FIELDS_CACHE.get(key)
+        if cached and (now - cached[0]) < _FIELDS_CACHE_TTL:
+            _FIELDS_CACHE.move_to_end(key)
+            return cached[1]
+    return None
+
+
+def fields_cache_put(key: _FieldsCacheKey, fields: dict) -> None:
+    """Store ``fields`` under ``key`` (LRU-bounded). Empty payloads are never cached."""
+    if not fields or not isinstance(fields, dict):
+        return
+    with _FIELDS_CACHE_LOCK:
+        _FIELDS_CACHE[key] = (time.time(), fields)
+        _FIELDS_CACHE.move_to_end(key)
+        while len(_FIELDS_CACHE) > _FIELDS_CACHE_MAX:
+            _FIELDS_CACHE.popitem(last=False)
+
+
+def get_fields_for_model(client: Any, model: str, attributes: Sequence[str] | None = None) -> dict:
     """Return the fields_get response for a model, with TTL+LRU caching.
+
+    ``attributes`` narrows the request (and the cache key) to that subset —
+    callers that only need type/required/readonly share one entry per model
+    instead of each pulling the full definition.
 
     Empty responses are NOT cached — they typically indicate a silently-failed
     Odoo connection, and we don't want to grant a write token based on
     'no fields exist therefore validation passes'.
     """
-    now = time.time()
-    with _FIELDS_CACHE_LOCK:
-        cached = _FIELDS_CACHE.get(model)
-        if cached and (now - cached[0]) < _FIELDS_CACHE_TTL:
-            _FIELDS_CACHE.move_to_end(model)
-            return cached[1]
+    key = fields_cache_key(client, model, attributes)
+    cached = fields_cache_get(key)
+    if cached is not None:
+        return cached
 
     # Cache miss or expired — fetch fresh.
     # Treat any exception (network failure, model-not-found, auth error) as
     # an empty schema — the caller's pre-flight will refuse to issue a
     # token without a verified field list, which is the safe behaviour.
+    kwargs: dict[str, Any] = {"attributes": list(attributes)} if attributes else {}
     try:
-        fields = client.execute_method(model, "fields_get")
+        fields = client.execute_method(model, "fields_get", **kwargs)
     except Exception as exc:
         logger.warning("fields_get for %r failed: %s", model, exc)
         return {}
@@ -464,9 +503,5 @@ def get_fields_for_model(client, model: str) -> dict:
         # want to remember a failure.
         return {}
 
-    with _FIELDS_CACHE_LOCK:
-        _FIELDS_CACHE[model] = (now, fields)
-        _FIELDS_CACHE.move_to_end(model)
-        while len(_FIELDS_CACHE) > _FIELDS_CACHE_MAX:
-            _FIELDS_CACHE.popitem(last=False)
-    return fields
+    fields_cache_put(key, fields)
+    return cast(dict, fields)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,3 +129,15 @@ def users_db_seed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> RegistrySe
     conn.commit()
     conn.close()
     return seed
+
+
+@pytest.fixture(autouse=True)
+def _clear_fields_cache():
+    """The live fields_get cache is process-global; never let one test feed another."""
+    from odoo_mcp.utils import _FIELDS_CACHE, _FIELDS_CACHE_LOCK
+
+    with _FIELDS_CACHE_LOCK:
+        _FIELDS_CACHE.clear()
+    yield
+    with _FIELDS_CACHE_LOCK:
+        _FIELDS_CACHE.clear()

--- a/tests/test_event_loop_offload.py
+++ b/tests/test_event_loop_offload.py
@@ -1,0 +1,173 @@
+"""Pin that blocking Odoo round-trips never run on the event-loop thread.
+
+FastMCP 3.x dispatches handlers three different ways:
+
+* sync ``@mcp.tool`` and *static* ``@mcp.resource`` bodies run in the anyio
+  worker threadpool (non-blocking);
+* *template* resources (``odoo://model/{model_name}/...``) whose body is a
+  plain sync function are called **inline on the loop** by
+  ``FunctionResourceTemplate.read`` — one slow ``fields_get`` freezes every
+  session, ping included;
+* ``async def`` tools that call the synchronous ``requests``-based
+  ``OdooClient`` block the loop for the whole call.
+
+The fixes register every parameterized resource as an ``async`` wrapper that
+offloads the sync body, and route the Odoo calls inside ``batch_execute`` /
+``execute_workflow`` through ``anyio.to_thread``. These tests fail loudly if a
+future resource or tool regresses to loop-blocking dispatch.
+
+No live Odoo: ``get_odoo_client`` is patched with a stub that records the
+thread it was called from.
+"""
+
+import asyncio
+import inspect
+import json
+import re
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp import Client
+
+import odoo_mcp.resources as resources
+import odoo_mcp.server as server
+from odoo_mcp.app import mcp
+
+_FIELDS = {
+    "id": {"type": "integer", "readonly": True},
+    "name": {"type": "char", "required": True},
+}
+
+
+def _recording_client(record: dict, **method_returns):
+    """Stub OdooClient whose calls note the thread they ran on."""
+    client = MagicMock()
+
+    def _make(name, value):
+        def _call(*args, **kwargs):
+            record.setdefault(name, []).append(threading.get_ident())
+            return value
+
+        return _call
+
+    for name, value in method_returns.items():
+        getattr(client, name).side_effect = _make(name, value)
+    return client
+
+
+def _token_from(text: str) -> str:
+    match = re.search(r"confirmation_token='([^']+)'", text or "")
+    assert match, f"no confirmation token in: {text!r}"
+    return match.group(1)
+
+
+# ----- template resources -----
+
+
+def test_every_resource_template_is_registered_as_coroutine():
+    """Only a coroutine template escapes FunctionResourceTemplate's inline call."""
+    templates = asyncio.run(mcp.list_resource_templates(run_middleware=False))
+    assert templates, "expected registered resource templates"
+    blocking = [t.uri_template for t in templates if not inspect.iscoroutinefunction(t.fn)]
+    assert blocking == [], f"sync template bodies run on the event loop: {blocking}"
+
+
+def test_template_resource_read_runs_odoo_call_off_loop_thread():
+    record: dict = {}
+    stub = _recording_client(record, get_model_fields=_FIELDS)
+
+    async def _read():
+        async with Client(mcp) as client:
+            contents = await client.read_resource("odoo://model/res.partner/quick-schema")
+        return threading.get_ident(), contents
+
+    with patch.object(resources, "get_odoo_client", return_value=stub):
+        loop_thread, contents = asyncio.run(_read())
+
+    assert record["get_model_fields"], "fields_get was never called"
+    assert all(tid != loop_thread for tid in record["get_model_fields"])
+    payload = json.loads(contents[0].text)
+    assert payload["model"] == "res.partner"
+    assert payload["fields"]["name"]["req"] is True
+
+
+def test_template_wrapper_returns_same_payload_as_sync_body():
+    """The async registration must be a pure offload — no behaviour drift."""
+    stub = _recording_client({}, get_model_fields=_FIELDS)
+
+    async def _read():
+        async with Client(mcp) as client:
+            contents = await client.read_resource("odoo://model/res.partner/fields")
+        return contents[0].text
+
+    with patch.object(resources, "get_odoo_client", return_value=stub):
+        via_mcp = asyncio.run(_read())
+        direct = resources.get_model_fields_light("res.partner")
+
+    assert json.loads(via_mcp) == json.loads(direct)
+
+
+# ----- async tools -----
+
+
+def test_batch_execute_runs_odoo_calls_off_loop_thread(monkeypatch):
+    monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+    record: dict = {}
+    stub = _recording_client(record, execute_method=[{"id": 1, "name": "A"}])
+
+    async def _run():
+        response = await server.batch_execute(
+            operations=[
+                {"model": "res.partner", "method": "search_read", "kwargs_json": '{"fields": ["name"]}'},
+                {"model": "res.partner", "method": "search_count", "kwargs_json": "{}"},
+            ],
+            progress=AsyncMock(),
+        )
+        return threading.get_ident(), response
+
+    with patch.object(server, "get_odoo_client", return_value=stub):
+        loop_thread, response = asyncio.run(_run())
+
+    assert response.success is True, response.error
+    assert len(record["execute_method"]) == 2
+    assert all(tid != loop_thread for tid in record["execute_method"])
+
+
+def test_execute_workflow_runs_odoo_calls_off_loop_thread(monkeypatch):
+    monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+    monkeypatch.setenv("MCP_SAFETY_MODE", "strict")
+    record: dict = {}
+    stub = _recording_client(
+        record,
+        search_read=[{"id": 7, "type": "opportunity"}],
+        execute_method=True,
+    )
+
+    async def _run():
+        first = await server.execute_workflow(
+            workflow="lead_to_won", params_json='{"lead_id": 7}', progress=AsyncMock()
+        )
+        if first.pending_confirmation:
+            first = await server.execute_workflow(
+                workflow="lead_to_won",
+                params_json='{"lead_id": 7}',
+                confirmed=True,
+                confirmation_token=_token_from(first.tip),
+                progress=AsyncMock(),
+            )
+        return threading.get_ident(), first
+
+    with patch.object(server, "get_odoo_client", return_value=stub):
+        loop_thread, response = asyncio.run(_run())
+
+    assert response.success is True, response.error
+    called = record.get("search_read", []) + record.get("execute_method", [])
+    assert called, "workflow made no Odoo call"
+    assert all(tid != loop_thread for tid in called)
+
+
+@pytest.mark.parametrize("tool", [server.batch_execute, server.execute_workflow])
+def test_async_tools_stay_async(tool):
+    """Guard against 'fixing' the blocking by turning the task tools sync."""
+    assert inspect.iscoroutinefunction(tool)

--- a/tests/test_event_loop_offload.py
+++ b/tests/test_event_loop_offload.py
@@ -25,11 +25,13 @@ import inspect
 import json
 import re
 import threading
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp import Client
 
+import odoo_mcp.app as app
 import odoo_mcp.resources as resources
 import odoo_mcp.server as server
 from odoo_mcp.app import mcp
@@ -54,6 +56,21 @@ def _recording_client(record: dict, **method_returns):
     for name, value in method_returns.items():
         getattr(client, name).side_effect = _make(name, value)
     return client
+
+
+@contextmanager
+def _stubbed(stub):
+    """Serve ``stub`` to the resource handlers *and* to the FastMCP lifespan.
+
+    ``Client(mcp)`` runs ``app_lifespan``, which builds the env client at
+    startup; patching only ``resources`` would make these tests depend on a
+    real ODOO_* config (CI deliberately has none).
+    """
+    with (
+        patch.object(resources, "get_odoo_client", return_value=stub),
+        patch.object(app, "get_odoo_client", return_value=stub),
+    ):
+        yield
 
 
 def _token_from(text: str) -> str:
@@ -82,7 +99,7 @@ def test_template_resource_read_runs_odoo_call_off_loop_thread():
             contents = await client.read_resource("odoo://model/res.partner/quick-schema")
         return threading.get_ident(), contents
 
-    with patch.object(resources, "get_odoo_client", return_value=stub):
+    with _stubbed(stub):
         loop_thread, contents = asyncio.run(_read())
 
     assert record["get_model_fields"], "fields_get was never called"
@@ -101,7 +118,7 @@ def test_template_wrapper_returns_same_payload_as_sync_body():
             contents = await client.read_resource("odoo://model/res.partner/fields")
         return contents[0].text
 
-    with patch.object(resources, "get_odoo_client", return_value=stub):
+    with _stubbed(stub):
         via_mcp = asyncio.run(_read())
         direct = resources.get_model_fields_light("res.partner")
 

--- a/tests/test_fields_cache.py
+++ b/tests/test_fields_cache.py
@@ -84,3 +84,42 @@ def test_lru_eviction():
 
     with _FIELDS_CACHE_LOCK:
         assert len(_FIELDS_CACHE) <= 100
+
+
+# ----- attribute-scoped and client-scoped keys -----
+
+
+def test_attributes_are_forwarded_on_cache_miss():
+    client = MagicMock()
+    client.execute_method.return_value = {"name": {"type": "char"}}
+
+    get_fields_for_model(client, "res.partner", attributes=("type", "required"))
+
+    assert client.execute_method.call_args.kwargs == {"attributes": ["type", "required"]}
+
+
+def test_different_attribute_sets_are_cached_separately():
+    """A compact fetch must never be served for a request that needs the full definition."""
+    client = MagicMock()
+    client.execute_method.return_value = {"name": {"type": "char"}}
+
+    get_fields_for_model(client, "res.partner", attributes=("type",))
+    get_fields_for_model(client, "res.partner")
+    get_fields_for_model(client, "res.partner", attributes=("type",))
+
+    assert client.execute_method.call_count == 2
+
+
+def test_cache_is_scoped_per_client_identity():
+    """fields_get depends on the caller's access rights; users must not share entries."""
+    alice = MagicMock(url="https://erp.example.com", username="alice")
+    bob = MagicMock(url="https://erp.example.com", username="bob")
+    alice.execute_method.return_value = {"name": {"type": "char"}}
+    bob.execute_method.return_value = {"name": {"type": "char"}}
+
+    get_fields_for_model(alice, "res.partner")
+    get_fields_for_model(bob, "res.partner")
+    get_fields_for_model(alice, "res.partner")
+
+    assert alice.execute_method.call_count == 1
+    assert bob.execute_method.call_count == 1

--- a/tests/test_odoo_client.py
+++ b/tests/test_odoo_client.py
@@ -109,3 +109,31 @@ class TestErrorBodyNeverLeaksTraceback:
 
         assert "Invalid apikey" in str(exc.value)
         assert "SECRET_INTERNALS" not in str(exc.value)
+
+
+class TestFieldsGetAttributes:
+    """``get_model_fields`` narrows the request when an attribute subset is given.
+
+    A full ``fields_get`` on a big model is ~300 KB; the compact schema views only
+    read a handful of attributes, so forwarding ``attributes`` to JSON-2 is what
+    makes ``odoo://bundle`` and ``session-bootstrap`` cheap.
+    """
+
+    def test_attributes_are_forwarded_to_fields_get(self):
+        client = _make_client()
+        client.session = MagicMock()
+        client.session.post.return_value = _stub_response({"name": {"type": "char"}})
+
+        client.get_model_fields("res.partner", attributes=["type", "required"])
+
+        payload = client.session.post.call_args.kwargs["json"]
+        assert payload == {"attributes": ["type", "required"]}
+
+    def test_no_attributes_requests_the_full_definition(self):
+        client = _make_client()
+        client.session = MagicMock()
+        client.session.post.return_value = _stub_response({"name": {"type": "char"}})
+
+        client.get_model_fields("res.partner")
+
+        assert client.session.post.call_args.kwargs["json"] == {}

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -16,6 +16,8 @@ import json
 from unittest.mock import MagicMock, patch
 
 import odoo_mcp.resources as resources
+from odoo_mcp.constants import COMPACT_FIELD_ATTRIBUTES
+from odoo_mcp.safety import validate_payload_against_schema
 
 # A minimal but realistic fields_get payload for a valid model.
 _VALID_FIELDS = {
@@ -38,8 +40,12 @@ _CRYPTIC = "object has no attribute"
 def _stub_client(fields_by_model):
     """Return a MagicMock client whose get_model_fields looks up per-model."""
     client = MagicMock()
-    client.get_model_fields.side_effect = lambda model: fields_by_model[model]
+    client.get_model_fields.side_effect = lambda model, attributes=None: fields_by_model[model]
     return client
+
+
+def _attributes_requested(client) -> list:
+    return [call.kwargs.get("attributes") for call in client.get_model_fields.call_args_list]
 
 
 # ----- quick-schema -----
@@ -142,3 +148,59 @@ def test_find_model_multiword_partial_match_still_resolves():
     models = {m["model"] for m in out["all_matches"]}
     assert "res.partner" in models
     assert out["source"] == "alias-token"
+
+
+# ----- fields_get narrowing + shared cache -----
+
+
+def test_quick_schema_requests_only_compact_attributes():
+    client = _stub_client({"res.partner": _VALID_FIELDS})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        resources.get_model_quick_schema("res.partner")
+    assert _attributes_requested(client) == [list(COMPACT_FIELD_ATTRIBUTES)]
+
+
+def test_fields_light_requests_only_compact_attributes():
+    client = _stub_client({"res.partner": _VALID_FIELDS})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        resources.get_model_fields_light("res.partner")
+    assert _attributes_requested(client) == [list(COMPACT_FIELD_ATTRIBUTES)]
+
+
+def test_full_schema_requests_the_complete_definition():
+    client = _stub_client({"res.partner": _VALID_FIELDS})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        resources.get_model_schema("res.partner")
+    assert _attributes_requested(client) == [None]
+
+
+def test_repeated_quick_schema_reads_hit_the_cache():
+    client = _stub_client({"res.partner": _VALID_FIELDS})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        first = resources.get_model_quick_schema("res.partner")
+        second = resources.get_model_quick_schema("res.partner")
+    assert first == second
+    assert client.get_model_fields.call_count == 1
+
+
+def test_bundle_and_bootstrap_share_the_compact_cache_entry(monkeypatch):
+    monkeypatch.setenv("MCP_BOOTSTRAP_MODELS", "res.partner,sale.order")
+    client = _stub_client({"res.partner": _VALID_FIELDS, "sale.order": _VALID_FIELDS})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        resources.get_bundle("res.partner,sale.order")
+        resources.get_session_bootstrap()
+        resources.get_model_quick_schema("sale.order")
+    # Two models, one fetch each — bootstrap and quick-schema reuse the bundle's entries.
+    assert client.get_model_fields.call_count == 2
+    assert set(map(tuple, _attributes_requested(client))) == {tuple(COMPACT_FIELD_ATTRIBUTES)}
+
+
+def test_payload_preflight_reuses_the_quick_schema_fetch():
+    """quick-schema then a gated write must cost one fields_get, not two."""
+    client = _stub_client({"res.partner": _VALID_FIELDS})
+    client.execute_method.side_effect = AssertionError("pre-flight must not refetch fields_get")
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        resources.get_model_quick_schema("res.partner")
+        result = validate_payload_against_schema(client, "res.partner", "write", args=[[1], {"name": "X"}])
+    assert result.ok is True
+    assert client.get_model_fields.call_count == 1

--- a/tests/test_tool_execution_paths.py
+++ b/tests/test_tool_execution_paths.py
@@ -1,0 +1,408 @@
+"""Characterization tests for the execution paths of the three write-capable tools.
+
+Before the v1.17 refactor these branches had no direct unit test: the
+``resolve_json`` Many2one resolution, the ``search_read`` → ``search`` + ``read``
+fallback, the search defaults, both ``execute_workflow`` bodies and
+``batch_execute`` with ``atomic=False``. They pin the observable behaviour so the
+long functions can be split into helpers without drift.
+
+No live Odoo: ``get_odoo_client`` is patched with a stub. Tests that exercise a
+MEDIUM-risk method run in ``permissive`` mode so the token gate does not get in
+the way — the gate itself is pinned by ``test_token_gate.py``.
+"""
+
+import asyncio
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import odoo_mcp.server as server
+from odoo_mcp.constants import DEFAULT_LIMIT, MAX_LIMIT
+
+
+@pytest.fixture(autouse=True)
+def _permissive(monkeypatch):
+    monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+    monkeypatch.delenv("MCP_WRITE_ALLOWLIST", raising=False)
+    monkeypatch.delenv("MCP_VALIDATE_PAYLOADS", raising=False)
+    monkeypatch.setenv("MCP_SAFETY_MODE", "permissive")
+
+
+def _client(**side_effects):
+    client = MagicMock()
+    for name, effect in side_effects.items():
+        getattr(client, name).side_effect = effect
+    return client
+
+
+def _call(client, **kwargs):
+    with patch.object(server, "get_odoo_client", return_value=client):
+        return server.execute_method(ctx=MagicMock(), **kwargs)
+
+
+def _sent(client):
+    """(model, method, args, kwargs) of every execute_method call on the stub."""
+    return [(c.args[0], c.args[1], list(c.args[2:]), dict(c.kwargs)) for c in client.execute_method.call_args_list]
+
+
+# ----- resolve_json -----
+
+
+def _resolver(matches, executed=True):
+    def _execute(model, method, *args, **kwargs):
+        if method == "name_search":
+            return matches
+        return executed
+
+    return _client(execute_method=_execute)
+
+
+def test_resolve_json_injects_id_into_write_vals():
+    client = _resolver([[42, "Alice"]])
+    response = _call(
+        client,
+        model="res.partner",
+        method="write",
+        args_json='[[1], {"name": "X"}]',
+        resolve_json='{"country_id": {"model": "res.country", "search": "Belgium"}}',
+    )
+    assert response.success is True
+    assert ("res.country", "name_search", [], {"name": "Belgium", "limit": 5}) in _sent(client)
+    assert ("res.partner", "write", [[1], {"name": "X", "country_id": 42}], {}) in _sent(client)
+
+
+def test_resolve_json_injects_id_into_create_vals_dict_and_list():
+    client = _resolver([[42, "Alice"]])
+    single = _call(
+        client,
+        model="res.partner",
+        method="create",
+        args_json='[{"name": "X"}]',
+        resolve_json='{"country_id": {"model": "res.country", "search": "Belgium"}}',
+    )
+    batch = _call(
+        client,
+        model="res.partner",
+        method="create",
+        args_json='[[{"name": "X"}, {"name": "Y"}]]',
+        resolve_json='{"country_id": {"model": "res.country", "search": "Belgium"}}',
+    )
+    assert single.success and batch.success
+    creates = [call for call in _sent(client) if call[1] == "create"]
+    assert creates[0][2] == [{"name": "X", "country_id": 42}]
+    assert creates[1][2] == [[{"name": "X", "country_id": 42}, {"name": "Y", "country_id": 42}]]
+
+
+def test_resolve_json_no_match_reports_error_with_hint():
+    client = _resolver([])
+    response = _call(
+        client,
+        model="res.partner",
+        method="write",
+        args_json="[[1], {}]",
+        resolve_json='{"country_id": {"model": "res.country", "search": "Nowhere"}}',
+    )
+    assert response.success is False
+    assert "No match for 'Nowhere' in res.country" in response.error
+    assert "res.country" in response.hint
+    assert not [c for c in _sent(client) if c[1] == "write"]
+
+
+def test_resolve_json_ambiguous_match_lists_options():
+    client = _resolver([[1, "Belgium"], [2, "Belgium (old)"]])
+    response = _call(
+        client,
+        model="res.partner",
+        method="write",
+        args_json="[[1], {}]",
+        resolve_json='{"country_id": {"model": "res.country", "search": "Belgium"}}',
+    )
+    assert response.success is False
+    assert "Ambiguous match" in response.error
+    assert "1: Belgium" in response.hint and "2: Belgium (old)" in response.hint
+
+
+@pytest.mark.parametrize(
+    "spec, fragment",
+    [
+        ('{"country_id": {"model": "res.country"}}', "requires 'model' and 'search'"),
+        ('{"country_id": {"model": "Not A Model", "search": "x"}}', "resolve_json['country_id']"),
+        ('{"user_id": {"model": "res.users", "search": "x"}}', "blocked for safety"),
+        ('{"country_id": 5}', "requires 'model' and 'search'"),
+        ("[1, 2]", "must be a JSON object"),
+        ("{not json", "Invalid resolve_json"),
+    ],
+)
+def test_resolve_json_rejects_bad_specs_before_any_call(spec, fragment):
+    client = _resolver([[42, "x"]])
+    response = _call(client, model="res.partner", method="write", args_json="[[1], {}]", resolve_json=spec)
+    assert response.success is False
+    assert fragment in response.error
+    assert client.execute_method.call_count == 0
+
+
+def test_resolve_json_malformed_name_search_result_is_reported_as_resolve_failure():
+    """A broken name_search tuple must surface as a resolve_json error, not a generic failure."""
+    client = _resolver([[1], [2]])  # ambiguous, and each hit lacks its display name
+    response = _call(
+        client,
+        model="res.partner",
+        method="write",
+        args_json="[[1], {}]",
+        resolve_json='{"country_id": {"model": "res.country", "search": "Belgium"}}',
+    )
+    assert response.success is False
+    assert response.error.startswith("resolve_json: Failed to resolve 'country_id'")
+    assert not [c for c in _sent(client) if c[1] == "write"]
+
+
+# ----- search defaults and domain normalisation -----
+
+
+def test_search_read_gets_default_limit_and_cap():
+    client = _client(execute_method=lambda *a, **k: [])
+    _call(client, model="res.partner", method="search_read", kwargs_json='{"domain": []}')
+    _call(client, model="res.partner", method="search_read", kwargs_json='{"domain": [], "limit": 5000}')
+    limits = [call[3]["limit"] for call in _sent(client)]
+    assert limits == [DEFAULT_LIMIT, MAX_LIMIT]
+
+
+def test_double_wrapped_domain_is_unwrapped():
+    client = _client(execute_method=lambda *a, **k: 3)
+    _call(client, model="res.partner", method="search_count", args_json='[[[["name", "=", "x"]]]]')
+    assert _sent(client)[0][2] == [[["name", "=", "x"]]]
+
+
+# ----- search_read fallback -----
+
+
+def _failing_search_read(records):
+    def _execute(model, method, *args, **kwargs):
+        if method == "search_read":
+            raise ValueError("Request failed: 500 Internal Server Error for url: x")
+        if method == "search":
+            return [r["id"] for r in records]
+        if method == "read":
+            return records
+        raise AssertionError(method)
+
+    return _client(execute_method=_execute)
+
+
+def test_search_read_500_falls_back_to_search_plus_read():
+    client = _failing_search_read([{"id": 1, "name": "A"}])
+    response = _call(
+        client,
+        model="stock.move.line",
+        method="search_read",
+        kwargs_json='{"domain": [["picking_type_id", "!=", false]], "fields": ["name"], "limit": 10, "order": "id"}',
+    )
+    assert response.success is True
+    assert response.fallback_used is True
+    assert response.result == [{"id": 1, "name": "A"}]
+    assert response.issue_analysis is not None
+    assert response.note.startswith("Fallback search+read used")
+    sent = _sent(client)
+    assert (
+        "stock.move.line",
+        "search",
+        [],
+        {"domain": [["picking_type_id", "!=", False]], "limit": 10, "offset": 0, "order": "id"},
+    ) in sent
+    assert ("stock.move.line", "read", [[1]], {"fields": ["name"]}) in sent
+
+
+def test_search_read_fallback_with_no_ids_skips_read():
+    client = _failing_search_read([])
+    response = _call(client, model="res.partner", method="search_read", kwargs_json='{"domain": []}')
+    assert response.success is True and response.result == []
+    assert not [c for c in _sent(client) if c[1] == "read"]
+
+
+def test_search_read_fallback_failure_reports_both_errors():
+    def _execute(model, method, *args, **kwargs):
+        if method == "search_read":
+            raise ValueError("500 Internal Server Error")
+        raise ValueError("search also broke")
+
+    response = _call(_client(execute_method=_execute), model="res.partner", method="search_read", kwargs_json="{}")
+    assert response.success is False
+    assert "500" in response.error and "search also broke" in response.error
+    assert "model-limitations" in response.suggestion
+
+
+def test_field_error_gets_schema_hint():
+    def _execute(*a, **k):
+        raise ValueError("Invalid field 'foo' on model 'res.partner'")
+
+    response = _call(_client(execute_method=_execute), model="res.partner", method="search_read", kwargs_json="{}")
+    assert response.success is False
+    assert "odoo://model/res.partner/fields" in response.hint
+
+
+# ----- batch_execute -----
+
+
+def _batch(client, **kwargs):
+    with patch.object(server, "get_odoo_client", return_value=client):
+        return asyncio.run(server.batch_execute(progress=AsyncMock(), **kwargs))
+
+
+def _flaky(fail_index):
+    calls = {"n": 0}
+
+    def _execute(model, method, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] - 1 == fail_index:
+            raise ValueError("boom")
+        return {"ok": calls["n"]}
+
+    return _client(execute_method=_execute)
+
+
+_OPS = [
+    {"model": "res.partner", "method": "search_read", "kwargs_json": "{}"},
+    {"model": "res.partner", "method": "search_count", "kwargs_json": "{}"},
+    {"model": "res.partner", "method": "read", "args_json": "[[1]]"},
+]
+
+
+def test_batch_non_atomic_continues_past_failure():
+    response = _batch(_flaky(1), operations=_OPS, atomic=False)
+    assert response.success is False
+    assert [r.success for r in response.results] == [True, False, True]
+    assert response.failed_operations == 1 and response.successful_operations == 2
+    assert response.error == "1 operations failed"
+
+
+def test_batch_atomic_stops_at_first_failure_and_keeps_completed_results():
+    response = _batch(_flaky(1), operations=_OPS, atomic=True)
+    assert response.success is False
+    assert [r.success for r in response.results] == [True, False]
+    assert response.error.startswith("Failed at operation 1")
+
+
+def test_batch_reports_invalid_operation_without_calling_odoo():
+    client = _client(execute_method=lambda *a, **k: 1)
+    response = _batch(client, operations=[{"model": "res.partner", "method": "read", "args_json": "{not json"}])
+    assert response.results[0].success is False
+    assert response.results[0].error  # the JSON decode message
+    assert client.execute_method.call_count == 0
+
+
+# ----- execute_workflow -----
+
+
+def _workflow(client, **kwargs):
+    """Run a workflow, confirming through the token gate when it asks."""
+
+    async def _run():
+        response = await server.execute_workflow(progress=AsyncMock(), **kwargs)
+        if response.pending_confirmation:
+            token = re.search(r"confirmation_token='([^']+)'", response.tip).group(1)
+            response = await server.execute_workflow(
+                progress=AsyncMock(), confirmed=True, confirmation_token=token, **kwargs
+            )
+        return response
+
+    with patch.object(server, "get_odoo_client", return_value=client):
+        return asyncio.run(_run())
+
+
+def test_lead_to_won_converts_a_lead_then_marks_it_won():
+    client = _client(search_read=lambda *a, **k: [{"id": 7, "type": "lead"}], execute_method=lambda *a, **k: True)
+    response = _workflow(client, workflow="lead_to_won", params_json='{"lead_id": 7, "partner_id": 3}')
+    assert response.success is True
+    assert [s.step for s in response.steps] == ["convert_to_opportunity", "mark_won"]
+    assert ("crm.lead", "convert_opportunity", [[7]], {"partner_id": 3}) in _sent(client)
+    assert ("crm.lead", "action_set_won", [[7]], {}) in _sent(client)
+
+
+def test_lead_to_won_skips_conversion_for_an_opportunity():
+    client = _client(
+        search_read=lambda *a, **k: [{"id": 7, "type": "opportunity"}], execute_method=lambda *a, **k: True
+    )
+    response = _workflow(client, workflow="crm_workflow", params_json='{"lead_id": 7}')
+    assert response.success is True
+    assert response.steps[0].skipped is True
+    assert [c[1] for c in _sent(client)] == ["action_set_won"]
+
+
+def test_lead_to_won_reports_a_failed_step():
+    def _execute(model, method, *a, **k):
+        raise ValueError("cannot win")
+
+    client = _client(search_read=lambda *a, **k: [{"id": 7, "type": "opportunity"}], execute_method=_execute)
+    response = _workflow(client, workflow="lead_to_won", params_json='{"lead_id": 7}')
+    assert response.success is False
+    assert response.steps[1].success is False and "cannot win" in response.steps[1].error
+
+
+def test_lead_to_won_requires_lead_id():
+    response = _workflow(_client(), workflow="lead_to_won", params_json="{}")
+    assert response.success is False and "lead_id" in response.error
+
+
+def test_create_and_post_invoice_creates_then_posts():
+    def _execute(model, method, *a, **k):
+        return 99 if method == "create" else True
+
+    client = _client(execute_method=_execute)
+    response = _workflow(
+        client,
+        workflow="quick_invoice",
+        params_json='{"partner_id": 5, "lines": [{"product_id": 1, "quantity": 2, "price_unit": 10}]}',
+    )
+    assert response.success is True and response.invoice_id == 99
+    create = next(c for c in _sent(client) if c[1] == "create")
+    vals = create[2][0][0]  # args == ([invoice_vals],)
+    assert vals["move_type"] == "out_invoice" and vals["partner_id"] == 5
+    assert vals["invoice_line_ids"] == [(0, 0, {"product_id": 1, "quantity": 2, "price_unit": 10, "name": "Product"})]
+    assert ("account.move", "action_post", [[99]], {}) in _sent(client)
+
+
+def test_create_and_post_invoice_can_skip_posting():
+    client = _client(execute_method=lambda model, method, *a, **k: 99)
+    response = _workflow(
+        client,
+        workflow="create_and_post_invoice",
+        params_json='{"partner_id": 5, "lines": [{"product_id": 1}], "post": false}',
+    )
+    assert response.success is True
+    assert [c[1] for c in _sent(client)] == ["create"]
+
+
+def test_create_and_post_invoice_stops_when_create_fails():
+    def _execute(*a, **k):
+        raise ValueError("no journal")
+
+    response = _workflow(
+        _client(execute_method=_execute),
+        workflow="create_and_post_invoice",
+        params_json='{"partner_id": 5, "lines": [{"product_id": 1}]}',
+    )
+    assert response.success is False
+    assert [s.step for s in response.steps] == ["create_invoice"]
+    assert "no journal" in response.steps[0].error
+
+
+@pytest.mark.parametrize(
+    "params, fragment",
+    [('{"lines": [{"product_id": 1}]}', "partner_id required"), ('{"partner_id": 5}', "lines required")],
+)
+def test_create_and_post_invoice_validates_params(params, fragment):
+    response = _workflow(_client(), workflow="create_and_post_invoice", params_json=params)
+    assert response.success is False and fragment in response.error
+
+
+def test_unknown_workflow_lists_available_ones():
+    response = _workflow(_client(), workflow="stock_transfer", params_json="{}")
+    assert response.success is False
+    assert response.error == "Unknown workflow: stock_transfer"
+    assert any(w.startswith("lead_to_won") for w in response.available_workflows)
+
+
+def test_invalid_params_json_is_rejected():
+    response = _workflow(_client(), workflow="lead_to_won", params_json="{oops")
+    assert response.success is False and "Invalid params_json" in response.error


### PR DESCRIPTION
## Summary

Three changes from the code-quality and performance analysis of the server, verified live against the production Odoo (read-only).

### 1. Odoo round-trips no longer block the event loop
FastMCP 3.x calls a sync **template** resource body inline on the loop thread, and `batch_execute` / `execute_workflow` are `async def` around the synchronous `requests` client. One slow `fields_get` or a 100-op batch froze every session, pings included.
- Every parameterized `odoo://…/{x}` resource is registered through `resources._threaded_resource` (an `async` wrapper over `anyio.to_thread`; the sync body is kept for the `read_resource` bridge and the tests).
- The six client calls inside the two async tools go through `server._run_blocking`.
- `tests/test_event_loop_offload.py` fails if a template is ever registered without the wrapper, and checks by thread identity that the calls run off the loop.
- `anyio>=4` becomes a declared dependency (already transitive via FastMCP).

### 2. Compact schema views request only the attributes they use
- `OdooClient.get_model_fields(model, attributes=None)` forwards `fields_get`'s `attributes`.
- quick-schema, `/fields`, bundle, session-bootstrap, the dynamic `/workflow` fallback and the locked-mode payload pre-flight request `COMPACT_FIELD_ATTRIBUTES` (six keys instead of the ~300 KB full definition) and share one TTL+LRU cache entry keyed by `(client url, username, model, attributes)`. The client identity in the key keeps multi-user callers from sharing a definition filtered by someone else's access rights.
- `/schema` and `odoo://model/{m}` still fetch the full definition.

Live measurements on prod: quick-schema `res.partner` 216 ms then 1 ms cached; bundle of 5 models 163 ms; `/fields sale.order` served from the bundle's entry in 3 ms.

### 3. `execute_method` split into phases, gate and read-only text shared
- Phase helpers: `_parse_json_args`, `_resolve_many2one_names`, `_lookup_resolve_target`, `_inject_resolved_values`, `_reject_private_method`, `_classify_and_gate`, `_apply_search_defaults`, `_search_read_fallback`, `_failure_response`. Cyclomatic complexity 71 → 14, 359 → 86 lines.
- `_confirmation_gate` / `_GateDecision` and `_read_only_error` are shared by the three write-capable tools instead of being copied three times.
- `resolve_json` injection returns new arg lists instead of mutating the payload; a non-dict entry gets the clear "requires 'model' and 'search' keys" message; the read-only wording is now identical across tools (`execute_workflow` previously said "enable workflows").
- `tests/test_tool_execution_paths.py` is the characterization suite for `resolve_json`, the `search_read` fallback, search defaults, both workflows and non-atomic batches — none of these had a direct test before.

An independent review of the diff found no parity break; the one narrowed exception boundary it spotted (malformed `name_search` tuple) is fixed and pinned by a test.

## Baselines

| | before | after |
|---|---|---|
| `pytest --ignore=tests/live` | 374 passed | 423 passed |
| unit coverage | 50 % | 66 % (`server.py` 25 % → 74 %) |
| `ruff check .` | 33 | 29 |
| `mypy src/odoo_mcp` | 76 | 76 |
| `black` / `isort` | clean | clean |

CHANGELOG `[Unreleased]` and CLAUDE.md (module tree, event-loop and schema-fetch rules, test inventory, baselines) are updated.

## Test plan
- [x] Unit suite green on Python 3.13 locally
- [x] `black --check` / `isort --check-only` clean
- [x] No new ruff or mypy errors against the documented baseline
- [x] Live read-only smoke test on prod: quick-schema, bundle, `/fields`, `/workflow`, `execute_method`, `batch_execute`
- [ ] CI matrix (3.10–3.13) green on this PR
- [ ] Restart a Claude Code / Claude Desktop session against the branch and read `odoo://bundle/res.partner,sale.order` natively (template path, not the `read_resource` bridge)

## Follow-ups (not in this PR)
- Mechanical mypy cleanup (implicit Optional, untyped dict literals) and the dead `OdooConnectionConfig` dataclass / never-populated `invoice_ids` field
- `get_model_docs` sequential selection queries, `find_model` 500-model limit, `odoo://record` binary fields, bearer-verification SQLite connection per request, configurable anyio thread budget
