### PR TITLE
feat(resources): API reference resources, ORM guides, api-index, session; binary-free records; 429 retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   most 20 identities, oldest evicted) so registry users never share a
   group-filtered index. All four are routed
   through the `read_resource` bridge and listed in `odoo://templates`.
+- **Five ORM guides and a live session resource** (`orm_guides.py`).
+  `odoo://api/datetime` (server formats `YYYY-MM-DD` / `YYYY-MM-DD HH:MM:SS`,
+  UTC storage with client-side tz, the 19.0 dynamic domain values and 17.3
+  date parts), `odoo://api/mail-thread` (keyword-only `message_post`
+  signature with `body_is_html`, the `mail_notrack` / `tracking_disable` /
+  `mail_create_nosubscribe` context kill-switches, followers, activities),
+  `odoo://api/security-model` (ACLs are additive, record rules default-allow,
+  global rules AND vs group rules OR, field groups vanish from `fields_get`,
+  `has_access` / `has_group` as the callable checks), `odoo://api/web-read`
+  (the nested `specification` of `web_read` / `web_search_read` / `web_save`)
+  and `odoo://api/xmlids` (`ir.model.data.check_object_reference` as the only
+  public resolver, custom model/field constraints). `odoo://session` is live:
+  `res.users/context_get` + the user's companies + `res.lang.get_installed`,
+  so an agent knows which tz, lang and company scope it is reading in.
+- **`odoo://domain-syntax` gains `dynamic_dates`, `date_parts` and the `any!`
+  / `not any!` operators** (data in `module_knowledge.json`).
 - **Handler ↔ bridge-route parity is now tested.** `tests/test_api_reference.py`
   enumerates every registered resource and template and asserts exactly one
   `_RESOURCE_ROUTES` entry matches — adding a resource without a route no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Four API reference resources** (`api_reference.py`). Three are static,
+  transcribed from the Odoo 19 source and docs so an agent stops guessing:
+  `odoo://api/json2-protocol` (the `/json/2` contract — `ids`/`context`/named
+  params only, five-key error body, status-code table, one-transaction-per-call
+  rule, no rate limiting in Odoo core), `odoo://api/version-drift` (every ORM
+  rename since 15.2 with its replacement, JSON-2 impact and PR link — `name_get`
+  → `display_name`, `args` → `domain`, `read_group` → `formatted_read_group`,
+  `check_access_rights` → `has_access`, `group_operator` → `aggregator`…) and
+  `odoo://api/x2many-commands` (the seven literal `[code, id, value]` triples
+  with worked examples). The fourth, `odoo://api-index`, is live: it compacts
+  `/doc-bearer/index.json` (2.4 MB on a full instance) into the module list
+  plus one line per readable model, cached 5 min per `(url, username)` (at
+  most 20 identities, oldest evicted) so registry users never share a
+  group-filtered index. All four are routed
+  through the `read_resource` bridge and listed in `odoo://templates`.
+- **Handler ↔ bridge-route parity is now tested.** `tests/test_api_reference.py`
+  enumerates every registered resource and template and asserts exactly one
+  `_RESOURCE_ROUTES` entry matches — adding a resource without a route no
+  longer silently 404s the bridge.
+
+### Fixed
+- **`odoo://record/{model}/{id}` no longer ships binary blobs.** The handler
+  read every field: on `res.partner` that was ~550 KB of base64 images for a
+  single record, and the 15 000-char `read_resource` cap then cut the JSON in
+  the middle of a blob, leaving the caller with an unparseable fragment. The
+  read now excludes `binary` fields (types come from the shared compact
+  `fields_get` cache, so it costs no extra round-trip after a quick-schema) and
+  lists their names under `_omitted_binary_fields`. Partner 1 drops from 568 KB
+  to ~12 KB of valid JSON.
+- **`OdooClient` retries once after `429 Too Many Requests`.** Odoo SaaS
+  throttles bursts, and `odoo://session-bootstrap` fans out its `fields_get`
+  calls in parallel, so one model regularly landed in `errors` instead of
+  `schemas`. The client now honours `Retry-After` (delta-seconds form, capped
+  at 5 s, 1 s default) for a single retry; a second 429 is raised as before, so
+  a persistent throttle can never become an unbounded wait. Only read methods
+  (`safety.SAFE_METHODS`) are retried — a throttled `create`/`unlink` is raised
+  immediately rather than risk a double application.
+
 ## [1.17.0] - 2026-09-07
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **Version**: 1.17.0 · **Python**: 3.10+ · **MCP**: 2025-11-25 (FastMCP `>=3.4.6,<4`; `cryptography>=42` is a *direct* dependency of `token_crypto`, not just a transitive Authlib one; `anyio>=4` is a direct dependency of the event-loop offload in `server.py` / `resources.py`)
 - **The `<4` ceiling is deliberate.** FastMCP 4.x targets MCP spec 2026-07-28 and is not a drop-in — see `docs/mcp-2026-07-28-migration.md` and `tests/test_dependency_pins.py`, which fails the build if the bound is widened or the environment drifts. **`uv.lock` is gitignored** (`.gitignore`: *"project uses pip + pyproject.toml"*) — it pins only your local `.venv`, never the documented `pip install git+…` path, so `pyproject.toml` is the only thing between a fresh install and FastMCP 4.x. Do not relax the ceiling on the strength of the lockfile.
-- **Surface**: 5 tools, 28 `odoo://` resources, 19 prompts (12 generic + 7 `cyanview-*` workflow skill prompts)
+- **Surface**: 5 tools, 32 `odoo://` resources, 19 prompts (12 generic + 7 `cyanview-*` workflow skill prompts)
 - **Discovery is via resources, action is via tools** — there is no `list_models` tool, agents read `odoo://models` instead.
 - **Two deployment shapes**: single-user (STDIO or HTTP with one static `MCP_API_KEY`) and **multi-user HTTP** (per-user `cv_odoo_…` keys from the CLORAG-managed registry, personal Odoo clients, per-user skill visibility — see "Multi-user mode" below).
 
@@ -73,7 +73,7 @@ Note: live tests under `tests/live/` are **script-style runners**, not pytest mo
 
 Run `black . && isort .` before pushing — CI enforces formatting.
 
-**Lint and typecheck are not clean gates.** Baseline as of v1.17.0: `pytest --ignore=tests/live` → **458 passed** (unit coverage 75 %); `black --check .` and `isort --check-only .` → **clean**; `ruff check .` → **26 errors** (20 E501, 6 E402); `mypy src/odoo_mcp` → **51 errors** (27 `resources.py`, 14 `server.py`, 6 `utils.py`, 1 each in `prompts.py` / `constants.py` / `user_clients.py`, plus 1 `import-untyped` in `odoo_client.py` when `types-requests` is absent from the venv; counts drift slightly with the mypy version — 2.1.0 here). No function is rated worse than radon C except `find_model_resource` (D, 21) and `get_error_suggestion` (D, 22). Judge a change by *no new errors against that baseline*, not by a zero exit code. All 6 remaining E402s are in `tests/live/`, where `load_dotenv()` must run before the `odoo_mcp` imports — inherent to those script-style runners, not a defect. None of them come from the deliberate "import `app.py` first" ordering in `server.py`/`resources.py`, so do not reorder module imports to chase them.
+**Lint and typecheck are not clean gates.** Baseline as of v1.17.0: `pytest --ignore=tests/live` → **498 passed** (unit coverage 75 %); `black --check .` and `isort --check-only .` → **clean**; `ruff check .` → **26 errors** (20 E501, 6 E402); `mypy src/odoo_mcp` → **51 errors** (27 `resources.py`, 14 `server.py`, 6 `utils.py`, 1 each in `prompts.py` / `constants.py` / `user_clients.py`, plus 1 `import-untyped` in `odoo_client.py` when `types-requests` is absent from the venv; counts drift slightly with the mypy version — 2.1.0 here). No function is rated worse than radon C except `find_model_resource` (D, 21) and `get_error_suggestion` (D, 22). Judge a change by *no new errors against that baseline*, not by a zero exit code. All 6 remaining E402s are in `tests/live/`, where `load_dotenv()` must run before the `odoo_mcp` imports — inherent to those script-style runners, not a defect. None of them come from the deliberate "import `app.py` first" ordering in `server.py`/`resources.py`, so do not reorder module imports to chase them.
 
 ## High-level architecture
 
@@ -93,9 +93,12 @@ src/odoo_mcp/
 │                      (per op: _parse_batch_operation reuses _parse_json_args); execute_workflow
 │                      dispatches through _WORKFLOW_RUNNERS (_run_lead_to_won,
 │                      _run_create_and_post_invoice), each step via _attempt_step
-├── resources.py       28 odoo:// resource handlers; parameterized ones registered via
+├── resources.py       32 odoo:// resource handlers; parameterized ones registered via
 │                      _threaded_resource so the blocking body runs off the event loop.
 │                      Every handler taking a model name goes through _validate_model first
+├── api_reference.py   Static odoo://api/* references (JSON-2 protocol, ORM version drift, x2many
+│                      commands) transcribed from the Odoo 19 source, plus build_api_index() which
+│                      compacts /doc-bearer/index.json for odoo://api-index (cached per (url, user))
 ├── method_catalog.py  Pure builder behind odoo://methods/{model}: static ORM table whose params
 │                      are derived from arg_mapping.V2_ARG_MAPPING (never restated), module
 │                      knowledge special methods, and /doc-bearer/ enrichment via _enrich_from_live
@@ -140,7 +143,7 @@ src/odoo_mcp/
 8. Send to Odoo. On 500 from `search_read` → automatically fall back to `search` + `read`, categorize the error (timeout / relational_filter / computed_field / …), record runtime issue, return enriched `issue_analysis`.
 9. On any error: match against ~25 patterns in `utils.get_error_suggestion` (with `{model}` templating). Server tracebacks are logged to stderr, **never** forwarded to clients.
 
-**2. Resource bridge** — `read_resource(uri)` exists because some clients (Claude Desktop) don't speak resource templates. The `_RESOURCE_ROUTES` table in `server.py` maps URIs to the same handlers `resources.py` registers, so the same `odoo://...` URI works either way. Two properties nothing tests: **parity** — 28 routes ↔ 28 `@mcp.resource` handlers today, and adding a resource without adding a route silently 404s the bridge while the template client keeps working; and **order** — the list is matched top-down, so `odoo://module-knowledge/{name}` must stay above `odoo://module-knowledge`, and the specific `odoo://model/{m}/…` variants above the catch-all `odoo://model/{m}`. `read_resource` also **truncates at 15 000 chars** (`_READ_RESOURCE_MAX_CHARS`), appending a `_truncated` JSON marker — so `odoo://model/{m}/schema` (~300 KB) returns a fragment unless the caller passes `max_chars=0`.
+**2. Resource bridge** — `read_resource(uri)` exists because some clients (Claude Desktop) don't speak resource templates. The `_RESOURCE_ROUTES` table in `server.py` maps URIs to the same handlers `resources.py` registers, so the same `odoo://...` URI works either way. Two properties: **parity** — 32 routes ↔ 32 `@mcp.resource` handlers, pinned by `tests/test_api_reference.py::test_every_registered_resource_has_exactly_one_bridge_route` (adding a resource without adding a route silently 404s the bridge while the template client keeps working); and **order** — the list is matched top-down, so `odoo://module-knowledge/{name}` must stay above `odoo://module-knowledge`, and the specific `odoo://model/{m}/…` variants above the catch-all `odoo://model/{m}`. `read_resource` also **truncates at 15 000 chars** (`_READ_RESOURCE_MAX_CHARS`), appending a `_truncated` JSON marker — so `odoo://model/{m}/schema` (~300 KB) returns a fragment unless the caller passes `max_chars=0`.
 
 **Event-loop rule (post-1.16.0).** FastMCP 3.x runs sync tools and *static* resources in the anyio threadpool, but calls a sync *template* resource body inline on the loop and, of course, runs `async def` tools on the loop. `OdooClient` is synchronous `requests`, so: every parameterized `odoo://…/{x}` resource must be registered with `resources._threaded_resource` (not bare `@mcp.resource`), and any Odoo call inside an `async def` tool must go through `server._run_blocking`. `tests/test_event_loop_offload.py` enforces both. Contextvars propagate through `anyio.to_thread`, so per-user client resolution is unaffected.
 
@@ -263,6 +266,8 @@ Audit log via `logging.getLogger("odoo_mcp.safety")` (configured in `__init__.py
 | `odoo://model-limitations` | Known issues + runtime-detected problematic combos |
 | `odoo://domain-syntax` / `odoo://aggregation` / `odoo://pagination` / `odoo://hierarchical` | Reference docs |
 | `odoo://server-status` | Resolved safety profile, transport, host, allowlist, warnings. Non-secret. New in v1.16.0. |
+| `odoo://api/json2-protocol` / `odoo://api/version-drift` / `odoo://api/x2many-commands` | Static API references: the `/json/2` contract (body keys, error shape, status codes, transactions), ORM renames since 15.2, and the x2many command triples. Read them when a call 404s/422s. New in v1.18.0. |
+| `odoo://api-index` | Live `/doc-bearer/index.json` compacted to module list + per-model field/method counts (~70 KB, cached 5 min per identity). Needs `api_doc.group_allow_doc`; falls back to an actionable error. New in v1.18.0. |
 
 When read through the `read_resource` tool (rather than a native resource client), every one of these is capped at 15 000 chars by default — `odoo://model/{model}/schema` needs `max_chars=0` to come back whole.
 
@@ -310,7 +315,7 @@ Read `odoo://model-limitations` for the full live list (static + runtime-detecte
 - **Docker**: non-root user (UID 1001); `run-docker.sh` uses `--env-file`; `docker-compose.yml` uses `${MCP_API_KEY:?required}`.
 - **Docker must not restate dependency constraints.** The Dockerfile installs a stub package to resolve `pyproject.toml`'s dependency set into its own cached layer, then installs the real source with `--no-deps`. A hand-copied list drifts silently — it had already lost the `fastmcp<4` ceiling and never listed `cryptography>=42`. `tests/test_dependency_pins.py::TestDockerfileUsesDeclaredDependencies` fails if a restated pin reappears.
 - **HTTP**: `sys.exit(1)` unless `MCP_API_KEY` or `USERS_DB_PATH` is set. Wizard auto-generates keys with `secrets.token_urlsafe(32)`. Multi-user token compare uses `hmac.compare_digest` (static key) / sha256 hash lookup (registry keys — plaintext keys are never stored).
-- **Resource limits**: `MCP_DEFAULT_CONTEXT` ≤ 4KB; `MCP_BOOTSTRAP_MODELS` ≤ 20 models; `_DOC_CACHE` and `_FIELDS_CACHE` ≤ 100 entries each.
+- **Resource limits**: `MCP_DEFAULT_CONTEXT` ≤ 4KB; `MCP_BOOTSTRAP_MODELS` ≤ 20 models; `_DOC_CACHE` and `_FIELDS_CACHE` ≤ 100 entries each; `_API_INDEX_CACHE` ≤ 20 identities (each entry is the raw ~2 MB index).
 - **Gitignored**: `.env`, `.env.local`, `.mcp.json`, `odoo_config.json`.
 
 ## Release process

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **Version**: 1.17.0 · **Python**: 3.10+ · **MCP**: 2025-11-25 (FastMCP `>=3.4.6,<4`; `cryptography>=42` is a *direct* dependency of `token_crypto`, not just a transitive Authlib one; `anyio>=4` is a direct dependency of the event-loop offload in `server.py` / `resources.py`)
 - **The `<4` ceiling is deliberate.** FastMCP 4.x targets MCP spec 2026-07-28 and is not a drop-in — see `docs/mcp-2026-07-28-migration.md` and `tests/test_dependency_pins.py`, which fails the build if the bound is widened or the environment drifts. **`uv.lock` is gitignored** (`.gitignore`: *"project uses pip + pyproject.toml"*) — it pins only your local `.venv`, never the documented `pip install git+…` path, so `pyproject.toml` is the only thing between a fresh install and FastMCP 4.x. Do not relax the ceiling on the strength of the lockfile.
-- **Surface**: 5 tools, 32 `odoo://` resources, 19 prompts (12 generic + 7 `cyanview-*` workflow skill prompts)
+- **Surface**: 5 tools, 38 `odoo://` resources, 19 prompts (12 generic + 7 `cyanview-*` workflow skill prompts)
 - **Discovery is via resources, action is via tools** — there is no `list_models` tool, agents read `odoo://models` instead.
 - **Two deployment shapes**: single-user (STDIO or HTTP with one static `MCP_API_KEY`) and **multi-user HTTP** (per-user `cv_odoo_…` keys from the CLORAG-managed registry, personal Odoo clients, per-user skill visibility — see "Multi-user mode" below).
 
@@ -73,7 +73,7 @@ Note: live tests under `tests/live/` are **script-style runners**, not pytest mo
 
 Run `black . && isort .` before pushing — CI enforces formatting.
 
-**Lint and typecheck are not clean gates.** Baseline as of v1.17.0: `pytest --ignore=tests/live` → **498 passed** (unit coverage 75 %); `black --check .` and `isort --check-only .` → **clean**; `ruff check .` → **26 errors** (20 E501, 6 E402); `mypy src/odoo_mcp` → **51 errors** (27 `resources.py`, 14 `server.py`, 6 `utils.py`, 1 each in `prompts.py` / `constants.py` / `user_clients.py`, plus 1 `import-untyped` in `odoo_client.py` when `types-requests` is absent from the venv; counts drift slightly with the mypy version — 2.1.0 here). No function is rated worse than radon C except `find_model_resource` (D, 21) and `get_error_suggestion` (D, 22). Judge a change by *no new errors against that baseline*, not by a zero exit code. All 6 remaining E402s are in `tests/live/`, where `load_dotenv()` must run before the `odoo_mcp` imports — inherent to those script-style runners, not a defect. None of them come from the deliberate "import `app.py` first" ordering in `server.py`/`resources.py`, so do not reorder module imports to chase them.
+**Lint and typecheck are not clean gates.** Baseline as of v1.17.0: `pytest --ignore=tests/live` → **519 passed** (unit coverage 75 %); `black --check .` and `isort --check-only .` → **clean**; `ruff check .` → **26 errors** (20 E501, 6 E402); `mypy src/odoo_mcp` → **51 errors** (27 `resources.py`, 14 `server.py`, 6 `utils.py`, 1 each in `prompts.py` / `constants.py` / `user_clients.py`, plus 1 `import-untyped` in `odoo_client.py` when `types-requests` is absent from the venv; counts drift slightly with the mypy version — 2.1.0 here). No function is rated worse than radon C except `find_model_resource` (D, 21) and `get_error_suggestion` (D, 22). Judge a change by *no new errors against that baseline*, not by a zero exit code. All 6 remaining E402s are in `tests/live/`, where `load_dotenv()` must run before the `odoo_mcp` imports — inherent to those script-style runners, not a defect. None of them come from the deliberate "import `app.py` first" ordering in `server.py`/`resources.py`, so do not reorder module imports to chase them.
 
 ## High-level architecture
 
@@ -93,12 +93,14 @@ src/odoo_mcp/
 │                      (per op: _parse_batch_operation reuses _parse_json_args); execute_workflow
 │                      dispatches through _WORKFLOW_RUNNERS (_run_lead_to_won,
 │                      _run_create_and_post_invoice), each step via _attempt_step
-├── resources.py       32 odoo:// resource handlers; parameterized ones registered via
+├── resources.py       38 odoo:// resource handlers; parameterized ones registered via
 │                      _threaded_resource so the blocking body runs off the event loop.
 │                      Every handler taking a model name goes through _validate_model first
 ├── api_reference.py   Static odoo://api/* references (JSON-2 protocol, ORM version drift, x2many
 │                      commands) transcribed from the Odoo 19 source, plus build_api_index() which
 │                      compacts /doc-bearer/index.json for odoo://api-index (cached per (url, user))
+├── orm_guides.py      Static odoo://api/{datetime,mail-thread,security-model,web-read,xmlids} guides,
+│                      same transcription discipline as api_reference.py (every payload names its source)
 ├── method_catalog.py  Pure builder behind odoo://methods/{model}: static ORM table whose params
 │                      are derived from arg_mapping.V2_ARG_MAPPING (never restated), module
 │                      knowledge special methods, and /doc-bearer/ enrichment via _enrich_from_live
@@ -143,7 +145,7 @@ src/odoo_mcp/
 8. Send to Odoo. On 500 from `search_read` → automatically fall back to `search` + `read`, categorize the error (timeout / relational_filter / computed_field / …), record runtime issue, return enriched `issue_analysis`.
 9. On any error: match against ~25 patterns in `utils.get_error_suggestion` (with `{model}` templating). Server tracebacks are logged to stderr, **never** forwarded to clients.
 
-**2. Resource bridge** — `read_resource(uri)` exists because some clients (Claude Desktop) don't speak resource templates. The `_RESOURCE_ROUTES` table in `server.py` maps URIs to the same handlers `resources.py` registers, so the same `odoo://...` URI works either way. Two properties: **parity** — 32 routes ↔ 32 `@mcp.resource` handlers, pinned by `tests/test_api_reference.py::test_every_registered_resource_has_exactly_one_bridge_route` (adding a resource without adding a route silently 404s the bridge while the template client keeps working); and **order** — the list is matched top-down, so `odoo://module-knowledge/{name}` must stay above `odoo://module-knowledge`, and the specific `odoo://model/{m}/…` variants above the catch-all `odoo://model/{m}`. `read_resource` also **truncates at 15 000 chars** (`_READ_RESOURCE_MAX_CHARS`), appending a `_truncated` JSON marker — so `odoo://model/{m}/schema` (~300 KB) returns a fragment unless the caller passes `max_chars=0`.
+**2. Resource bridge** — `read_resource(uri)` exists because some clients (Claude Desktop) don't speak resource templates. The `_RESOURCE_ROUTES` table in `server.py` maps URIs to the same handlers `resources.py` registers, so the same `odoo://...` URI works either way. Two properties: **parity** — 38 routes ↔ 38 `@mcp.resource` handlers, pinned by `tests/test_api_reference.py::test_every_registered_resource_has_exactly_one_bridge_route` (adding a resource without adding a route silently 404s the bridge while the template client keeps working); and **order** — the list is matched top-down, so `odoo://module-knowledge/{name}` must stay above `odoo://module-knowledge`, and the specific `odoo://model/{m}/…` variants above the catch-all `odoo://model/{m}`. `read_resource` also **truncates at 15 000 chars** (`_READ_RESOURCE_MAX_CHARS`), appending a `_truncated` JSON marker — so `odoo://model/{m}/schema` (~300 KB) returns a fragment unless the caller passes `max_chars=0`.
 
 **Event-loop rule (post-1.16.0).** FastMCP 3.x runs sync tools and *static* resources in the anyio threadpool, but calls a sync *template* resource body inline on the loop and, of course, runs `async def` tools on the loop. `OdooClient` is synchronous `requests`, so: every parameterized `odoo://…/{x}` resource must be registered with `resources._threaded_resource` (not bare `@mcp.resource`), and any Odoo call inside an `async def` tool must go through `server._run_blocking`. `tests/test_event_loop_offload.py` enforces both. Contextvars propagate through `anyio.to_thread`, so per-user client resolution is unaffected.
 
@@ -267,6 +269,8 @@ Audit log via `logging.getLogger("odoo_mcp.safety")` (configured in `__init__.py
 | `odoo://domain-syntax` / `odoo://aggregation` / `odoo://pagination` / `odoo://hierarchical` | Reference docs |
 | `odoo://server-status` | Resolved safety profile, transport, host, allowlist, warnings. Non-secret. New in v1.16.0. |
 | `odoo://api/json2-protocol` / `odoo://api/version-drift` / `odoo://api/x2many-commands` | Static API references: the `/json/2` contract (body keys, error shape, status codes, transactions), ORM renames since 15.2, and the x2many command triples. Read them when a call 404s/422s. New in v1.18.0. |
+| `odoo://api/datetime` / `mail-thread` / `security-model` / `web-read` / `xmlids` | Static ORM guides: date formats and dynamic domain values, chatter and its context kill-switches, ACL/rule/field-group composition, the `web_read` specification, XML id resolution. New in v1.18.0. |
+| `odoo://session` | Live: `context_get` + user + companies + `res.lang.get_installed` — the lang/tz/company scope an agent must interpret data in. New in v1.18.0. |
 | `odoo://api-index` | Live `/doc-bearer/index.json` compacted to module list + per-model field/method counts (~70 KB, cached 5 min per identity). Needs `api_doc.group_allow_doc`; falls back to an actionable error. New in v1.18.0. |
 
 When read through the `read_resource` tool (rather than a native resource client), every one of these is capped at 15 000 chars by default — `odoo://model/{model}/schema` needs `max_chars=0` to come back whole.
@@ -283,7 +287,7 @@ When read through the `read_resource` tool (rather than a native resource client
 
 **`read_group` is deprecated in v19.** Use `formatted_read_group` (param is `aggregates`, not `fields`).
 
-**Domain logic is Polish-prefix.** `["&", t1, t2]` AND, `["|", t1, t2]` OR, `["!", t]` NOT. Dot notation works (`["partner_id.country_id.code", "=", "US"]`) but can break on computed fields — check `odoo://model-limitations`.
+**Domain logic is Polish-prefix.** `["&", t1, t2]` AND, `["|", t1, t2]` OR, `["!", t]` NOT. Dot notation works (`["partner_id.country_id.code", "=", "US"]`) but can break on computed fields — check `odoo://model-limitations`. Since 19.0 date values may be dynamic (`"-3d +1H"`, `"=monday -1w"`) and date parts are traversable (`"date.month_number"`); `odoo://domain-syntax` and `odoo://api/datetime` document both.
 
 **One2many / Many2many command tuples**: `(0,0,vals)` create, `(1,id,vals)` update, `(2,id,0)` delete, `(4,id,0)` link, `(6,0,[ids])` replace all.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ layer blocks every non-safe method.
 | | |
 |---|---|
 | **5 tools** | `execute_method` reaches any method on any model; `batch_execute`, `execute_workflow`, `configure_odoo`, and `read_resource` cover the rest |
-| **28 resources** | Model discovery, compact schemas, state-machine workflows, introspection, and runtime posture (`odoo://server-status`) |
+| **32 resources** | Model discovery, compact schemas, state-machine workflows, introspection, API reference (`odoo://api/*`), and runtime posture (`odoo://server-status`) |
 | **19 prompts** | 12 generic guided workflows plus 7 `cyanview-*` skill prompts, gated per user in multi-user mode |
 | **Safety layer** | Risk classification before execution, 8 blocked models, 6 sensitive models, cascade warnings |
 | **Locked mode** | One flag (`MCP_SAFETY_MODE=locked`) turns writes off, enforces a write allowlist, binds HTTP to localhost, and pre-flights payloads against live `fields_get` — each layer independently overridable |
@@ -270,7 +270,7 @@ token issued for `unlink([1])` and reuse it on `unlink([1, 2, …, 1000])`.
 | `configure_odoo` | Interactive connection setup |
 | `read_resource` | Read any `odoo://` resource by URI |
 
-### Resources (28)
+### Resources (32)
 
 | Resource | Description |
 |----------|-------------|
@@ -302,6 +302,10 @@ token issued for `unlink([1])` and reuse it on `unlink([1, 2, …, 1000])`.
 | `odoo://aggregation` | Aggregation guide (formatted_read_group) |
 | `odoo://model-limitations` | Known model issues + runtime problems |
 | `odoo://server-status` | Runtime safety posture (mode, host, allowlist, warnings). Non-secret. **New in v1.16.0.** |
+| `odoo://api/json2-protocol` | JSON-2 contract: body keys, error shape, status codes, transaction rule. **New in v1.18.0.** |
+| `odoo://api/version-drift` | ORM renames since 15.2 (`name_get`, `args`→`domain`, `read_group`…) and what to call instead. **New in v1.18.0.** |
+| `odoo://api/x2many-commands` | One2many/Many2many command triples with examples. **New in v1.18.0.** |
+| `odoo://api-index` | Live catalogue of installed modules and readable models (`/doc-bearer/index.json`, cached per user). **New in v1.18.0.** |
 
 ### Prompts (19)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ layer blocks every non-safe method.
 | | |
 |---|---|
 | **5 tools** | `execute_method` reaches any method on any model; `batch_execute`, `execute_workflow`, `configure_odoo`, and `read_resource` cover the rest |
-| **32 resources** | Model discovery, compact schemas, state-machine workflows, introspection, API reference (`odoo://api/*`), and runtime posture (`odoo://server-status`) |
+| **38 resources** | Model discovery, compact schemas, state-machine workflows, introspection, API reference (`odoo://api/*`), and runtime posture (`odoo://server-status`) |
 | **19 prompts** | 12 generic guided workflows plus 7 `cyanview-*` skill prompts, gated per user in multi-user mode |
 | **Safety layer** | Risk classification before execution, 8 blocked models, 6 sensitive models, cascade warnings |
 | **Locked mode** | One flag (`MCP_SAFETY_MODE=locked`) turns writes off, enforces a write allowlist, binds HTTP to localhost, and pre-flights payloads against live `fields_get` — each layer independently overridable |
@@ -270,7 +270,7 @@ token issued for `unlink([1])` and reuse it on `unlink([1, 2, …, 1000])`.
 | `configure_odoo` | Interactive connection setup |
 | `read_resource` | Read any `odoo://` resource by URI |
 
-### Resources (32)
+### Resources (38)
 
 | Resource | Description |
 |----------|-------------|
@@ -306,6 +306,12 @@ token issued for `unlink([1])` and reuse it on `unlink([1, 2, …, 1000])`.
 | `odoo://api/version-drift` | ORM renames since 15.2 (`name_get`, `args`→`domain`, `read_group`…) and what to call instead. **New in v1.18.0.** |
 | `odoo://api/x2many-commands` | One2many/Many2many command triples with examples. **New in v1.18.0.** |
 | `odoo://api-index` | Live catalogue of installed modules and readable models (`/doc-bearer/index.json`, cached per user). **New in v1.18.0.** |
+| `odoo://api/datetime` | Server date formats, UTC storage, client-side tz, dynamic domain values (`'-3d +1H'`), date parts. **New in v1.18.0.** |
+| `odoo://api/mail-thread` | `message_post` signature, notification kill-switch context keys, followers, activities. **New in v1.18.0.** |
+| `odoo://api/security-model` | How ACLs, record rules and field groups compose; `has_access` / `has_group` checks. **New in v1.18.0.** |
+| `odoo://api/web-read` | `web_read` / `web_search_read` / `web_save` nested specification. **New in v1.18.0.** |
+| `odoo://api/xmlids` | XML id resolution over JSON-2 (`check_object_reference`) and custom model/field constraints. **New in v1.18.0.** |
+| `odoo://session` | Live identity: uid, login, lang, tz, current and allowed companies, installed languages. **New in v1.18.0.** |
 
 ### Prompts (19)
 

--- a/src/odoo_mcp/api_reference.py
+++ b/src/odoo_mcp/api_reference.py
@@ -1,0 +1,301 @@
+"""Static API reference payloads and the compact ``/doc-bearer/index.json`` catalogue.
+
+Everything here is transcribed from the Odoo 19 source and developer docs —
+cite the file next to each block so a future refresh can diff against the
+same place:
+
+* ``odoo/addons/rpc/controllers/json2.py`` (the single ``/json/2`` route)
+* ``odoo/http.py`` (``serialize_exception``, ``Json2Dispatcher.handle_error``)
+* ``odoo/orm/commands.py`` (the ``Command`` enum docstring)
+* ``content/developer/reference/backend/orm/changelog.rst``
+* ``content/developer/reference/external_api.rst`` ("Transaction")
+
+The three ``*_reference()`` builders are pure: no Odoo call, no env.
+``build_api_index`` compacts the live index so a 2 MB payload becomes a
+per-model summary an agent can scan in one read.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+_PR = "https://github.com/odoo/odoo/pull/"
+
+
+def json2_protocol_reference() -> Dict[str, Any]:
+    """The ``/json/2`` request/response contract, as implemented in Odoo 19."""
+    return {
+        "endpoint": "POST {ODOO_URL}/json/2/{model}/{method}",
+        "headers": {
+            "Authorization": "Bearer <api key> (global-scope key; the 'rpc' scope maps to it)",
+            "Content-Type": "application/json (anything else is 415)",
+            "X-Odoo-Database": "optional — needed only when the host serves several databases",
+        },
+        "body": {
+            "ids": "Recordset the method runs on. Omit (or send []) for @api.model methods "
+            "such as search_read, fields_get, create, name_search — passing ids to one is a 422.",
+            "context": "Dict merged into the environment context (lang, tz, allowed_company_ids, active_test…).",
+            "<param>": "Every other key is bound by name to the Python signature.",
+        },
+        "positional_args": False,
+        "positional_args_note": "The controller binds kwargs with inspect.signature(func).bind(records, **kwargs); "
+        "there is no way to pass a positional argument. This server maps them via arg_mapping.",
+        "private_methods": "Methods starting with '_' or decorated @api.private raise AccessError: 403 "
+        "(not 404 — the method exists but is not exposed).",
+        "return_value": "The bare JSON of the Python return value — no {'result': …} envelope. "
+        "A returned recordset is serialised as its list of ids.",
+        "error_body_keys": ["name", "message", "arguments", "context", "debug"],
+        "error_body_note": "name is the fully qualified exception class (odoo.exceptions.AccessError, "
+        "werkzeug.exceptions.NotFound…); arguments is exc.args; debug is the server traceback "
+        "(this server logs it to stderr and never forwards it).",
+        "status_codes": {
+            "400": "Body is not valid JSON.",
+            "401": "Missing or invalid bearer key (WWW-Authenticate: bearer).",
+            "403": "odoo.exceptions.AccessError — ACL, record rule or field group denies the operation, "
+            "or the method is private ('_' prefix / @api.private).",
+            "404": "Unknown model or unknown method name, or odoo.exceptions.MissingError (record deleted).",
+            "409": "odoo.exceptions.LockError — the record is locked by another transaction; retry later.",
+            "415": "Content-Type is not application/json — the response is HTML, not JSON.",
+            "422": "Signature bind failed (unknown or missing named parameter), ids sent to an @api.model "
+            "method, or a business rule (odoo.exceptions.UserError / ValidationError) — read message.",
+            "500": "Any other exception (ValueError, KeyError, psycopg2 errors…) — check message.",
+        },
+        "transactions": {
+            "rule": "Every call runs in its own SQL transaction: committed on success, discarded on error. "
+            "Calls cannot be chained inside one transaction.",
+            "advice": "Prefer one composite method (search_read, action_confirm, action_post…) over a "
+            "sequence of primitive calls: concurrent requests can change the data between two calls. "
+            "batch_execute(atomic=True) stops at the first failure but does not roll back earlier ops.",
+        },
+        "useful_calls": {
+            "current user": "POST res.users/context_get (no ids) → {lang, tz, uid} of the key's owner",
+            "server version": "GET {ODOO_URL}/web/version → {version, version_info}",
+            "raw many2one ids": "read with kwargs {'load': null} returns ints instead of [id, display_name]",
+            "xml id lookup": "ir.model.data/check_object_reference(module, xml_id) → [model, res_id]; "
+            "env.ref() does not exist over JSON-2",
+        },
+        "rate_limiting": {
+            "odoo_core": None,
+            "note": "Odoo itself defines no 429 on the HTTP RPC path (only a websocket limit). "
+            "A 429 comes from the hosting infrastructure in front of Odoo, before execution.",
+            "this_server": "Read methods are retried once after a 429 (Retry-After honoured, capped); "
+            "write methods are never retried.",
+        },
+        "sources": [
+            "odoo/addons/rpc/controllers/json2.py",
+            "odoo/http.py (serialize_exception, Json2Dispatcher.handle_error)",
+            "developer/reference/external_api.rst",
+        ],
+    }
+
+
+def version_drift_reference() -> Dict[str, Any]:
+    """ORM renames and removals since Odoo 15.2 that break calls written from older knowledge."""
+    changes: List[Dict[str, str]] = [
+        {
+            "since": "19.1",
+            "old": "ir.config_parameter get_param/set_param usage patterns",
+            "use": "new ir.config_parameter API (writes on this model stay BLOCKED by this server)",
+            "json2_impact": "Read parameters with search_read on ir.config_parameter; do not script set_param.",
+            "pr": f"{_PR}223180",
+        },
+        {
+            "since": "19.0",
+            "old": "static date strings in domains",
+            "use": "dynamic values: 'today', 'now', '-3d +1H', '=monday -1w' (units d w m y H M S)",
+            "json2_impact": "Domains can carry relative dates; see odoo://domain-syntax.",
+            "pr": f"{_PR}216665",
+        },
+        {
+            "since": "18.2",
+            "old": "read_group",
+            "use": "formatted_read_group(domain, groupby, aggregates, …) — param is aggregates, not fields",
+            "json2_impact": "read_group still answers but is deprecated; _read_group is private (404).",
+            "pr": f"{_PR}163300",
+        },
+        {
+            "since": "18.2",
+            "old": "calling any public Python method over RPC",
+            "use": "only methods without @api.private — check_access/search_fetch are private, "
+            "use has_access/search_read",
+            "json2_impact": "@api.private methods raise AccessError (403) even though they are public in Python.",
+            "pr": f"{_PR}195402",
+        },
+        {
+            "since": "18.0",
+            "old": "check_access_rights",
+            "use": "check_access(operation) (raises) or has_access(operation) (bool) — both combine ACL + record rules",
+            "json2_impact": "Still callable in 19.0 but @api.deprecated (server logs a warning); has_access is the "
+            "RPC-friendly replacement (check_access is @api.private → 403).",
+            "pr": f"{_PR}179148",
+        },
+        {
+            "since": "18.0",
+            "old": "check_access_rule",
+            "use": "has_access(operation) — record rules are now checked together with the ACL",
+            "json2_impact": "Still callable in 19.0 but @api.deprecated; prefer has_access.",
+            "pr": f"{_PR}179148",
+        },
+        {
+            "since": "18.0",
+            "old": "_name_search overrides / name_search semantics",
+            "use": "_search_display_name — name_search still works and delegates to it",
+            "json2_impact": "None for callers; explains why custom name matching follows display_name.",
+            "pr": f"{_PR}174967",
+        },
+        {
+            "since": "17.3",
+            "old": "grouping by a date field only at day/week/month granularity",
+            "use": "date-part groupby and domain traversal: 'date.month_number', 'date.day_of_week'…",
+            "json2_impact": "formatted_read_group groupby accepts 'field:month_number'.",
+            "pr": f"{_PR}159528",
+        },
+        {
+            "since": "17.2",
+            "old": "group_operator",
+            "use": "aggregator",
+            "json2_impact": "fields_get exposes 'aggregator'; a domain or aggregate on 'group_operator' fails.",
+            "pr": f"{_PR}127353",
+        },
+        {
+            "since": "16.4",
+            "old": "name_get",
+            "use": "read the display_name field",
+            "json2_impact": "name_get is deprecated; read(fields=['display_name']) or search_read.",
+            "pr": f"{_PR}122085",
+        },
+        {
+            "since": "16.2",
+            "old": "search + read",
+            "use": "search_fetch / fetch exist but are @api.private — use search_read over JSON-2",
+            "json2_impact": "search_fetch is @api.private: 403 over RPC despite appearing in older examples.",
+            "pr": f"{_PR}112126",
+        },
+        {
+            "since": "16.0",
+            "old": "search_count ignoring limit",
+            "use": "search_count(domain, limit=N) stops counting at N",
+            "json2_impact": "Pass limit to bound the cost of an existence check.",
+            "pr": f"{_PR}95589",
+        },
+        {
+            "since": "15.3",
+            "old": "args",
+            "use": "domain — first parameter of search, search_count and _search",
+            "json2_impact": "JSON-2 is named-args-only: {'args': [...]} is a 422, send {'domain': [...]}.",
+            "pr": f"{_PR}83687",
+        },
+        {
+            "since": "15.3",
+            "old": "fields_get_keys, get_xml_id, browse('12')",
+            "use": "list(fields_get()), ir.model.data lookup, browse(12)",
+            "json2_impact": "Deprecated helpers; string ids are rejected.",
+            "pr": f"{_PR}83687",
+        },
+    ]
+    return {
+        "description": "ORM API changes since Odoo 15.2 that make calls written from older docs fail over JSON-2",
+        "usage": "When a method name or parameter 404s/422s, look it up here before retrying.",
+        "changes": changes,
+        "source": "developer/reference/backend/orm/changelog.rst",
+    }
+
+
+def x2many_commands_reference() -> Dict[str, Any]:
+    """The literal One2many / Many2many command triples accepted over RPC."""
+    return {
+        "rpc_rule": "Over RPC only the literal 3-element triple [code, id, value] is accepted — "
+        "neither Command.link(...) nor the constant names exist in JSON.",
+        "commands": [
+            {
+                "code": 0,
+                "name": "CREATE",
+                "shape": "[0, 0, values]",
+                "effect": "Create a record in the comodel with values and link it.",
+                "notes": "On a many2many one shared record is created; on a one2many one per record in ids.",
+            },
+            {
+                "code": 1,
+                "name": "UPDATE",
+                "shape": "[1, id, values]",
+                "effect": "Write values on the linked record id.",
+                "notes": "The record must already be linked.",
+            },
+            {
+                "code": 2,
+                "name": "DELETE",
+                "shape": "[2, id, 0]",
+                "effect": "Unlink then delete the record id from the database.",
+                "notes": "Irreversible. Some many2many relations refuse it — use 3 to just detach.",
+            },
+            {
+                "code": 3,
+                "name": "UNLINK",
+                "shape": "[3, id, 0]",
+                "effect": "Remove the relation to id; the record is kept unless the inverse many2one cascades.",
+                "notes": "On a one2many whose inverse has ondelete='cascade' (e.g. sale.order.line.order_id) "
+                "UNLINK deletes the line exactly like DELETE; otherwise it only nulls the inverse field, "
+                "which fails if that field is required.",
+            },
+            {
+                "code": 4,
+                "name": "LINK",
+                "shape": "[4, id, 0]",
+                "effect": "Add a relation to the existing record id.",
+                "notes": "Idempotent on many2many.",
+            },
+            {
+                "code": 5,
+                "name": "CLEAR",
+                "shape": "[5, 0, 0]",
+                "effect": "Remove every relation (records are kept).",
+                "notes": "",
+            },
+            {
+                "code": 6,
+                "name": "SET",
+                "shape": "[6, 0, ids]",
+                "effect": "Replace the whole relation with ids.",
+                "notes": "Most common for many2many: tag_ids = [[6, 0, [1, 2, 3]]].",
+            },
+        ],
+        "examples": {
+            "add two tags": {"tag_ids": [[4, 7, 0], [4, 9, 0]]},
+            "replace all tags": {"tag_ids": [[6, 0, [7, 9]]]},
+            "create an order line": {"order_line": [[0, 0, {"product_id": 42, "product_uom_qty": 2}]]},
+            "update a line": {"order_line": [[1, 315, {"product_uom_qty": 3}]]},
+            "delete a line": {"order_line": [[2, 315, 0]]},
+        },
+        "source": "odoo/orm/commands.py (class Command docstring)",
+    }
+
+
+def build_api_index(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Compact ``/doc-bearer/index.json``: keep model names and counts, drop the field maps.
+
+    The raw index lists every readable field's label for every model (~2 MB on
+    a full instance); this keeps a ~80-byte line per model so the whole catalogue
+    fits one read. Field detail belongs to ``odoo://model/{m}/quick-schema``.
+    """
+    modules = list(raw.get("modules") or [])
+    models = sorted(
+        (
+            {
+                "model": entry.get("model", ""),
+                "name": entry.get("name", ""),
+                "field_count": len(entry.get("fields") or {}),
+                "method_count": len(entry.get("methods") or []),
+            }
+            for entry in raw.get("models") or []
+        ),
+        key=lambda m: m["model"],
+    )
+    return {
+        "description": "Installed modules (dependency order) and every model readable by this API user",
+        "usage": "Pick a model here, then read odoo://model/{model}/quick-schema and odoo://methods/{model}",
+        "source": "/doc-bearer/index.json",
+        "module_count": len(modules),
+        "model_count": len(models),
+        "modules": modules,
+        "models": models,
+    }

--- a/src/odoo_mcp/constants.py
+++ b/src/odoo_mcp/constants.py
@@ -364,6 +364,12 @@ _DOC_CACHE_TTL = 300  # 5 minutes
 _DOC_CACHE_MAX_ENTRIES = 100
 _DOC_CACHE_LOCK = threading.Lock()
 
+# /doc-bearer/index.json is filtered by the caller's groups, so it is cached per
+# (url, username) — never shared across registry users. Same TTL as the docs.
+_API_INDEX_CACHE: Dict[tuple, tuple] = {}
+_API_INDEX_CACHE_MAX_ENTRIES = 20  # ~2 MB per entry on a full instance
+_API_INDEX_CACHE_LOCK = threading.Lock()
+
 
 # ----- Concept to Model Mappings -----
 
@@ -553,3 +559,12 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
 # ----- read_resource max chars -----
 
 _READ_RESOURCE_MAX_CHARS = 15000  # Safe default for Claude Desktop context window
+
+# ----- HTTP rate-limit retry (Odoo SaaS answers request bursts with 429) -----
+# One retry only: a second 429 is raised so a throttled server can never turn
+# into an unbounded wait. Retry-After is honoured but capped — a hostile or
+# misconfigured header must not stall the event-loop worker for minutes.
+RATE_LIMIT_STATUS = 429
+RATE_LIMIT_MAX_RETRIES = 1
+RATE_LIMIT_RETRY_DEFAULT_DELAY = 1.0  # seconds, when Retry-After is absent or unparseable
+RATE_LIMIT_RETRY_MAX_DELAY = 5.0  # seconds, ceiling applied to Retry-After

--- a/src/odoo_mcp/module_knowledge.json
+++ b/src/odoo_mcp/module_knowledge.json
@@ -3,7 +3,6 @@
   "_version": "1.5.0",
   "_updated": "2026-03-10",
   "_validated_against": "Odoo 19.0 source code and official documentation",
-
   "model_limitations": {
     "_note": "Known model-specific limitations and workarounds for the JSON-2 API. This list is enriched automatically when 500 errors trigger the fallback mechanism.",
     "stock.move.line": {
@@ -15,27 +14,58 @@
         "root_causes": {
           "picking_type_id_search": {
             "description": "picking_type_id is a computed field with custom search that returns NotImplemented for negative operators",
-            "affected_operators": ["!=", "not in", "not like"],
+            "affected_operators": [
+              "!=",
+              "not in",
+              "not like"
+            ],
             "solution": "Avoid filtering on picking_type_id with negative operators. Use picking_id.picking_type_id instead."
           },
           "deep_related_fields": {
             "description": "Several related fields create 3+ level JOINs that may timeout or fail",
-            "problematic_fields": ["product_category_name", "picking_code", "picking_partner_id", "move_partner_id"],
+            "problematic_fields": [
+              "product_category_name",
+              "picking_code",
+              "picking_partner_id",
+              "move_partner_id"
+            ],
             "solution": "Exclude these fields from 'fields' parameter, fetch separately if needed"
           },
           "non_stored_computed": {
             "description": "Fields like lots_visible and allowed_uom_ids are computed but not stored",
-            "problematic_fields": ["lots_visible", "allowed_uom_ids"],
+            "problematic_fields": [
+              "lots_visible",
+              "allowed_uom_ids"
+            ],
             "solution": "Exclude from 'fields' parameter - they must be computed per-record"
           }
         },
-        "safe_fields": ["id", "product_id", "lot_id", "quantity", "location_id", "location_dest_id", "picking_id", "move_id", "state", "date"],
-        "avoid_in_domain": ["picking_type_id with !=", "product_category_name", "any 3+ level dot notation"],
-        "avoid_in_fields": ["lots_visible", "allowed_uom_ids", "picking_code", "product_category_name"]
+        "safe_fields": [
+          "id",
+          "product_id",
+          "lot_id",
+          "quantity",
+          "location_id",
+          "location_dest_id",
+          "picking_id",
+          "move_id",
+          "state",
+          "date"
+        ],
+        "avoid_in_domain": [
+          "picking_type_id with !=",
+          "product_category_name",
+          "any 3+ level dot notation"
+        ],
+        "avoid_in_fields": [
+          "lots_visible",
+          "allowed_uom_ids",
+          "picking_code",
+          "product_category_name"
+        ]
       }
     }
   },
-
   "json2_api": {
     "_note": "Official Odoo 19 JSON-2 API specification (from odoo.com/documentation/19.0)",
     "endpoint": "/json/2/{model}/{method}",
@@ -58,8 +88,17 @@
     "request_format": {
       "description": "JSON object with named parameters only (no positional args)",
       "example": {
-        "domain": [["is_company", "=", true]],
-        "fields": ["name", "email"],
+        "domain": [
+          [
+            "is_company",
+            "=",
+            true
+          ]
+        ],
+        "fields": [
+          "name",
+          "email"
+        ],
         "limit": 10
       }
     },
@@ -70,7 +109,11 @@
       "note": "Cannot chain multiple calls in single transaction"
     },
     "deprecation_notice": {
-      "deprecated": ["/xmlrpc", "/xmlrpc/2", "/jsonrpc"],
+      "deprecated": [
+        "/xmlrpc",
+        "/xmlrpc/2",
+        "/jsonrpc"
+      ],
       "removal": {
         "db_service": "Removed — Odoo 20 (fall 2026) / Online 19.1 (winter 2025)",
         "common_and_object_services": "Odoo 22 (fall 2028) / Online 21.1 (winter 2027)"
@@ -80,83 +123,483 @@
     "documentation_endpoint": {
       "url": "/doc",
       "description": "Built-in API documentation for every Odoo 19 instance",
-      "features": ["Browse all models", "View fields and methods", "Generate code snippets (Python, JSON, etc.)"]
+      "features": [
+        "Browse all models",
+        "View fields and methods",
+        "Generate code snippets (Python, JSON, etc.)"
+      ]
     }
   },
-
   "domain_syntax": {
     "_note": "Complete domain operator reference for Odoo 19 JSON-2 API",
     "operators": {
       "comparison": {
-        "=": {"description": "Equals", "example": ["name", "=", "John"]},
-        "!=": {"description": "Not equals", "example": ["state", "!=", "draft"]},
-        ">": {"description": "Greater than", "example": ["amount", ">", 1000]},
-        ">=": {"description": "Greater than or equal", "example": ["date", ">=", "2024-01-01"]},
-        "<": {"description": "Less than", "example": ["quantity", "<", 10]},
-        "<=": {"description": "Less than or equal", "example": ["priority", "<=", 2]},
-        "=?": {"description": "Equals if value is set, otherwise True (conditional)", "example": ["partner_id", "=?", false], "note": "Useful for optional filters"}
+        "=": {
+          "description": "Equals",
+          "example": [
+            "name",
+            "=",
+            "John"
+          ]
+        },
+        "!=": {
+          "description": "Not equals",
+          "example": [
+            "state",
+            "!=",
+            "draft"
+          ]
+        },
+        ">": {
+          "description": "Greater than",
+          "example": [
+            "amount",
+            ">",
+            1000
+          ]
+        },
+        ">=": {
+          "description": "Greater than or equal",
+          "example": [
+            "date",
+            ">=",
+            "2024-01-01"
+          ]
+        },
+        "<": {
+          "description": "Less than",
+          "example": [
+            "quantity",
+            "<",
+            10
+          ]
+        },
+        "<=": {
+          "description": "Less than or equal",
+          "example": [
+            "priority",
+            "<=",
+            2
+          ]
+        },
+        "=?": {
+          "description": "Equals if value is set, otherwise True (conditional)",
+          "example": [
+            "partner_id",
+            "=?",
+            false
+          ],
+          "note": "Useful for optional filters"
+        }
       },
       "list": {
-        "in": {"description": "Value in list", "example": ["state", "in", ["draft", "sent"]]},
-        "not in": {"description": "Value not in list", "example": ["state", "not in", ["cancel", "done"]]}
+        "in": {
+          "description": "Value in list",
+          "example": [
+            "state",
+            "in",
+            [
+              "draft",
+              "sent"
+            ]
+          ]
+        },
+        "not in": {
+          "description": "Value not in list",
+          "example": [
+            "state",
+            "not in",
+            [
+              "cancel",
+              "done"
+            ]
+          ]
+        }
       },
       "text": {
-        "like": {"description": "Pattern match (case-sensitive, auto-adds %wildcards%)", "example": ["name", "like", "test"]},
-        "ilike": {"description": "Pattern match (case-insensitive, auto-adds %wildcards%)", "example": ["email", "ilike", "@gmail"]},
-        "=like": {"description": "Exact pattern match (case-sensitive, manual wildcards)", "example": ["code", "=like", "SO%"]},
-        "=ilike": {"description": "Exact pattern match (case-insensitive, manual wildcards)", "example": ["name", "=ilike", "john%"]},
-        "not like": {"description": "Negated like", "example": ["name", "not like", "test"]},
-        "not ilike": {"description": "Negated ilike", "example": ["email", "not ilike", "spam"]},
-        "not =like": {"description": "Negated exact pattern (v17+)", "example": ["zip", "not =like", "75%"]},
-        "not =ilike": {"description": "Negated exact pattern case-insensitive (v17+)", "example": ["city", "not =ilike", "paris%"]}
+        "like": {
+          "description": "Pattern match (case-sensitive, auto-adds %wildcards%)",
+          "example": [
+            "name",
+            "like",
+            "test"
+          ]
+        },
+        "ilike": {
+          "description": "Pattern match (case-insensitive, auto-adds %wildcards%)",
+          "example": [
+            "email",
+            "ilike",
+            "@gmail"
+          ]
+        },
+        "=like": {
+          "description": "Exact pattern match (case-sensitive, manual wildcards)",
+          "example": [
+            "code",
+            "=like",
+            "SO%"
+          ]
+        },
+        "=ilike": {
+          "description": "Exact pattern match (case-insensitive, manual wildcards)",
+          "example": [
+            "name",
+            "=ilike",
+            "john%"
+          ]
+        },
+        "not like": {
+          "description": "Negated like",
+          "example": [
+            "name",
+            "not like",
+            "test"
+          ]
+        },
+        "not ilike": {
+          "description": "Negated ilike",
+          "example": [
+            "email",
+            "not ilike",
+            "spam"
+          ]
+        },
+        "not =like": {
+          "description": "Negated exact pattern (v17+)",
+          "example": [
+            "zip",
+            "not =like",
+            "75%"
+          ]
+        },
+        "not =ilike": {
+          "description": "Negated exact pattern case-insensitive (v17+)",
+          "example": [
+            "city",
+            "not =ilike",
+            "paris%"
+          ]
+        }
       },
       "hierarchical": {
-        "child_of": {"description": "Record is child/grandchild of given ID (uses _parent_name)", "example": ["category_id", "child_of", 5], "note": "Works on models with parent_id or _parent_name field"},
-        "parent_of": {"description": "Record is parent/grandparent of given ID", "example": ["id", "parent_of", 10], "note": "Inverse of child_of"}
+        "child_of": {
+          "description": "Record is child/grandchild of given ID (uses _parent_name)",
+          "example": [
+            "category_id",
+            "child_of",
+            5
+          ],
+          "note": "Works on models with parent_id or _parent_name field"
+        },
+        "parent_of": {
+          "description": "Record is parent/grandparent of given ID",
+          "example": [
+            "id",
+            "parent_of",
+            10
+          ],
+          "note": "Inverse of child_of"
+        }
       },
       "relational": {
-        "any": {"description": "At least one related record matches (x2many)", "example": ["order_line", "any", [["product_id", "=", 1]]], "note": "v17+ for One2many/Many2many"},
-        "not any": {"description": "No related record matches", "example": ["invoice_ids", "not any", [["state", "=", "posted"]]]}
+        "any": {
+          "description": "At least one related record matches (x2many)",
+          "example": [
+            "order_line",
+            "any",
+            [
+              [
+                "product_id",
+                "=",
+                1
+              ]
+            ]
+          ],
+          "note": "v17+ for One2many/Many2many"
+        },
+        "not any": {
+          "description": "No related record matches",
+          "example": [
+            "invoice_ids",
+            "not any",
+            [
+              [
+                "state",
+                "=",
+                "posted"
+              ]
+            ]
+          ]
+        },
+        "any!": {
+          "description": "Like 'any' but bypasses access checks on the traversed records (19.0)",
+          "example": [
+            "order_line",
+            "any!",
+            [
+              [
+                "product_id.type",
+                "=",
+                "service"
+              ]
+            ]
+          ]
+        },
+        "not any!": {
+          "description": "Negation of 'any!'",
+          "example": [
+            "order_line",
+            "not any!",
+            [
+              [
+                "state",
+                "=",
+                "cancel"
+              ]
+            ]
+          ]
+        }
       },
       "logic": {
-        "&": {"description": "AND (default, implicit between terms)", "example": ["&", ["state", "=", "draft"], ["amount", ">", 100]]},
-        "|": {"description": "OR", "example": ["|", ["state", "=", "draft"], ["state", "=", "sent"]]},
-        "!": {"description": "NOT (negates following term)", "example": ["!", ["active", "=", false]]}
+        "&": {
+          "description": "AND (default, implicit between terms)",
+          "example": [
+            "&",
+            [
+              "state",
+              "=",
+              "draft"
+            ],
+            [
+              "amount",
+              ">",
+              100
+            ]
+          ]
+        },
+        "|": {
+          "description": "OR",
+          "example": [
+            "|",
+            [
+              "state",
+              "=",
+              "draft"
+            ],
+            [
+              "state",
+              "=",
+              "sent"
+            ]
+          ]
+        },
+        "!": {
+          "description": "NOT (negates following term)",
+          "example": [
+            "!",
+            [
+              "active",
+              "=",
+              false
+            ]
+          ]
+        }
       }
     },
     "dot_notation": {
       "_note": "Access related fields with dot notation",
       "examples": [
-        {"domain": ["partner_id.country_id.code", "=", "US"], "description": "Filter by related country code"},
-        {"domain": ["order_id.partner_id.is_company", "=", true], "description": "Filter by customer type via order"}
+        {
+          "domain": [
+            "partner_id.country_id.code",
+            "=",
+            "US"
+          ],
+          "description": "Filter by related country code"
+        },
+        {
+          "domain": [
+            "order_id.partner_id.is_company",
+            "=",
+            true
+          ],
+          "description": "Filter by customer type via order"
+        }
       ]
     },
     "complex_examples": [
       {
         "description": "Active customers in US or Canada with orders > $1000",
-        "domain": ["&", "&", ["active", "=", true], ["is_company", "=", true], "|", ["country_id.code", "=", "US"], ["country_id.code", "=", "CA"]]
+        "domain": [
+          "&",
+          "&",
+          [
+            "active",
+            "=",
+            true
+          ],
+          [
+            "is_company",
+            "=",
+            true
+          ],
+          "|",
+          [
+            "country_id.code",
+            "=",
+            "US"
+          ],
+          [
+            "country_id.code",
+            "=",
+            "CA"
+          ]
+        ]
       },
       {
         "description": "Invoices from last 30 days that are unpaid",
-        "domain": ["&", ["move_type", "=", "out_invoice"], "&", ["invoice_date", ">=", "2024-12-01"], ["payment_state", "in", ["not_paid", "partial"]]]
+        "domain": [
+          "&",
+          [
+            "move_type",
+            "=",
+            "out_invoice"
+          ],
+          "&",
+          [
+            "invoice_date",
+            ">=",
+            "2024-12-01"
+          ],
+          [
+            "payment_state",
+            "in",
+            [
+              "not_paid",
+              "partial"
+            ]
+          ]
+        ]
       },
       {
         "description": "Products in category or any child category",
-        "domain": ["categ_id", "child_of", 1]
+        "domain": [
+          "categ_id",
+          "child_of",
+          1
+        ]
       },
       {
         "description": "Orders with at least one line containing product X",
-        "domain": ["order_line", "any", [["product_id", "=", 42]]]
+        "domain": [
+          "order_line",
+          "any",
+          [
+            [
+              "product_id",
+              "=",
+              42
+            ]
+          ]
+        ]
       }
-    ]
+    ],
+    "dynamic_dates": {
+      "_note": "Since 19.0 a date/datetime value in a domain may be relative to now in the user's timezone: optional 'today' (midnight) or 'now', then terms +N<unit> / -N<unit> / =N<unit> or a lower-case weekday.",
+      "units": {
+        "d": "days",
+        "w": "weeks",
+        "m": "months",
+        "y": "years",
+        "H": "hours",
+        "M": "minutes",
+        "S": "seconds"
+      },
+      "examples": [
+        {
+          "domain": [
+            "date_order",
+            ">=",
+            "today"
+          ],
+          "description": "Since midnight today"
+        },
+        {
+          "domain": [
+            "write_date",
+            ">=",
+            "-3d +1H"
+          ],
+          "description": "Now minus 3 days plus 1 hour"
+        },
+        {
+          "domain": [
+            "date_order",
+            ">=",
+            "=monday -1w"
+          ],
+          "description": "Since Monday of last week"
+        },
+        {
+          "domain": [
+            "date",
+            ">=",
+            "=1m"
+          ],
+          "description": "Same day in January, at midnight"
+        }
+      ]
+    },
+    "date_parts": {
+      "_note": "Since 17.3 a date field can be traversed to a numeric part, in domains and in formatted_read_group groupby",
+      "granularities": [
+        "year_number",
+        "quarter_number",
+        "month_number",
+        "iso_week_number",
+        "day_of_week",
+        "day_of_month",
+        "day_of_year",
+        "hour_number",
+        "minute_number",
+        "second_number"
+      ],
+      "examples": [
+        {
+          "domain": [
+            "birthday.month_number",
+            "=",
+            2
+          ],
+          "description": "Born in February, any year"
+        },
+        {
+          "groupby": "date_order:month_number",
+          "description": "Group orders by calendar month across years"
+        }
+      ]
+    }
   },
-
   "pagination": {
     "_note": "How to paginate results with execute_method",
     "parameters": {
-      "limit": {"type": "integer", "default": 100, "max": 1000, "description": "Maximum records to return"},
-      "offset": {"type": "integer", "default": 0, "description": "Number of records to skip"},
-      "order": {"type": "string", "example": "create_date desc, name asc", "description": "Sort order (field [asc|desc], ...)"}
+      "limit": {
+        "type": "integer",
+        "default": 100,
+        "max": 1000,
+        "description": "Maximum records to return"
+      },
+      "offset": {
+        "type": "integer",
+        "default": 0,
+        "description": "Number of records to skip"
+      },
+      "order": {
+        "type": "string",
+        "example": "create_date desc, name asc",
+        "description": "Sort order (field [asc|desc], ...)"
+      }
     },
     "get_total_count": {
       "description": "Use search_count before paginating to know total",
@@ -170,17 +613,37 @@
       "pattern": "Loop: offset=0, limit=100, then offset+=limit until result count < limit"
     }
   },
-
   "hierarchical_models": {
     "_note": "Models with parent/child tree structure",
     "common_models": {
-      "product.category": {"parent_field": "parent_id", "has_parent_store": true},
-      "account.account": {"parent_field": "parent_id", "has_parent_store": true},
-      "hr.department": {"parent_field": "parent_id", "has_parent_store": true},
-      "stock.location": {"parent_field": "location_id", "has_parent_store": true},
-      "documents.folder": {"parent_field": "parent_folder_id", "has_parent_store": true},
-      "project.task": {"parent_field": "parent_id", "has_parent_store": false},
-      "knowledge.article": {"parent_field": "parent_id", "has_parent_store": true}
+      "product.category": {
+        "parent_field": "parent_id",
+        "has_parent_store": true
+      },
+      "account.account": {
+        "parent_field": "parent_id",
+        "has_parent_store": true
+      },
+      "hr.department": {
+        "parent_field": "parent_id",
+        "has_parent_store": true
+      },
+      "stock.location": {
+        "parent_field": "location_id",
+        "has_parent_store": true
+      },
+      "documents.folder": {
+        "parent_field": "parent_folder_id",
+        "has_parent_store": true
+      },
+      "project.task": {
+        "parent_field": "parent_id",
+        "has_parent_store": false
+      },
+      "knowledge.article": {
+        "parent_field": "parent_id",
+        "has_parent_store": true
+      }
     },
     "query_patterns": {
       "get_all_children": {
@@ -205,7 +668,6 @@
       }
     }
   },
-
   "aggregation": {
     "_note": "Aggregation reference: read_group (deprecated) and formatted_read_group (v19+ recommended)",
     "read_group": {
@@ -285,18 +747,36 @@
       ]
     }
   },
-
   "orm_methods": {
     "_note": "Detailed ORM method reference for Odoo 19",
     "search": {
       "signature": "Model.search(domain, offset=0, limit=None, order=None, count=False)",
       "description": "Search for record IDs matching domain criteria",
       "parameters": {
-        "domain": {"type": "list", "description": "Filter conditions as list of tuples/operators"},
-        "offset": {"type": "int", "default": "0", "description": "Number of records to skip"},
-        "limit": {"type": "int | None", "default": "None", "description": "Maximum records to return (None = all)"},
-        "order": {"type": "str | None", "default": "None", "description": "Sort order (e.g., 'name asc, id desc')"},
-        "count": {"type": "bool", "default": "False", "description": "If True, return count instead of recordset"}
+        "domain": {
+          "type": "list",
+          "description": "Filter conditions as list of tuples/operators"
+        },
+        "offset": {
+          "type": "int",
+          "default": "0",
+          "description": "Number of records to skip"
+        },
+        "limit": {
+          "type": "int | None",
+          "default": "None",
+          "description": "Maximum records to return (None = all)"
+        },
+        "order": {
+          "type": "str | None",
+          "default": "None",
+          "description": "Sort order (e.g., 'name asc, id desc')"
+        },
+        "count": {
+          "type": "bool",
+          "default": "False",
+          "description": "If True, return count instead of recordset"
+        }
       },
       "returns": "Recordset of matching records (or int if count=True)",
       "vs_search_read": "search() returns only IDs; use search_read() when you need field values too",
@@ -319,7 +799,10 @@
       "signature": "Model.search_count(domain)",
       "description": "Count records matching domain without loading them",
       "parameters": {
-        "domain": {"type": "list", "description": "Filter conditions"}
+        "domain": {
+          "type": "list",
+          "description": "Filter conditions"
+        }
       },
       "returns": "Integer count of matching records",
       "performance": "Lighter than search() - only runs COUNT query, doesn't load record data",
@@ -333,12 +816,36 @@
       "signature": "Model.search_read(domain=None, fields=None, offset=0, limit=None, order=None, load='_classic_read')",
       "description": "Search and read in single database call - most efficient for filtered data retrieval",
       "parameters": {
-        "domain": {"type": "list", "default": "[]", "description": "Filter conditions"},
-        "fields": {"type": "list[str] | None", "default": "None", "description": "Fields to return (None = all)"},
-        "offset": {"type": "int", "default": "0", "description": "Records to skip"},
-        "limit": {"type": "int | None", "default": "None", "description": "Max records"},
-        "order": {"type": "str | None", "default": "None", "description": "Sort order"},
-        "load": {"type": "str | None", "default": "'_classic_read'", "description": "Many2one format: '_classic_read' for (id, name), None for raw ID"}
+        "domain": {
+          "type": "list",
+          "default": "[]",
+          "description": "Filter conditions"
+        },
+        "fields": {
+          "type": "list[str] | None",
+          "default": "None",
+          "description": "Fields to return (None = all)"
+        },
+        "offset": {
+          "type": "int",
+          "default": "0",
+          "description": "Records to skip"
+        },
+        "limit": {
+          "type": "int | None",
+          "default": "None",
+          "description": "Max records"
+        },
+        "order": {
+          "type": "str | None",
+          "default": "None",
+          "description": "Sort order"
+        },
+        "load": {
+          "type": "str | None",
+          "default": "'_classic_read'",
+          "description": "Many2one format: '_classic_read' for (id, name), None for raw ID"
+        }
       },
       "returns": "List of dictionaries with field values",
       "performance": "Single query vs search() + read() = 2 queries. Always prefer search_read when you need field data.",
@@ -511,10 +1018,26 @@
       "signature": "Model.name_search(name='', domain=None, operator='ilike', limit=100)",
       "description": "Search for records matching name pattern, used for Many2one autocomplete",
       "parameters": {
-        "name": {"type": "str", "default": "''", "description": "Search string to match"},
-        "domain": {"type": "list", "default": "None", "description": "Additional domain filter"},
-        "operator": {"type": "str", "default": "'ilike'", "description": "Comparison operator (ilike, like, =, etc.)"},
-        "limit": {"type": "int", "default": "100", "description": "Maximum results to return"}
+        "name": {
+          "type": "str",
+          "default": "''",
+          "description": "Search string to match"
+        },
+        "domain": {
+          "type": "list",
+          "default": "None",
+          "description": "Additional domain filter"
+        },
+        "operator": {
+          "type": "str",
+          "default": "'ilike'",
+          "description": "Comparison operator (ilike, like, =, etc.)"
+        },
+        "limit": {
+          "type": "int",
+          "default": "100",
+          "description": "Maximum results to return"
+        }
       },
       "returns": "List of tuples: [(id, display_name), ...]",
       "use_case": "Finding records by partial name match, like autocomplete in forms",
@@ -527,7 +1050,10 @@
       "signature": "Model.default_get(fields_list)",
       "description": "Get default values for specified fields when creating new records",
       "parameters": {
-        "fields_list": {"type": "list[str]", "description": "List of field names to get defaults for"}
+        "fields_list": {
+          "type": "list[str]",
+          "description": "List of field names to get defaults for"
+        }
       },
       "returns": "Dictionary of {field_name: default_value}",
       "use_case": "Pre-populating form values, understanding what defaults will be applied",
@@ -540,12 +1066,28 @@
       "signature": "Model.fields_get(allfields=None, attributes=None)",
       "description": "Get field definitions and metadata for the model",
       "parameters": {
-        "allfields": {"type": "list[str] | None", "default": "None", "description": "Specific fields to retrieve, or None for all"},
-        "attributes": {"type": "list[str] | None", "default": "None", "description": "Specific attributes to include (string, type, required, readonly, etc.)"}
+        "allfields": {
+          "type": "list[str] | None",
+          "default": "None",
+          "description": "Specific fields to retrieve, or None for all"
+        },
+        "attributes": {
+          "type": "list[str] | None",
+          "default": "None",
+          "description": "Specific attributes to include (string, type, required, readonly, etc.)"
+        }
       },
       "returns": "Dictionary of {field_name: {attribute: value, ...}}",
       "use_case": "Schema introspection, dynamic form generation, field validation",
-      "common_attributes": ["string", "type", "required", "readonly", "relation", "selection", "help"],
+      "common_attributes": [
+        "string",
+        "type",
+        "required",
+        "readonly",
+        "relation",
+        "selection",
+        "help"
+      ],
       "example": {
         "description": "Get all fields for res.partner",
         "call": "execute_method('res.partner', 'fields_get')"
@@ -555,7 +1097,11 @@
       "signature": "records.copy(default=None)",
       "description": "Duplicate a record with optional field overrides",
       "parameters": {
-        "default": {"type": "dict | None", "default": "None", "description": "Field values to override in the copy"}
+        "default": {
+          "type": "dict | None",
+          "default": "None",
+          "description": "Field values to override in the copy"
+        }
       },
       "returns": "New duplicated record",
       "note": "Fields with copy=False attribute are not copied. State fields typically reset to draft.",
@@ -568,8 +1114,15 @@
       "signature": "Model.check_access_rights(operation, raise_exception=True)",
       "description": "Check if current user has permission for operation on model (legacy, still works)",
       "parameters": {
-        "operation": {"type": "str", "description": "One of: 'read', 'write', 'create', 'unlink'"},
-        "raise_exception": {"type": "bool", "default": "True", "description": "Raise AccessError or return False"}
+        "operation": {
+          "type": "str",
+          "description": "One of: 'read', 'write', 'create', 'unlink'"
+        },
+        "raise_exception": {
+          "type": "bool",
+          "default": "True",
+          "description": "Raise AccessError or return False"
+        }
       },
       "returns": "True if permitted, False or raises AccessError if not",
       "note": "Still works in v19 but has_access is preferred. Note: check_access (without _rights) is @api.private and NOT callable via RPC.",
@@ -582,7 +1135,10 @@
       "signature": "Model.has_access(operation)",
       "description": "Check if user has access for operation on model (v19+ preferred)",
       "parameters": {
-        "operation": {"type": "str", "description": "One of: 'read', 'write', 'create', 'unlink'"}
+        "operation": {
+          "type": "str",
+          "description": "One of: 'read', 'write', 'create', 'unlink'"
+        }
       },
       "returns": "Boolean - True if user has access, False otherwise. Never raises an exception.",
       "note": "Preferred over check_access_rights in v19+. Simpler API: always returns boolean, never raises.",
@@ -595,7 +1151,10 @@
       "signature": "Model.browse(ids)",
       "description": "Return a recordset for the given IDs without fetching data from database",
       "parameters": {
-        "ids": {"type": "int | list[int]", "description": "Single ID or list of IDs"}
+        "ids": {
+          "type": "int | list[int]",
+          "description": "Single ID or list of IDs"
+        }
       },
       "returns": "Recordset containing the specified records (may include deleted/non-existent)",
       "note": "Does NOT verify records exist - use exists() to filter. Useful for building recordsets from known IDs.",
@@ -629,12 +1188,21 @@
       "signature": "records.filtered(func)",
       "description": "Return records satisfying the filter function",
       "parameters": {
-        "func": {"type": "callable | str", "description": "Function taking record returning bool, or field name (truthy filter)"}
+        "func": {
+          "type": "callable | str",
+          "description": "Function taking record returning bool, or field name (truthy filter)"
+        }
       },
       "returns": "Recordset with matching records",
       "examples": [
-        {"description": "Filter by lambda", "code": "partners.filtered(lambda p: p.is_company)"},
-        {"description": "Filter by field name", "code": "partners.filtered('is_company')"}
+        {
+          "description": "Filter by lambda",
+          "code": "partners.filtered(lambda p: p.is_company)"
+        },
+        {
+          "description": "Filter by field name",
+          "code": "partners.filtered('is_company')"
+        }
       ],
       "note": "Not directly callable via API - used internally in Odoo code"
     },
@@ -642,7 +1210,10 @@
       "signature": "records.filtered_domain(domain)",
       "description": "Filter records using a domain expression (in-memory, no SQL)",
       "parameters": {
-        "domain": {"type": "list", "description": "Standard Odoo domain filter"}
+        "domain": {
+          "type": "list",
+          "description": "Standard Odoo domain filter"
+        }
       },
       "returns": "Recordset with matching records",
       "use_case": "Apply domain filter to already-loaded recordset without new DB query",
@@ -652,13 +1223,25 @@
       "signature": "records.mapped(func)",
       "description": "Apply function to all records and return results",
       "parameters": {
-        "func": {"type": "callable | str", "description": "Function or field name (dot notation supported)"}
+        "func": {
+          "type": "callable | str",
+          "description": "Function or field name (dot notation supported)"
+        }
       },
       "returns": "List of results, or recordset if mapping to relational field",
       "examples": [
-        {"description": "Get all names", "code": "partners.mapped('name')"},
-        {"description": "Get related countries", "code": "partners.mapped('country_id')"},
-        {"description": "Traverse relations", "code": "orders.mapped('partner_id.country_id.name')"}
+        {
+          "description": "Get all names",
+          "code": "partners.mapped('name')"
+        },
+        {
+          "description": "Get related countries",
+          "code": "partners.mapped('country_id')"
+        },
+        {
+          "description": "Traverse relations",
+          "code": "orders.mapped('partner_id.country_id.name')"
+        }
       ],
       "note": "Since v13, relational field access works like mapped: records.partner_id == records.mapped('partner_id')"
     },
@@ -666,20 +1249,36 @@
       "signature": "records.sorted(key=None, reverse=False)",
       "description": "Return recordset sorted by key function",
       "parameters": {
-        "key": {"type": "callable | str | None", "description": "Sort key function or field name"},
-        "reverse": {"type": "bool", "default": "False", "description": "Reverse sort order"}
+        "key": {
+          "type": "callable | str | None",
+          "description": "Sort key function or field name"
+        },
+        "reverse": {
+          "type": "bool",
+          "default": "False",
+          "description": "Reverse sort order"
+        }
       },
       "returns": "New sorted recordset",
       "examples": [
-        {"description": "Sort by name", "code": "partners.sorted('name')"},
-        {"description": "Sort by date descending", "code": "orders.sorted('date_order', reverse=True)"}
+        {
+          "description": "Sort by name",
+          "code": "partners.sorted('name')"
+        },
+        {
+          "description": "Sort by date descending",
+          "code": "orders.sorted('date_order', reverse=True)"
+        }
       ]
     },
     "grouped": {
       "signature": "records.grouped(key)",
       "description": "Group records by key, returning dict of recordsets",
       "parameters": {
-        "key": {"type": "callable | str", "description": "Grouping function or field name"}
+        "key": {
+          "type": "callable | str",
+          "description": "Grouping function or field name"
+        }
       },
       "returns": "Dictionary mapping keys to recordsets",
       "example": {
@@ -692,11 +1291,21 @@
       "signature": "records.with_context(*args, **kwargs)",
       "description": "Return recordset with modified context",
       "parameters": {
-        "args": {"type": "dict", "description": "Context dict to merge (replaces if single arg)"},
-        "kwargs": {"type": "any", "description": "Context key=value pairs to add"}
+        "args": {
+          "type": "dict",
+          "description": "Context dict to merge (replaces if single arg)"
+        },
+        "kwargs": {
+          "type": "any",
+          "description": "Context key=value pairs to add"
+        }
       },
       "returns": "New recordset with updated context",
-      "use_cases": ["Set language for translations", "Pass flags to methods", "Set default values"],
+      "use_cases": [
+        "Set language for translations",
+        "Pass flags to methods",
+        "Set default values"
+      ],
       "example": {
         "description": "Set language context",
         "code": "partners.with_context(lang='fr_FR').read(['name'])"
@@ -706,7 +1315,10 @@
       "signature": "records.with_user(user)",
       "description": "Return recordset with different user (for access rights)",
       "parameters": {
-        "user": {"type": "int | res.users", "description": "User ID or record"}
+        "user": {
+          "type": "int | res.users",
+          "description": "User ID or record"
+        }
       },
       "returns": "New recordset operating as specified user",
       "note": "Changes access rights context, not sudo"
@@ -715,7 +1327,10 @@
       "signature": "records.with_company(company)",
       "description": "Return recordset with different company context",
       "parameters": {
-        "company": {"type": "int | res.company", "description": "Company ID or record"}
+        "company": {
+          "type": "int | res.company",
+          "description": "Company ID or record"
+        }
       },
       "returns": "New recordset in specified company context",
       "use_case": "Multi-company operations, cross-company data access"
@@ -724,7 +1339,11 @@
       "signature": "records.sudo(flag=True)",
       "description": "Return recordset bypassing access rights (superuser mode)",
       "parameters": {
-        "flag": {"type": "bool", "default": "True", "description": "Enable/disable sudo mode"}
+        "flag": {
+          "type": "bool",
+          "default": "True",
+          "description": "Enable/disable sudo mode"
+        }
       },
       "returns": "New recordset in superuser mode",
       "warning": "Bypasses ALL security - use sparingly and carefully",
@@ -734,7 +1353,10 @@
       "signature": "Model.name_create(name)",
       "description": "Create record with only a name value (quick create)",
       "parameters": {
-        "name": {"type": "str", "description": "Display name for new record"}
+        "name": {
+          "type": "str",
+          "description": "Display name for new record"
+        }
       },
       "returns": "Tuple (id, display_name) of created record",
       "use_case": "Quick creation from autocomplete dropdowns",
@@ -747,11 +1369,26 @@
       "signature": "Model.search_fetch(domain, field_names, offset=0, limit=None, order=None)",
       "description": "Search and prefetch fields in optimized way (new in v17) - @api.private, NOT callable via RPC",
       "parameters": {
-        "domain": {"type": "list", "description": "Search domain"},
-        "field_names": {"type": "list[str]", "description": "Fields to prefetch into cache"},
-        "offset": {"type": "int", "default": "0"},
-        "limit": {"type": "int | None", "default": "None"},
-        "order": {"type": "str | None", "default": "None"}
+        "domain": {
+          "type": "list",
+          "description": "Search domain"
+        },
+        "field_names": {
+          "type": "list[str]",
+          "description": "Fields to prefetch into cache"
+        },
+        "offset": {
+          "type": "int",
+          "default": "0"
+        },
+        "limit": {
+          "type": "int | None",
+          "default": "None"
+        },
+        "order": {
+          "type": "str | None",
+          "default": "None"
+        }
       },
       "returns": "Recordset with specified fields pre-loaded in cache",
       "vs_search_read": "Returns recordset (not dicts), better for further ORM operations",
@@ -762,7 +1399,10 @@
       "signature": "records.fetch(field_names)",
       "description": "Prefetch specified fields for recordset (populate cache) - @api.private, NOT callable via RPC",
       "parameters": {
-        "field_names": {"type": "list[str]", "description": "Fields to fetch into cache"}
+        "field_names": {
+          "type": "list[str]",
+          "description": "Fields to fetch into cache"
+        }
       },
       "returns": "self (recordset unchanged, but cache populated)",
       "use_case": "Optimize batch operations by pre-loading needed fields",
@@ -792,7 +1432,6 @@
       }
     }
   },
-
   "model_types": {
     "_note": "Odoo 19 model types and their characteristics",
     "models.Model": {
@@ -816,7 +1455,6 @@
       "note": "Cannot be queried directly via API"
     }
   },
-
   "model_attributes": {
     "_note": "Common model attributes for schema understanding",
     "_name": "Unique technical identifier (e.g., 'sale.order')",
@@ -830,46 +1468,136 @@
     "_sql_constraints": "Database-level unique/check constraints",
     "_log_access": "Auto-create create_uid, create_date, write_uid, write_date fields"
   },
-
   "field_types": {
     "_note": "Odoo 19 field type reference for schema interpretation",
     "simple": {
-      "boolean": {"python": "bool", "json": "true/false", "default": "false"},
-      "char": {"python": "str", "json": "string", "params": ["size"], "note": "size limits max length"},
-      "text": {"python": "str", "json": "string", "note": "unlimited length, for large text"},
-      "integer": {"python": "int", "json": "number", "default": "0", "note": "no null, defaults to 0"},
-      "float": {"python": "float", "json": "number", "params": ["digits"], "note": "digits=(precision, scale)"},
-      "date": {"python": "date", "json": "string YYYY-MM-DD", "helpers": ["context_today", "today", "from_string", "to_string"]},
-      "datetime": {"python": "datetime", "json": "string YYYY-MM-DD HH:MM:SS", "helpers": ["now", "context_timestamp", "from_string", "to_string"]},
-      "binary": {"python": "bytes", "json": "base64 string", "note": "for files, images, attachments"},
-      "html": {"python": "str", "json": "string (HTML)", "note": "rich text with HTML formatting"},
-      "monetary": {"python": "float", "json": "number", "params": ["currency_field", "digits"], "note": "REQUIRES currency_field pointing to res.currency"}
+      "boolean": {
+        "python": "bool",
+        "json": "true/false",
+        "default": "false"
+      },
+      "char": {
+        "python": "str",
+        "json": "string",
+        "params": [
+          "size"
+        ],
+        "note": "size limits max length"
+      },
+      "text": {
+        "python": "str",
+        "json": "string",
+        "note": "unlimited length, for large text"
+      },
+      "integer": {
+        "python": "int",
+        "json": "number",
+        "default": "0",
+        "note": "no null, defaults to 0"
+      },
+      "float": {
+        "python": "float",
+        "json": "number",
+        "params": [
+          "digits"
+        ],
+        "note": "digits=(precision, scale)"
+      },
+      "date": {
+        "python": "date",
+        "json": "string YYYY-MM-DD",
+        "helpers": [
+          "context_today",
+          "today",
+          "from_string",
+          "to_string"
+        ]
+      },
+      "datetime": {
+        "python": "datetime",
+        "json": "string YYYY-MM-DD HH:MM:SS",
+        "helpers": [
+          "now",
+          "context_timestamp",
+          "from_string",
+          "to_string"
+        ]
+      },
+      "binary": {
+        "python": "bytes",
+        "json": "base64 string",
+        "note": "for files, images, attachments"
+      },
+      "html": {
+        "python": "str",
+        "json": "string (HTML)",
+        "note": "rich text with HTML formatting"
+      },
+      "monetary": {
+        "python": "float",
+        "json": "number",
+        "params": [
+          "currency_field",
+          "digits"
+        ],
+        "note": "REQUIRES currency_field pointing to res.currency"
+      }
     },
     "selection": {
-      "selection": {"python": "str", "json": "string (key)", "params": ["selection"], "note": "selection is list of (key, label) tuples or callable"},
-      "reference": {"python": "str", "json": "string 'model,id'", "params": ["selection"], "note": "dynamic link to multiple models"}
+      "selection": {
+        "python": "str",
+        "json": "string (key)",
+        "params": [
+          "selection"
+        ],
+        "note": "selection is list of (key, label) tuples or callable"
+      },
+      "reference": {
+        "python": "str",
+        "json": "string 'model,id'",
+        "params": [
+          "selection"
+        ],
+        "note": "dynamic link to multiple models"
+      }
     },
     "relational": {
       "many2one": {
         "python": "int (record ID)",
         "json_read": "(id, display_name) or id with load=null",
         "json_write": "integer ID",
-        "params": ["comodel_name", "ondelete", "delegate"],
-        "ondelete_options": ["restrict", "cascade", "set null"],
+        "params": [
+          "comodel_name",
+          "ondelete",
+          "delegate"
+        ],
+        "ondelete_options": [
+          "restrict",
+          "cascade",
+          "set null"
+        ],
         "note": "ALWAYS pass integer ID when writing, never the name string"
       },
       "one2many": {
         "python": "recordset",
         "json_read": "[id, id, ...]",
         "json_write": "commands: (0,0,{vals}), (1,id,{vals}), (2,id,0), etc.",
-        "params": ["comodel_name", "inverse_name"],
+        "params": [
+          "comodel_name",
+          "inverse_name"
+        ],
         "note": "inverse_name is the Many2one field on the related model"
       },
       "many2many": {
         "python": "recordset",
         "json_read": "[id, id, ...]",
         "json_write": "commands: (4,id,0) link, (3,id,0) unlink, (6,0,[ids]) replace",
-        "params": ["comodel_name", "relation", "column1", "column2"],
+        "params": [
+          "comodel_name",
+          "relation",
+          "column1",
+          "column2"
+        ],
         "note": "relation is the junction table name"
       }
     },
@@ -888,7 +1616,6 @@
       "groups": "Limit field access to security groups"
     }
   },
-
   "method_decorators": {
     "_note": "Odoo 19 method decorators and their RPC accessibility",
     "rpc_accessible": {
@@ -945,34 +1672,96 @@
       }
     },
     "mcp_implications": {
-      "callable_via_mcp": ["public methods", "@api.model", "@api.model_create_multi", "@api.readonly"],
-      "not_callable": ["@api.private methods", "@api.onchange (UI-only)"],
+      "callable_via_mcp": [
+        "public methods",
+        "@api.model",
+        "@api.model_create_multi",
+        "@api.readonly"
+      ],
+      "not_callable": [
+        "@api.private methods",
+        "@api.onchange (UI-only)"
+      ],
       "tip": "If execute_method returns 'method not found' or access error, the method may be @api.private"
     }
   },
-
   "module_documentation": {
     "_note": "Maps module names to documentation and GitHub paths for Odoo 19.0",
-    "ai": {"docs": "/applications/productivity/ai", "github": null, "note": "Enterprise only"},
-    "sale": {"docs": "/applications/sales/sales", "github": "/sale/models/"},
-    "purchase": {"docs": "/applications/inventory_and_mrp/purchase", "github": "/purchase/models/"},
-    "stock": {"docs": "/applications/inventory_and_mrp/inventory", "github": "/stock/models/"},
-    "account": {"docs": "/applications/finance/accounting", "github": "/account/models/"},
-    "crm": {"docs": "/applications/sales/crm", "github": "/crm/models/"},
-    "project": {"docs": "/applications/services/project", "github": "/project/models/"},
-    "hr": {"docs": "/applications/hr/employees", "github": "/hr/models/"},
-    "website": {"docs": "/applications/websites/website", "github": "/website/views/", "snippets": "/website/views/snippets"},
-    "website_sale": {"docs": "/applications/websites/ecommerce", "github": "/website_sale/models/"},
-    "mrp": {"docs": "/applications/inventory_and_mrp/manufacturing", "github": "/mrp/models/"},
-    "product": {"docs": "/applications/inventory_and_mrp/inventory/products", "github": "/product/models/"},
-    "helpdesk": {"docs": "/applications/services/helpdesk", "github": "/helpdesk/models/"},
-    "event": {"docs": "/applications/marketing/events", "github": "/event/models/"},
-    "knowledge": {"docs": "/applications/productivity/knowledge", "github": "/knowledge/models/"},
-    "mail": {"docs": "/applications/productivity/discuss", "github": "/mail/models/"},
-    "discuss": {"docs": "/applications/productivity/discuss", "github": "/mail/models/"},
-    "base": {"docs": null, "github": "/base/models/"}
+    "ai": {
+      "docs": "/applications/productivity/ai",
+      "github": null,
+      "note": "Enterprise only"
+    },
+    "sale": {
+      "docs": "/applications/sales/sales",
+      "github": "/sale/models/"
+    },
+    "purchase": {
+      "docs": "/applications/inventory_and_mrp/purchase",
+      "github": "/purchase/models/"
+    },
+    "stock": {
+      "docs": "/applications/inventory_and_mrp/inventory",
+      "github": "/stock/models/"
+    },
+    "account": {
+      "docs": "/applications/finance/accounting",
+      "github": "/account/models/"
+    },
+    "crm": {
+      "docs": "/applications/sales/crm",
+      "github": "/crm/models/"
+    },
+    "project": {
+      "docs": "/applications/services/project",
+      "github": "/project/models/"
+    },
+    "hr": {
+      "docs": "/applications/hr/employees",
+      "github": "/hr/models/"
+    },
+    "website": {
+      "docs": "/applications/websites/website",
+      "github": "/website/views/",
+      "snippets": "/website/views/snippets"
+    },
+    "website_sale": {
+      "docs": "/applications/websites/ecommerce",
+      "github": "/website_sale/models/"
+    },
+    "mrp": {
+      "docs": "/applications/inventory_and_mrp/manufacturing",
+      "github": "/mrp/models/"
+    },
+    "product": {
+      "docs": "/applications/inventory_and_mrp/inventory/products",
+      "github": "/product/models/"
+    },
+    "helpdesk": {
+      "docs": "/applications/services/helpdesk",
+      "github": "/helpdesk/models/"
+    },
+    "event": {
+      "docs": "/applications/marketing/events",
+      "github": "/event/models/"
+    },
+    "knowledge": {
+      "docs": "/applications/productivity/knowledge",
+      "github": "/knowledge/models/"
+    },
+    "mail": {
+      "docs": "/applications/productivity/discuss",
+      "github": "/mail/models/"
+    },
+    "discuss": {
+      "docs": "/applications/productivity/discuss",
+      "github": "/mail/models/"
+    },
+    "base": {
+      "docs": null,
+      "github": "/base/models/"
+    }
   },
-
   "model_to_module": {
     "_note": "Maps model names to their parent module",
     "ai.agent": "ai",
@@ -1023,62 +1812,150 @@
     "mail.followers": "mail",
     "mail.activity": "mail"
   },
-
   "api_patterns": {
     "_note": "Common API patterns for Odoo v2 JSON-2 API",
     "domain_operators": {
-      "comparison": ["=", "!=", ">", ">=", "<", "<="],
-      "list": ["in", "not in"],
-      "text": ["like", "ilike", "=like", "=ilike"],
-      "logic": ["&", "|", "!"]
+      "comparison": [
+        "=",
+        "!=",
+        ">",
+        ">=",
+        "<",
+        "<="
+      ],
+      "list": [
+        "in",
+        "not in"
+      ],
+      "text": [
+        "like",
+        "ilike",
+        "=like",
+        "=ilike"
+      ],
+      "logic": [
+        "&",
+        "|",
+        "!"
+      ]
     },
     "relational_commands": {
       "_note": "Commands for One2many and Many2many fields (Command class in odoo.fields)",
       "CREATE": {
-        "tuple": [0, 0, {"values": "..."}],
+        "tuple": [
+          0,
+          0,
+          {
+            "values": "..."
+          }
+        ],
         "description": "Create a new record and link it",
-        "applies_to": ["One2many", "Many2many"]
+        "applies_to": [
+          "One2many",
+          "Many2many"
+        ]
       },
       "UPDATE": {
-        "tuple": [1, "id", {"values": "..."}],
+        "tuple": [
+          1,
+          "id",
+          {
+            "values": "..."
+          }
+        ],
         "description": "Update an existing linked record",
-        "applies_to": ["One2many"]
+        "applies_to": [
+          "One2many"
+        ]
       },
       "DELETE": {
-        "tuple": [2, "id", 0],
+        "tuple": [
+          2,
+          "id",
+          0
+        ],
         "description": "Remove record from database (unlink + delete)",
-        "applies_to": ["One2many"]
+        "applies_to": [
+          "One2many"
+        ]
       },
       "UNLINK": {
-        "tuple": [3, "id", 0],
+        "tuple": [
+          3,
+          "id",
+          0
+        ],
         "description": "Remove link without deleting record",
-        "applies_to": ["Many2many"]
+        "applies_to": [
+          "Many2many"
+        ]
       },
       "LINK": {
-        "tuple": [4, "id", 0],
+        "tuple": [
+          4,
+          "id",
+          0
+        ],
         "description": "Link an existing record",
-        "applies_to": ["Many2many"]
+        "applies_to": [
+          "Many2many"
+        ]
       },
       "CLEAR": {
-        "tuple": [5, 0, 0],
+        "tuple": [
+          5,
+          0,
+          0
+        ],
         "description": "Remove all links (does not delete records)",
-        "applies_to": ["Many2many"]
+        "applies_to": [
+          "Many2many"
+        ]
       },
       "SET": {
-        "tuple": [6, 0, ["ids"]],
+        "tuple": [
+          6,
+          0,
+          [
+            "ids"
+          ]
+        ],
         "description": "Replace all links with given IDs",
-        "applies_to": ["Many2many"]
+        "applies_to": [
+          "Many2many"
+        ]
       }
     },
     "one2many_commands": {
       "_note": "Legacy format reference - use relational_commands above",
-      "0": {"syntax": "(0, 0, {values})", "description": "Create new linked record"},
-      "1": {"syntax": "(1, id, {values})", "description": "Update existing record"},
-      "2": {"syntax": "(2, id, 0)", "description": "Delete record"},
-      "3": {"syntax": "(3, id, 0)", "description": "Unlink without delete (M2M only)"},
-      "4": {"syntax": "(4, id, 0)", "description": "Link existing record (M2M only)"},
-      "5": {"syntax": "(5, 0, 0)", "description": "Unlink all (M2M only)"},
-      "6": {"syntax": "(6, 0, [ids])", "description": "Replace all with list (M2M only)"}
+      "0": {
+        "syntax": "(0, 0, {values})",
+        "description": "Create new linked record"
+      },
+      "1": {
+        "syntax": "(1, id, {values})",
+        "description": "Update existing record"
+      },
+      "2": {
+        "syntax": "(2, id, 0)",
+        "description": "Delete record"
+      },
+      "3": {
+        "syntax": "(3, id, 0)",
+        "description": "Unlink without delete (M2M only)"
+      },
+      "4": {
+        "syntax": "(4, id, 0)",
+        "description": "Link existing record (M2M only)"
+      },
+      "5": {
+        "syntax": "(5, 0, 0)",
+        "description": "Unlink all (M2M only)"
+      },
+      "6": {
+        "syntax": "(6, 0, [ids])",
+        "description": "Replace all with list (M2M only)"
+      }
     },
     "field_types": {
       "Many2one": "Always use numeric ID, never string name",
@@ -1098,14 +1975,17 @@
       "user_notification": "Notification for specific recipient"
     }
   },
-
   "modules": {
     "knowledge": {
       "model": "knowledge.article",
       "special_methods": {
         "article_create": {
           "instead_of": "create",
-          "params": {"title": "string", "body": "html", "parent_id": "integer|false"},
+          "params": {
+            "title": "string",
+            "body": "html",
+            "parent_id": "integer|false"
+          },
           "description": "Create a new knowledge article"
         },
         "article_duplicate": {
@@ -1118,7 +1998,6 @@
       },
       "notes": "Do NOT use create() directly - use article_create(title=...)"
     },
-
     "sale": {
       "model": "sale.order",
       "special_methods": {
@@ -1169,19 +2048,27 @@
           "description": "Update prices based on current pricelist"
         },
         "action_view_invoice": {
-          "params": {"invoices": "recordset|false"},
+          "params": {
+            "invoices": "recordset|false"
+          },
           "description": "Open linked invoices view"
         },
         "_create_invoices": {
-          "params": {"grouped": "boolean", "final": "boolean", "date": "date|null"},
+          "params": {
+            "grouped": "boolean",
+            "final": "boolean",
+            "date": "date|null"
+          },
           "description": "Create invoices from confirmed orders"
         }
       },
       "workflows": {
-        "quotation_to_invoice": ["action_confirm", "_create_invoices"]
+        "quotation_to_invoice": [
+          "action_confirm",
+          "_create_invoices"
+        ]
       }
     },
-
     "account": {
       "model": "account.move",
       "special_methods": {
@@ -1235,7 +2122,9 @@
           "description": "Switch between invoice types (customer/vendor)"
         },
         "action_view_invoice": {
-          "params": {"invoices": "recordset|false"},
+          "params": {
+            "invoices": "recordset|false"
+          },
           "description": "Open invoice view"
         }
       },
@@ -1250,7 +2139,6 @@
       },
       "notes": "move_type determines invoice direction. state: draft, posted, cancel"
     },
-
     "crm": {
       "model": "crm.lead",
       "write_restrictions": "write() may 404 via JSON API for stage/state changes. Use action methods: action_set_won (won), action_set_lost (lost), action_restore (reopen). For non-terminal stage changes, write({stage_id: X}) may work but test first.",
@@ -1268,7 +2156,10 @@
           "requires_ids": true
         },
         "action_set_lost": {
-          "params": {"lost_reason_id": "integer|false", "lost_feedback": "string"},
+          "params": {
+            "lost_reason_id": "integer|false",
+            "lost_feedback": "string"
+          },
           "description": "Mark opportunity as lost",
           "requires_ids": true,
           "instead_of": "write with stage_id to lost stage",
@@ -1279,11 +2170,17 @@
           "description": "Reset to AI-calculated probability"
         },
         "convert_opportunity": {
-          "params": {"partner_id": "integer", "user_ids": "list|false", "team_id": "integer|false"},
+          "params": {
+            "partner_id": "integer",
+            "user_ids": "list|false",
+            "team_id": "integer|false"
+          },
           "description": "Convert lead to opportunity"
         },
         "action_schedule_meeting": {
-          "params": {"smart_calendar": "boolean"},
+          "params": {
+            "smart_calendar": "boolean"
+          },
           "description": "Open meeting scheduler"
         },
         "action_reschedule_meeting": {
@@ -1308,7 +2205,6 @@
         "type_opportunity": "Opportunity - qualified sales opportunity"
       }
     },
-
     "stock": {
       "model": "stock.picking",
       "special_methods": {
@@ -1344,7 +2240,11 @@
           "description": "Lock/unlock the picking"
         },
         "action_put_in_pack": {
-          "params": {"package_id": "integer|false", "package_type_id": "integer|false", "package_name": "string|false"},
+          "params": {
+            "package_id": "integer|false",
+            "package_type_id": "integer|false",
+            "package_name": "string|false"
+          },
           "description": "Put selected items into a package"
         },
         "button_scrap": {
@@ -1369,7 +2269,6 @@
         }
       }
     },
-
     "purchase": {
       "model": "purchase.order",
       "special_methods": {
@@ -1379,7 +2278,9 @@
           "requires_ids": true
         },
         "button_approve": {
-          "params": {"force": "boolean"},
+          "params": {
+            "force": "boolean"
+          },
           "description": "Approve purchase order (with optional force)",
           "requires_ids": true
         },
@@ -1408,11 +2309,15 @@
           "description": "Acknowledge receipt of RFQ"
         },
         "action_create_invoice": {
-          "params": {"attachment_ids": "list|false"},
+          "params": {
+            "attachment_ids": "list|false"
+          },
           "description": "Create vendor bill from PO"
         },
         "action_view_invoice": {
-          "params": {"invoices": "recordset|false"},
+          "params": {
+            "invoices": "recordset|false"
+          },
           "description": "View linked vendor bills"
         },
         "action_merge": {
@@ -1421,7 +2326,6 @@
         }
       }
     },
-
     "hr_expense": {
       "model": "hr.expense",
       "special_methods": {
@@ -1434,12 +2338,13 @@
           "description": "Approve expense report"
         },
         "action_refuse_expense": {
-          "params": {"reason": "string"},
+          "params": {
+            "reason": "string"
+          },
           "description": "Refuse expense with reason"
         }
       }
     },
-
     "hr_leave": {
       "model": "hr.leave",
       "special_methods": {
@@ -1458,7 +2363,6 @@
         }
       }
     },
-
     "project": {
       "model": "project.task",
       "special_methods": {
@@ -1472,35 +2376,41 @@
         }
       }
     },
-
     "documents": {
       "model": "documents.document",
       "special_methods": {
         "document_create": {
           "instead_of": "create",
-          "params": {"name": "string", "folder_id": "integer", "datas": "base64"},
+          "params": {
+            "name": "string",
+            "folder_id": "integer",
+            "datas": "base64"
+          },
           "description": "Create a new document"
         }
       },
       "notes": "Some document operations require specific folder permissions"
     },
-
     "discuss": {
       "model": "discuss.channel",
       "special_methods": {
         "channel_create": {
-          "params": {"name": "string", "group_id": "integer|false"},
+          "params": {
+            "name": "string",
+            "group_id": "integer|false"
+          },
           "description": "Create a new channel"
         },
         "add_members": {
-          "params": {"partner_ids": "list[integer]"},
+          "params": {
+            "partner_ids": "list[integer]"
+          },
           "description": "Add members to channel",
           "requires_ids": true
         }
       },
       "notes": "Use create() with kwargs_json={'vals_list': [{...}]}. For posting messages, create mail.message directly instead of message_post (which fails via JSON-2 API)."
     },
-
     "ai": {
       "_note": "Odoo 19 Enterprise AI module - Agents, Topics, RAG Sources",
       "models": {
@@ -1519,7 +2429,7 @@
             "is_system_agent": "System agent (cannot be deleted)"
           }
         },
-    "ai.topic": {
+        "ai.topic": {
           "description": "Topic containing instructions and AI tools (deprecated — use ir.actions.server with use_in_ai=True)",
           "deprecated": true,
           "key_fields": {
@@ -1576,7 +2486,11 @@
       "special_methods": {
         "get_direct_response": {
           "model": "ai.agent",
-          "params": {"prompt": "string", "context_message": "string", "enable_html_response": "boolean"},
+          "params": {
+            "prompt": "string",
+            "context_message": "string",
+            "enable_html_response": "boolean"
+          },
           "description": "Generate AI response directly without chat",
           "requires_ids": true
         },
@@ -1588,17 +2502,26 @@
         },
         "create_from_attachments": {
           "model": "ai.agent.source",
-          "params": {"attachment_ids": "list[integer]", "agent_id": "integer"},
+          "params": {
+            "attachment_ids": "list[integer]",
+            "agent_id": "integer"
+          },
           "description": "Create sources from existing attachments"
         },
         "create_from_binary_files": {
           "model": "ai.agent.source",
-          "params": {"files_datas": "list[base64]", "agent_id": "integer"},
+          "params": {
+            "files_datas": "list[base64]",
+            "agent_id": "integer"
+          },
           "description": "Create sources from uploaded binary files"
         },
         "create_from_urls": {
           "model": "ai.agent.source",
-          "params": {"urls": "list[string]", "agent_id": "integer"},
+          "params": {
+            "urls": "list[string]",
+            "agent_id": "integer"
+          },
           "description": "Create sources from URLs (will be scraped)"
         }
       },
@@ -1624,9 +2547,18 @@
         }
       },
       "response_styles": {
-        "analytical": {"temperature": 0.2, "description": "Precise, factual, consistent"},
-        "balanced": {"temperature": 0.5, "description": "Mix of accuracy and creativity"},
-        "creative": {"temperature": 0.8, "description": "Varied, human-like responses"}
+        "analytical": {
+          "temperature": 0.2,
+          "description": "Precise, factual, consistent"
+        },
+        "balanced": {
+          "temperature": 0.5,
+          "description": "Mix of accuracy and creativity"
+        },
+        "creative": {
+          "temperature": 0.8,
+          "description": "Varied, human-like responses"
+        }
       },
       "ai_tools": {
         "_note": "AI tools are ir.actions.server with use_in_ai=True",
@@ -1652,18 +2584,33 @@
             "state": "code",
             "use_in_ai": true,
             "code": "record.write({'description': content})",
-            "ai_tool_schema": [{"name": "content", "type": "string", "description": "New description"}]
+            "ai_tool_schema": [
+              {
+                "name": "content",
+                "type": "string",
+                "description": "New description"
+              }
+            ]
           }
         }
       },
       "default_topics": {
         "natural_language_search": {
           "description": "Interpret queries and open appropriate views",
-          "tools": ["Get Menu Details", "Get Fields", "Open Menu *", "Adjust Search"]
+          "tools": [
+            "Get Menu Details",
+            "Get Fields",
+            "Open Menu *",
+            "Adjust Search"
+          ]
         },
         "information_retrieval": {
           "description": "Search and aggregate data",
-          "tools": ["Get Fields", "Search", "Read group"]
+          "tools": [
+            "Get Fields",
+            "Search",
+            "Read group"
+          ]
         },
         "create_leads": {
           "description": "Automated lead creation (requires CRM)",
@@ -1682,8 +2629,14 @@
         "google_key": "ir.config_parameter: ai.google_key or env ODOO_AI_GEMINI_TOKEN"
       },
       "system_parameters": {
-        "ai.max_successive_calls": {"default": 20, "description": "Max recursive tool-calling loop iterations per agent response"},
-        "ai.max_tool_calls_per_call": {"default": 20, "description": "Max tool calls the LLM can make in a single response"}
+        "ai.max_successive_calls": {
+          "default": 20,
+          "description": "Max recursive tool-calling loop iterations per agent response"
+        },
+        "ai.max_tool_calls_per_call": {
+          "default": 20,
+          "description": "Max tool calls the LLM can make in a single response"
+        }
       },
       "access_control": {
         "group_user": "Read-only on ai.agent, ai.topic, ai.agent.source, ai.embedding",
@@ -1698,11 +2651,12 @@
         "ai.topic is deprecated in Odoo 19 — tools now use ir.actions.server with use_in_ai=True directly"
       ]
     },
-
     "mail": {
       "model": "mail.message",
       "special_methods": {},
-      "required_fields": ["message_type"],
+      "required_fields": [
+        "message_type"
+      ],
       "field_values": {
         "message_type": {
           "_note": "REQUIRED field - categorizes how the message was generated",
@@ -1738,7 +2692,6 @@
       "notes": "message_post() does not work via JSON-2 API. Create mail.message directly. REQUIRED: message_type field. Use 'comment' for user messages, 'notification' for system messages."
     }
   },
-
   "error_patterns": {
     "422": {
       "patterns": [

--- a/src/odoo_mcp/odoo_client.py
+++ b/src/odoo_mcp/odoo_client.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import threading
+import time
 import urllib.parse
 from typing import Any, Sequence, cast
 
@@ -16,6 +17,13 @@ import requests
 from dotenv import load_dotenv
 
 from .arg_mapping import convert_args_to_v2
+from .constants import (
+    RATE_LIMIT_MAX_RETRIES,
+    RATE_LIMIT_RETRY_DEFAULT_DELAY,
+    RATE_LIMIT_RETRY_MAX_DELAY,
+    RATE_LIMIT_STATUS,
+)
+from .safety import is_side_effect_method
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +141,7 @@ class OdooClient:
         payload = convert_args_to_v2(method, tuple(args), kwargs)
 
         try:
-            response = self.session.post(url, json=payload, timeout=self.timeout)
+            response = self._post_with_rate_limit_retry(url, payload, retry_allowed=not is_side_effect_method(method))
 
             # Extract Odoo error details from response body BEFORE raise_for_status
             if response.status_code >= 400:
@@ -165,6 +173,32 @@ class OdooClient:
             raise ConnectionError(f"Failed to connect to Odoo: {e}")
         except requests.exceptions.RequestException as e:
             raise ValueError(f"Request failed: {e}")
+
+    def _post_with_rate_limit_retry(
+        self, url: str, payload: dict[str, Any], *, retry_allowed: bool = True
+    ) -> requests.Response:
+        """POST once, retrying a single time after a 429 Too Many Requests.
+
+        Odoo SaaS throttles bursts (session-bootstrap fans out several
+        ``fields_get`` calls at once). The delay honours ``Retry-After`` when
+        it is a plain number of seconds, capped at ``RATE_LIMIT_RETRY_MAX_DELAY``;
+        any other value falls back to ``RATE_LIMIT_RETRY_DEFAULT_DELAY``. The
+        last response — whatever its status — is returned to the normal error
+        path so a persistent throttle surfaces as a regular ``429`` error.
+
+        ``retry_allowed`` is False for side-effect methods: a throttle in front
+        of Odoo answers before execution, but nothing guarantees that on every
+        stack, and re-sending a ``create``/``unlink`` could double-apply it.
+        """
+        response = self.session.post(url, json=payload, timeout=self.timeout)
+        for _ in range(RATE_LIMIT_MAX_RETRIES if retry_allowed else 0):
+            if response.status_code != RATE_LIMIT_STATUS:
+                break
+            delay = _retry_after_delay(response.headers.get("Retry-After"))
+            logger.warning("Odoo rate limit (429) on %s — retrying in %.1fs", url, delay)
+            time.sleep(delay)
+            response = self.session.post(url, json=payload, timeout=self.timeout)
+        return response
 
     def execute_method(self, model: str, method: str, *args, **kwargs) -> Any:
         """Execute an arbitrary method on a model."""
@@ -237,6 +271,22 @@ class OdooClient:
             logger.debug("get_model_doc failed for %s: %s: %s", model_name, type(e).__name__, e)
             return None
 
+    def get_api_index(self) -> dict[str, Any] | None:
+        """Fetch /doc-bearer/index.json — every installed module and readable model.
+
+        Same access rule as ``get_model_doc`` (api_doc.group_allow_doc); returns
+        None when the endpoint is unavailable so the caller can fall back.
+        """
+        url = f"{self.url}/doc-bearer/index.json"
+        try:
+            response = self.session.post(url, json={}, timeout=self.timeout)
+            response.raise_for_status()
+            data = response.json()
+            return cast("dict[str, Any] | None", data if isinstance(data, dict) else None)
+        except Exception as e:
+            logger.warning("/doc-bearer/index.json unavailable: %s: %s", type(e).__name__, e)
+            return None
+
     def search_read(
         self,
         model_name: str,
@@ -265,6 +315,21 @@ class OdooClient:
         if fields is not None:
             kwargs["fields"] = fields
         return cast("list[dict[str, Any]]", self._execute(model_name, "read", ids, **kwargs))
+
+
+def _retry_after_delay(header_value: str | None) -> float:
+    """Seconds to wait before retrying a 429, from its ``Retry-After`` header.
+
+    Only the delta-seconds form is honoured; the HTTP-date form (and garbage)
+    falls back to the default so a bad header never disables the retry.
+    """
+    try:
+        seconds = float(header_value) if header_value is not None else RATE_LIMIT_RETRY_DEFAULT_DELAY
+    except (TypeError, ValueError):
+        return RATE_LIMIT_RETRY_DEFAULT_DELAY
+    if seconds <= 0:
+        return RATE_LIMIT_RETRY_DEFAULT_DELAY
+    return min(seconds, RATE_LIMIT_RETRY_MAX_DELAY)
 
 
 def load_config() -> dict[str, str]:

--- a/src/odoo_mcp/orm_guides.py
+++ b/src/odoo_mcp/orm_guides.py
@@ -1,0 +1,267 @@
+"""Static ORM guides behind ``odoo://api/{datetime,mail-thread,security-model,web-read,xmlids}``.
+
+Each builder is pure and transcribed from a named Odoo 19 source or doc file
+(see the ``source`` key of every payload) so a future refresh can diff against
+the same place. Companion of ``api_reference.py``; split so neither module
+grows past the project's file-size guideline.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+_DATE_UNITS = {"d": "days", "w": "weeks", "m": "months", "y": "years", "H": "hours", "M": "minutes", "S": "seconds"}
+
+
+def datetime_reference() -> Dict[str, Any]:
+    """Server date formats, UTC storage, and the 19.0 dynamic domain values."""
+    return {
+        "write_formats": {"date": "YYYY-MM-DD", "datetime": "YYYY-MM-DD HH:MM:SS", "empty": "false"},
+        "rejected_forms": [
+            "ISO-8601 with 'T' separator or offset (2026-09-07T10:00:00+02:00) — not a server format",
+            "milliseconds, Unix timestamps, locale strings",
+        ],
+        "storage": "Datetime columns are 'timestamp without time zone' holding UTC.",
+        "timezone": "Timezone conversion is entirely client-side: JSON-2 returns naive UTC strings and expects "
+        "naive UTC strings. Convert with the user's tz from res.users/context_get (see odoo://session).",
+        "comparison": "Compare date fields to date strings and datetime fields to datetime strings only — "
+        "a datetime string always sorts after a date string of the same day.",
+        "dynamic_domain_values": {
+            "since": "19.0",
+            "rule": "In a domain, a date/datetime value may be a space-separated expression relative to now in the "
+            "user's timezone: optional 'today' (midnight) or 'now', then terms starting with + (add), - (subtract) "
+            "or = (set) followed by an integer and a unit, or a lower-case weekday.",
+            "units": dict(_DATE_UNITS),
+            "examples": {
+                "now": ["date_order", "<", "now"],
+                "today at midnight": ["date_order", ">=", "today"],
+                "now minus 3 days plus 1 hour": ["write_date", ">=", "-3d +1H"],
+                "today at 03:00": ["create_date", "<", "=3H"],
+                "5th of this month": ["date", ">=", "=5d"],
+                "Monday of last week": ["date", ">=", "=monday -1w"],
+            },
+        },
+        "date_parts": {
+            "since": "17.3",
+            "rule": "A date field can be traversed to a numeric part in domains and groupby.",
+            "granularities": [
+                "year_number",
+                "quarter_number",
+                "month_number",
+                "iso_week_number",
+                "day_of_week",
+                "day_of_month",
+                "day_of_year",
+                "hour_number",
+                "minute_number",
+                "second_number",
+            ],
+            "example": ["birthday.month_number", "=", 2],
+        },
+        "source": "developer/reference/backend/orm.rst (Date(time) Fields, Dynamic time values, Search domains)",
+    }
+
+
+def mail_thread_reference() -> Dict[str, Any]:
+    """Chatter, followers and activities over JSON-2, with the notification kill-switches."""
+    return {
+        "message_post": {
+            "keyword_only": True,
+            "signature": "message_post(*, body='', subject=None, message_type='notification', email_from=None, "
+            "author_id=None, parent_id=False, subtype_xmlid=None, subtype_id=False, partner_ids=None, "
+            "outgoing_email_to=False, incoming_email_to=False, incoming_email_cc=False, attachments=None, "
+            "attachment_ids=None, body_is_html=False, **kwargs)",
+            "params": {
+                "body": "Escaped as plain text unless body_is_html=true.",
+                "body_is_html": "Set true to post HTML — documented 'to be used only for RPC calls'.",
+                "message_type": "'comment' for a real note/message, 'notification' (default) for system lines.",
+                "subtype_xmlid": "'mail.mt_comment' to send to followers, 'mail.mt_note' for an internal note.",
+                "partner_ids": "List of res.partner ids to notify explicitly.",
+                "attachment_ids": "Existing ir.attachment ids; 'attachments' takes [name, raw_content] pairs "
+                "(not base64) and is awkward over JSON — create the ir.attachment first.",
+            },
+            "returns": "list with the created mail.message id, e.g. [123] — message_post returns a recordset and "
+            "JSON-2 serialises any recordset as its list of ids",
+            "json2_example": {
+                "model": "sale.order",
+                "method": "message_post",
+                "ids": [15],
+                "body": "Shipped today",
+                "message_type": "comment",
+                "subtype_xmlid": "mail.mt_note",
+            },
+            "access": "Posting requires write access on the record by default (_mail_post_access = 'write').",
+        },
+        "context_kill_switches": {
+            "mail_notrack": "Skip field-change tracking messages for this write.",
+            "tracking_disable": "Skip tracking and its notifications entirely.",
+            "mail_create_nosubscribe": "Do not auto-subscribe the creator as follower on create.",
+            "mail_create_nolog": "Skip the automatic 'created' chatter line.",
+            "mail_notify_force_send": "Send e-mails immediately instead of queueing them.",
+            "mail_post_autofollow": "Auto-follow recipients of a posted message.",
+            "mail_auto_subscribe_no_notify": "Subscribe followers without notifying them.",
+            "usage": "Pass them in the 'context' key of the JSON-2 body; a bulk write without mail_notrack "
+            "e-mails every follower once per record.",
+        },
+        "followers": {
+            "message_subscribe": "message_subscribe(partner_ids=None, subtype_ids=None) — ids in the body 'ids' key",
+            "message_unsubscribe": "message_unsubscribe(partner_ids=None)",
+        },
+        "activities": {
+            "activity_schedule": "activity_schedule(act_type_xmlid='', date_deadline=None, summary='', note='', "
+            "**act_values) — e.g. act_type_xmlid='mail.mail_activity_data_todo', user_id=<res.users id>",
+            "activity_feedback": "activity_feedback(act_type_xmlids, user_id=None, feedback=None) — marks done",
+            "activity_unlink": "activity_unlink(act_type_xmlids, user_id=None) — removes without feedback",
+            "model": "Activities live in mail.activity (res_model, res_id, activity_type_id, date_deadline, user_id).",
+        },
+        "source": "odoo/addons/mail/models/mail_thread.py, mail_activity_mixin.py; "
+        "developer/reference/backend/mixins.rst",
+    }
+
+
+def security_model_reference() -> Dict[str, Any]:
+    """How ACLs, record rules and field groups compose, and how to test access over JSON-2."""
+    return {
+        "access_rights": {
+            "model": "ir.model.access",
+            "semantics": "Grants read/write/create/unlink on a whole model to a group. No matching line = no access.",
+            "composition": "Additive: a user's rights are the union of every group they belong to.",
+            "perm_meaning": "perm_read / perm_write / perm_create / perm_unlink mean 'granted'.",
+        },
+        "record_rules": {
+            "model": "ir.rule",
+            "semantics": "Per-record conditions (domain_force) evaluated after the ACL, per operation.",
+            "default": "Default-allow: if the ACL grants access and no rule applies, the record is accessible.",
+            "global_rules": "Global rules (no groups) intersect — every one must pass (AND).",
+            "group_rules": "Group rules unify — any one passing is enough (OR), within the bounds of the global rules.",
+            "perm_meaning": "On ir.rule, perm_* means 'this rule applies to that operation' — "
+            "the opposite of ir.model.access.",
+            "domain_scope": "domain_force is a Python expression with time, user, company_id "
+            "(int) and company_ids (list).",
+            "multi_company": "Typical rule: ['|', ('company_id', '=', False), ('company_id', 'in', company_ids)] — "
+            "so the allowed_company_ids context key changes what a search returns.",
+        },
+        "field_groups": {
+            "semantics": "A field with groups='...' is invisible to users outside those groups.",
+            "symptom": "The field is absent from fields_get and from views; explicit "
+            "read/write of it raises AccessError.",
+            "diagnosis": "A field present in the database schema but missing from fields_get means a field group, "
+            "not a wrong model name.",
+        },
+        "how_to_check": {
+            "has_access": "POST {model}/has_access with ids=[...] and "
+            "operation='read'|'write'|'create'|'unlink' → bool. "
+            "Empty ids = model-level check.",
+            "check_access": "check_access(operation) raises instead of returning — but it is @api.private, so over "
+            "JSON-2 it answers 403 itself; use has_access.",
+            "has_group": "POST res.users/has_group with ids=[uid], group_ext_id='sales_team.group_sale_manager' → bool "
+            "(only for the current user).",
+            "error_shape": "A denied operation is odoo.exceptions.AccessError → HTTP 403; the message names the "
+            "model and operation.",
+        },
+        "source": "developer/reference/backend/security.rst; odoo/orm/models.py (has_access, check_access)",
+    }
+
+
+def web_read_reference() -> Dict[str, Any]:
+    """The nested ``specification`` used by web_read / web_search_read / web_save."""
+    return {
+        "why": "One call reads a record and its relations at any depth — replaces read + several follow-up reads.",
+        "specification": {
+            "rule": "A dict {field_name: spec}. Empty spec {} reads the raw value. For many2one, "
+            "{'fields': {...}} expands the related record; for one2many/many2many, {'fields': {...}} reads the "
+            "lines and accepts 'limit', 'order' and 'context'.",
+            "example": {
+                "name": {},
+                "partner_id": {"fields": {"name": {}, "email": {}}},
+                "order_line": {
+                    "fields": {"product_id": {"fields": {"display_name": {}}}, "product_uom_qty": {}},
+                    "limit": 50,
+                },
+            },
+            "many2one_without_fields": "A many2one spec without 'fields' returns the bare id (the "
+            "read uses load=None).",
+            "display_name": "Ask for display_name explicitly inside 'fields' — it is not included by default.",
+        },
+        "methods": {
+            "web_read": {
+                "call": "POST {model}/web_read with ids=[...], specification={...}",
+                "returns": "list of dicts, one per id",
+                "side_effect": False,
+            },
+            "web_search_read": {
+                "call": "POST {model}/web_search_read with domain, specification, offset, limit, order, count_limit",
+                "returns": "{'length': <count>, 'records': [...]} — length is capped by count_limit if given",
+                "side_effect": False,
+            },
+            "web_name_search": {
+                "call": "POST {model}/web_name_search with name, specification, domain, operator, limit",
+                "returns": "list of dicts shaped by specification (display_name included)",
+                "side_effect": False,
+            },
+            "web_save": {
+                "call": "POST {model}/web_save with ids=[] (create) or ids=[id] (write), "
+                "vals={...}, specification={...}",
+                "returns": "the saved record(s) re-read through specification",
+                "side_effect": True,
+            },
+        },
+        "gotcha": "web_* methods are what the Odoo web client uses; they honour access rules but skip nothing else — "
+        "a web_save is a real write and goes through this server's safety gate.",
+        "source": "odoo/addons/web/models/models.py (web_read, web_search_read, web_name_search, web_save)",
+    }
+
+
+def xmlids_reference() -> Dict[str, Any]:
+    """External ids over JSON-2, and the constraints on runtime-created models and fields."""
+    return {
+        "what": "An XML id 'module.name' maps to (model, res_id) in ir.model.data. Views, groups, activity types, "
+        "mail subtypes, report actions and sequences are addressed by XML id.",
+        "resolve": {
+            "model": "ir.model.data",
+            "method": "check_object_reference(module, xml_id, raise_on_access_error=False) → [model, res_id]",
+            "example": {
+                "model": "ir.model.data",
+                "method": "check_object_reference",
+                "module": "mail",
+                "xml_id": "mt_note",
+            },
+            "note": "env.ref() does not exist over JSON-2, and _xmlid_lookup / _xmlid_to_res_id are private (403). "
+            "Alternatively search_read ir.model.data with domain [['module','=',m],['name','=',n]].",
+            "reverse": "search_read ir.model.data with "
+            "[['model','=',model],['res_id','=',id]] gives a record's XML ids.",
+        },
+        "noupdate": "ir.model.data.noupdate=true marks data the module update must not overwrite — user-edited "
+        "records typically carry it.",
+        "custom_models": {
+            "model": "ir.model (BLOCKED for writes by this server)",
+            "name_prefix": "Custom model names must start with x_",
+            "state": "state must be 'manual' or the model is not loaded",
+            "limits": "No methods can be added to a custom model, only fields.",
+        },
+        "custom_fields": {
+            "model": "ir.model.fields (SENSITIVE: writes always confirm)",
+            "required_keys": ["model_id", "name", "ttype", "field_description"],
+            "optional_keys": [
+                "required",
+                "readonly",
+                "translate",
+                "groups",
+                "selection",
+                "size",
+                "on_delete",
+                "relation",
+                "relation_field",
+                "domain",
+            ],
+            "name_prefix": "Custom field names must start with x_ (Studio uses x_studio_)",
+            "not_possible": [
+                "Computed fields cannot be created via ir.model.fields",
+                "Defaults and onchange logic cannot be attached",
+                "Only state='manual' fields are activated",
+            ],
+        },
+        "source": "odoo/addons/base/models/ir_model.py (check_object_reference); "
+        "developer/reference/external_rpc_api.rst "
+        "(ir.model, ir.model.fields); tutorials/define_module_data.rst",
+    }

--- a/src/odoo_mcp/resources.py
+++ b/src/odoo_mcp/resources.py
@@ -40,6 +40,13 @@ from .constants import (
 )
 from .method_catalog import build_methods_payload
 from .odoo_client import get_odoo_client
+from .orm_guides import (
+    datetime_reference,
+    mail_thread_reference,
+    security_model_reference,
+    web_read_reference,
+    xmlids_reference,
+)
 from .utils import (
     _build_compact_schema,
     _get_documentation_urls,
@@ -615,6 +622,90 @@ def get_api_index() -> str:
 
 
 @mcp.resource(
+    "odoo://api/datetime",
+    description="Date/datetime over JSON-2: server formats, UTC storage, client-side tz, dynamic domain values, "
+    "date parts",
+)
+def get_datetime_guide() -> str:
+    return json.dumps(datetime_reference(), indent=2)
+
+
+@mcp.resource(
+    "odoo://api/mail-thread",
+    description="Chatter over JSON-2: message_post signature, notification kill-switch context keys, followers, "
+    "activities",
+)
+def get_mail_thread_guide() -> str:
+    return json.dumps(mail_thread_reference(), indent=2)
+
+
+@mcp.resource(
+    "odoo://api/security-model",
+    description="How ACLs, record rules and field groups compose, and how to test access with has_access/has_group",
+)
+def get_security_model_guide() -> str:
+    return json.dumps(security_model_reference(), indent=2)
+
+
+@mcp.resource(
+    "odoo://api/web-read",
+    description="web_read / web_search_read / web_save: the nested specification that reads relations in one call",
+)
+def get_web_read_guide() -> str:
+    return json.dumps(web_read_reference(), indent=2)
+
+
+@mcp.resource(
+    "odoo://api/xmlids",
+    description="External ids over JSON-2 (check_object_reference) and the constraints on custom models/fields",
+)
+def get_xmlids_guide() -> str:
+    return json.dumps(xmlids_reference(), indent=2)
+
+
+@mcp.resource(
+    "odoo://session",
+    description="Who the API key is: uid, login, lang, tz, current company, allowed companies, installed languages",
+)
+def get_session() -> str:
+    """Live identity of the connected Odoo user — the context an agent must interpret dates and languages in."""
+    client = get_odoo_client()
+    try:
+        ctx = client.execute_method("res.users", "context_get")
+        uid = int(ctx["uid"])
+        user = (client.read_records("res.users", [uid], fields=["name", "login", "company_id", "company_ids"]) or [{}])[
+            0
+        ]
+        company_ids = list(user.get("company_ids") or [])
+        companies = (
+            client.search_read("res.company", domain=[["id", "in", company_ids]], fields=["id", "name"], order="id")
+            if company_ids
+            else []
+        )
+        langs = client.execute_method("res.lang", "get_installed")
+    except Exception as e:
+        return json.dumps(
+            {"error": str(e), "hint": "context_get needs a valid bearer key; see odoo://api/json2-protocol"}, indent=2
+        )
+    company = user.get("company_id") or [None, None]
+    return json.dumps(
+        {
+            "uid": uid,
+            "name": user.get("name"),
+            "login": user.get("login"),
+            "lang": ctx.get("lang"),
+            "tz": ctx.get("tz"),
+            "company": {"id": company[0], "name": company[1]},
+            "allowed_companies": [{"id": c["id"], "name": c["name"]} for c in companies],
+            "installed_languages": [{"code": code, "name": name} for code, name in langs],
+            "context_hint": "Datetimes are UTC (convert with tz); pass {'allowed_company_ids': [...]} in context to "
+            "switch company scope and {'lang': ...} to read translations. See odoo://api/datetime.",
+        },
+        indent=2,
+    )
+
+
+@mcp.resource(
     "odoo://concepts",
     description="Mapping of business concepts to Odoo model names (contact->res.partner, invoice->account.move)",
 )
@@ -715,6 +806,30 @@ def get_resource_templates() -> str:
             "odoo://api-index": {
                 "description": "Live catalogue of installed modules and readable models (api_doc index)",
                 "example": "odoo://api-index",
+            },
+            "odoo://api/datetime": {
+                "description": "Server date formats, UTC storage, dynamic domain values, date parts",
+                "example": "odoo://api/datetime",
+            },
+            "odoo://api/mail-thread": {
+                "description": "message_post signature, notification kill-switches, followers, activities",
+                "example": "odoo://api/mail-thread",
+            },
+            "odoo://api/security-model": {
+                "description": "ACL / record rule / field group composition and how to test access",
+                "example": "odoo://api/security-model",
+            },
+            "odoo://api/web-read": {
+                "description": "web_read / web_search_read nested specification",
+                "example": "odoo://api/web-read",
+            },
+            "odoo://api/xmlids": {
+                "description": "XML id resolution over JSON-2 and custom model/field constraints",
+                "example": "odoo://api/xmlids",
+            },
+            "odoo://session": {
+                "description": "Live identity: uid, login, lang, tz, companies, installed languages",
+                "example": "odoo://session",
             },
             "odoo://module-knowledge/{module_name}": {
                 "description": "Get knowledge for a specific module (special methods, patterns)",

--- a/src/odoo_mcp/resources.py
+++ b/src/odoo_mcp/resources.py
@@ -19,6 +19,12 @@ from typing import Any, Callable, Dict, Sequence, TypeVar
 
 import anyio
 
+from .api_reference import (
+    build_api_index,
+    json2_protocol_reference,
+    version_drift_reference,
+    x2many_commands_reference,
+)
 from .app import mcp
 from .constants import (
     _DEFAULT_BOOTSTRAP_MODELS,
@@ -44,6 +50,7 @@ from .utils import (
     fields_cache_get,
     fields_cache_key,
     fields_cache_put,
+    get_live_api_index,
 )
 
 logger = logging.getLogger(__name__)
@@ -422,21 +429,37 @@ def get_session_bootstrap() -> str:
     description="Get a specific record by ID",
 )
 def get_record(model_name: str, record_id: str) -> str:
-    """Get a specific record by ID"""
+    """Get a specific record by ID — every non-binary field.
+
+    Binary fields (``image_*``, ``avatar_*``, attachments…) are excluded from
+    the ``read``: on ``res.partner`` they weighed ~550 KB of base64 for one
+    record, and the 15 000-char ``read_resource`` cap then cut the JSON in the
+    middle of a blob. Their names are listed under ``_omitted_binary_fields``
+    so the caller knows what to fetch separately.
+    """
     err = _validate_model(model_name)
     if err:
         return json.dumps({"error": err, "hint": _MODEL_LOOKUP_HINT}, separators=(",", ":"))
-    odoo_client = get_odoo_client()
-    try:
-        if not record_id or record_id == "None":
-            return json.dumps({"error": "Record ID is required"}, indent=2)
+    if not record_id or not record_id.isdigit():
+        return json.dumps({"error": f"Record ID must be a positive integer, got {record_id!r}"}, indent=2)
+    fields, error = _fetch_model_fields(model_name, attributes=COMPACT_FIELD_ATTRIBUTES)
+    if fields is None:
+        return json.dumps(error, separators=(",", ":"))
 
-        record = odoo_client.read_records(model_name, [int(record_id)])
-        if not record:
-            return json.dumps({"error": f"Record not found: {model_name} ID {record_id}"}, indent=2)
-        return json.dumps(record[0], indent=2)
+    readable = sorted(name for name, meta in fields.items() if meta.get("type") != "binary")
+    omitted = sorted(name for name, meta in fields.items() if meta.get("type") == "binary")
+    if not readable:
+        # Odoo's read() treats an empty field list as "every field" — which
+        # would bring the blobs straight back. Refuse instead of failing open.
+        return json.dumps({"error": f"{model_name} exposes no non-binary field to read"}, indent=2)
+    try:
+        record = get_odoo_client().read_records(model_name, [int(record_id)], fields=readable)
     except Exception as e:
         return json.dumps({"error": str(e)}, indent=2)
+    if not record:
+        return json.dumps({"error": f"Record not found: {model_name} ID {record_id}"}, indent=2)
+    payload = {**record[0], "_omitted_binary_fields": omitted} if omitted else record[0]
+    return json.dumps(payload, indent=2)
 
 
 @_threaded_resource(
@@ -544,6 +567,54 @@ def get_model_docs(model_name: str) -> str:
 
 
 @mcp.resource(
+    "odoo://api/json2-protocol",
+    description="JSON-2 contract: URL, body keys (ids/context/named params), error shape, status codes, transactions",
+)
+def get_json2_protocol() -> str:
+    """Static reference transcribed from odoo/addons/rpc/controllers/json2.py and odoo/http.py."""
+    return json.dumps(json2_protocol_reference(), indent=2)
+
+
+@mcp.resource(
+    "odoo://api/version-drift",
+    description="ORM renames since Odoo 15.2 (name_get, args→domain, read_group, check_access…) "
+    "and their JSON-2 impact",
+)
+def get_version_drift() -> str:
+    """Static reference transcribed from the ORM changelog."""
+    return json.dumps(version_drift_reference(), indent=2)
+
+
+@mcp.resource(
+    "odoo://api/x2many-commands",
+    description="One2many/Many2many command triples [code, id, value] accepted over RPC, with examples",
+)
+def get_x2many_commands() -> str:
+    """Static reference transcribed from odoo/orm/commands.py."""
+    return json.dumps(x2many_commands_reference(), indent=2)
+
+
+@mcp.resource(
+    "odoo://api-index",
+    description="Live catalogue from /doc-bearer/index.json: installed modules + every readable model "
+    "with field/method counts",
+)
+def get_api_index() -> str:
+    """Compact, per-identity-cached view of the api_doc index (falls back to an actionable error)."""
+    raw = get_live_api_index()
+    if raw is None:
+        return json.dumps(
+            {
+                "error": "/doc-bearer/index.json is unavailable",
+                "hint": "The API user needs the api_doc.group_allow_doc group (implied by Settings admin). "
+                "Until then use odoo://models for the model list.",
+            },
+            indent=2,
+        )
+    return json.dumps(build_api_index(raw), separators=(",", ":"))
+
+
+@mcp.resource(
     "odoo://concepts",
     description="Mapping of business concepts to Odoo model names (contact->res.partner, invoice->account.move)",
 )
@@ -628,6 +699,22 @@ def get_resource_templates() -> str:
             "odoo://docs/{target}": {
                 "description": "Documentation URLs and GitHub links for any model or module",
                 "example": "odoo://docs/sale",
+            },
+            "odoo://api/json2-protocol": {
+                "description": "JSON-2 contract: body keys, error shape, status codes, transaction rule",
+                "example": "odoo://api/json2-protocol",
+            },
+            "odoo://api/version-drift": {
+                "description": "ORM renames since 15.2 and what to call instead over JSON-2",
+                "example": "odoo://api/version-drift",
+            },
+            "odoo://api/x2many-commands": {
+                "description": "One2many/Many2many command triples with examples",
+                "example": "odoo://api/x2many-commands",
+            },
+            "odoo://api-index": {
+                "description": "Live catalogue of installed modules and readable models (api_doc index)",
+                "example": "odoo://api-index",
             },
             "odoo://module-knowledge/{module_name}": {
                 "description": "Get knowledge for a specific module (special methods, patterns)",

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -1281,6 +1281,12 @@ _RESOURCE_ROUTES: list[tuple[re.Pattern[str], Any, list[str]]] = [
         (r"^odoo://api/version-drift$", _resources.get_version_drift, []),
         (r"^odoo://api/x2many-commands$", _resources.get_x2many_commands, []),
         (r"^odoo://api-index$", _resources.get_api_index, []),
+        (r"^odoo://api/datetime$", _resources.get_datetime_guide, []),
+        (r"^odoo://api/mail-thread$", _resources.get_mail_thread_guide, []),
+        (r"^odoo://api/security-model$", _resources.get_security_model_guide, []),
+        (r"^odoo://api/web-read$", _resources.get_web_read_guide, []),
+        (r"^odoo://api/xmlids$", _resources.get_xmlids_guide, []),
+        (r"^odoo://session$", _resources.get_session, []),
     ]
 ]
 

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -1277,6 +1277,10 @@ _RESOURCE_ROUTES: list[tuple[re.Pattern[str], Any, list[str]]] = [
         (r"^odoo://hierarchical$", _resources.get_hierarchical_guide, []),
         (r"^odoo://aggregation$", _resources.get_aggregation_guide, []),
         (r"^odoo://tool-registry$", _resources.get_tool_registry, []),
+        (r"^odoo://api/json2-protocol$", _resources.get_json2_protocol, []),
+        (r"^odoo://api/version-drift$", _resources.get_version_drift, []),
+        (r"^odoo://api/x2many-commands$", _resources.get_x2many_commands, []),
+        (r"^odoo://api-index$", _resources.get_api_index, []),
     ]
 ]
 

--- a/src/odoo_mcp/utils.py
+++ b/src/odoo_mcp/utils.py
@@ -15,6 +15,9 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Sequence, cast
 
 from .constants import (
+    _API_INDEX_CACHE,
+    _API_INDEX_CACHE_LOCK,
+    _API_INDEX_CACHE_MAX_ENTRIES,
     _DOC_CACHE,
     _DOC_CACHE_LOCK,
     _DOC_CACHE_MAX_ENTRIES,
@@ -95,6 +98,38 @@ def _get_live_doc(model_name: str) -> Optional[Dict[str, Any]]:
         logger.warning("/doc-bearer/ unavailable for %s: %s", model_name, e)
 
     return None
+
+
+def get_live_api_index() -> Optional[Dict[str, Any]]:
+    """Cached ``/doc-bearer/index.json`` for the current client identity.
+
+    Keyed by (url, username) because the index is filtered by the caller's
+    groups — in multi-user mode two registry users must not share it. TTL is
+    ``_DOC_CACHE_TTL``, at most ``_API_INDEX_CACHE_MAX_ENTRIES`` identities
+    (oldest evicted). Returns None when the endpoint is unavailable.
+    """
+    client = get_odoo_client()
+    key = (getattr(client, "url", None), getattr(client, "username", None))
+    now = time.time()
+    with _API_INDEX_CACHE_LOCK:
+        cached = _API_INDEX_CACHE.get(key)
+        if cached and now - cached[0] < _DOC_CACHE_TTL:
+            return cast(Dict[str, Any], cached[1])
+    index = client.get_api_index()
+    if not index or not isinstance(index, dict) or "models" not in index:
+        return None
+    with _API_INDEX_CACHE_LOCK:
+        _API_INDEX_CACHE[key] = (now, index)
+        while len(_API_INDEX_CACHE) > _API_INDEX_CACHE_MAX_ENTRIES:
+            oldest = min(_API_INDEX_CACHE, key=lambda k: _API_INDEX_CACHE[k][0])
+            del _API_INDEX_CACHE[oldest]
+    return index
+
+
+def clear_api_index_cache() -> None:
+    """Drop every cached index (tests, credential rotation)."""
+    with _API_INDEX_CACHE_LOCK:
+        _API_INDEX_CACHE.clear()
 
 
 def _categorize_error(error_msg: str) -> str:

--- a/tests/test_api_reference.py
+++ b/tests/test_api_reference.py
@@ -1,0 +1,218 @@
+"""Unit tests for the v1.18 API reference resources.
+
+Three static references (``odoo://api/json2-protocol``, ``odoo://api/version-drift``,
+``odoo://api/x2many-commands``) transcribed from the Odoo 19 source / docs, and one
+live catalogue (``odoo://api-index``) built from ``/doc-bearer/index.json``.
+The facts pinned here are the ones an LLM trained on Odoo <= 16 gets wrong.
+"""
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import odoo_mcp.app  # noqa: F401  (binds the mcp decorator first)
+import odoo_mcp.resources as resources
+import odoo_mcp.utils as utils
+from odoo_mcp import api_reference
+from odoo_mcp.app import mcp
+from odoo_mcp.server import _RESOURCE_ROUTES, read_resource
+
+# ----- odoo://api/json2-protocol -----
+
+
+def test_json2_protocol_states_named_args_only_and_the_ids_rule():
+    ref = api_reference.json2_protocol_reference()
+    assert ref["endpoint"] == "POST {ODOO_URL}/json/2/{model}/{method}"
+    assert set(ref["body"]) >= {"ids", "context"}
+    assert ref["positional_args"] is False
+    assert "@api.model" in ref["body"]["ids"] and "422" in ref["body"]["ids"]
+
+
+def test_json2_protocol_error_shape_and_status_table():
+    ref = api_reference.json2_protocol_reference()
+    assert ref["error_body_keys"] == ["name", "message", "arguments", "context", "debug"]
+    statuses = ref["status_codes"]
+    assert "signature" in statuses["422"].lower()
+    assert "private" in statuses["403"].lower() and "private" not in statuses["404"].lower()
+    assert "403" in ref["private_methods"]
+    assert "html" in statuses["415"].lower()
+    assert "500" in statuses
+
+
+def test_json2_protocol_documents_transaction_isolation_and_rate_limits():
+    ref = api_reference.json2_protocol_reference()
+    assert "own SQL transaction" in ref["transactions"]["rule"]
+    assert "action_" in ref["transactions"]["advice"]
+    assert ref["rate_limiting"]["odoo_core"] is None
+    assert "429" in ref["rate_limiting"]["this_server"]
+
+
+# ----- odoo://api/version-drift -----
+
+
+@pytest.mark.parametrize(
+    "old,new",
+    [
+        ("name_get", "display_name"),
+        ("args", "domain"),
+        ("read_group", "formatted_read_group"),
+        ("check_access_rights", "check_access"),
+        ("group_operator", "aggregator"),
+    ],
+)
+def test_version_drift_maps_each_legacy_name_to_its_replacement(old, new):
+    entries = {e["old"]: e for e in api_reference.version_drift_reference()["changes"]}
+    assert new in entries[old]["use"]
+    assert entries[old]["since"]
+    assert entries[old]["pr"].startswith("https://github.com/odoo/odoo/pull/")
+
+
+def test_version_drift_never_claims_a_deprecated_method_is_gone():
+    """check_access_rights / check_access_rule are @api.deprecated in 19.0, not removed nor private."""
+    entries = {e["old"]: e for e in api_reference.version_drift_reference()["changes"]}
+    for old in ("check_access_rights", "check_access_rule"):
+        assert "deprecated" in entries[old]["json2_impact"].lower()
+        assert "404" not in entries[old]["json2_impact"]
+
+
+def test_version_drift_reports_private_methods_as_403():
+    changes = api_reference.version_drift_reference()["changes"]
+    private_entries = [e for e in changes if "@api.private" in e["use"] or "search_fetch" in e["use"]]
+    assert private_entries
+    assert all("403" in e["json2_impact"] for e in private_entries)
+
+
+def test_version_drift_entries_carry_the_json2_impact():
+    changes = api_reference.version_drift_reference()["changes"]
+    assert all({"since", "old", "use", "json2_impact", "pr"} <= set(e) for e in changes)
+    assert any("@api.private" in e["old"] or "@api.private" in e["use"] for e in changes)
+
+
+# ----- odoo://api/x2many-commands -----
+
+
+def test_x2many_commands_lists_the_seven_literal_triples():
+    ref = api_reference.x2many_commands_reference()
+    codes = {c["code"]: c for c in ref["commands"]}
+    assert sorted(codes) == [0, 1, 2, 3, 4, 5, 6]
+    assert codes[0]["shape"] == "[0, 0, values]"
+    assert codes[6]["shape"] == "[6, 0, ids]"
+    assert "literal" in ref["rpc_rule"].lower()
+    assert "many2many" in codes[0]["notes"].lower()
+    assert "cascade" in codes[3]["notes"].lower()
+
+
+# ----- odoo://api-index -----
+
+_RAW_INDEX = {
+    "modules": ["base", "web", "sale"],
+    "models": [
+        {
+            "model": "sale.order",
+            "name": "Sales Order",
+            "fields": {"name": {"string": "Order Reference"}, "state": {"string": "Status"}},
+            "methods": ["action_confirm", "read"],
+        },
+        {"model": "res.partner", "name": "Contact", "fields": {"name": {"string": "Name"}}, "methods": ["read"]},
+    ],
+}
+
+
+def test_build_api_index_keeps_names_and_counts_but_drops_field_maps():
+    out = api_reference.build_api_index(_RAW_INDEX)
+    assert out["module_count"] == 3 and out["model_count"] == 2
+    assert out["modules"] == ["base", "web", "sale"]
+    assert out["models"] == [
+        {"model": "res.partner", "name": "Contact", "field_count": 1, "method_count": 1},
+        {"model": "sale.order", "name": "Sales Order", "field_count": 2, "method_count": 2},
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _clear_api_index_cache():
+    utils.clear_api_index_cache()
+    yield
+    utils.clear_api_index_cache()
+
+
+def _client(index, url="https://a.example.com", username="bot"):
+    client = MagicMock()
+    client.url, client.username = url, username
+    client.get_api_index.return_value = index
+    return client
+
+
+def test_api_index_resource_returns_the_compact_catalogue():
+    with patch.object(utils, "get_odoo_client", return_value=_client(_RAW_INDEX)):
+        out = json.loads(resources.get_api_index())
+    assert out["model_count"] == 2
+    assert out["source"] == "/doc-bearer/index.json"
+
+
+def test_api_index_unavailable_doc_endpoint_gives_an_actionable_error():
+    with patch.object(utils, "get_odoo_client", return_value=_client(None)):
+        out = json.loads(resources.get_api_index())
+    assert "api_doc.group_allow_doc" in out["hint"]
+    assert "odoo://models" in out["hint"]
+
+
+def test_api_index_cache_is_bounded():
+    from odoo_mcp.constants import _API_INDEX_CACHE, _API_INDEX_CACHE_MAX_ENTRIES
+
+    for i in range(_API_INDEX_CACHE_MAX_ENTRIES + 3):
+        with patch.object(utils, "get_odoo_client", return_value=_client(_RAW_INDEX, username=f"user{i}")):
+            resources.get_api_index()
+    assert len(_API_INDEX_CACHE) == _API_INDEX_CACHE_MAX_ENTRIES
+
+
+def test_api_index_is_cached_per_client_identity():
+    shared = _client(_RAW_INDEX)
+    other = _client(_RAW_INDEX, username="someone-else")
+    with patch.object(utils, "get_odoo_client", return_value=shared):
+        resources.get_api_index()
+        resources.get_api_index()
+    with patch.object(utils, "get_odoo_client", return_value=other):
+        resources.get_api_index()
+    assert shared.get_api_index.call_count == 1
+    assert other.get_api_index.call_count == 1
+
+
+# ----- bridge routes + parity -----
+
+
+@pytest.mark.parametrize("uri", ["odoo://api/json2-protocol", "odoo://api/version-drift", "odoo://api/x2many-commands"])
+def test_bridge_routes_the_static_reference_uris(uri):
+    out = json.loads(read_resource(uri, max_chars=0))
+    assert "error" not in out
+
+
+def test_bridge_routes_api_index():
+    with patch.object(utils, "get_odoo_client", return_value=_client(_RAW_INDEX)):
+        out = json.loads(read_resource("odoo://api-index", max_chars=0))
+    assert out["model_count"] == 2
+
+
+def test_every_registered_resource_has_exactly_one_bridge_route():
+    """Adding a resource without a route silently 404s read_resource; this pins parity."""
+    statics = asyncio.run(mcp.list_resources(run_middleware=False))
+    templates = asyncio.run(mcp.list_resource_templates(run_middleware=False))
+    uris = [str(r.uri) for r in statics] + [t.uri_template for t in templates]
+    samples = {
+        "{model_name}": "res.partner",
+        "{record_id}": "1",
+        "{models_csv}": "res.partner,sale.order",
+        "{concept}": "invoice",
+        "{query}": "invoice",
+        "{model}": "sale.order",
+        "{target}": "sale",
+        "{module_name}": "sale",
+    }
+    for uri in uris:
+        for placeholder, value in samples.items():
+            uri = uri.replace(placeholder, value)
+        assert "{" not in uri, f"unmapped placeholder in {uri}"
+        matches = [p.pattern for p, _, _ in _RESOURCE_ROUTES if p.match(uri)]
+        assert len(matches) == 1, f"expected exactly one bridge route for {uri}, got {matches}"
+    assert len(uris) == len(_RESOURCE_ROUTES)

--- a/tests/test_odoo_client.py
+++ b/tests/test_odoo_client.py
@@ -12,10 +12,11 @@ These pin two corrections derived from Odoo 19's External JSON-2 API
      legitimately returns a dict containing ``result`` gets corrupted.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from odoo_mcp.constants import RATE_LIMIT_RETRY_DEFAULT_DELAY, RATE_LIMIT_RETRY_MAX_DELAY
 from odoo_mcp.odoo_client import OdooClient
 
 
@@ -137,3 +138,90 @@ class TestFieldsGetAttributes:
         client.get_model_fields("res.partner")
 
         assert client.session.post.call_args.kwargs["json"] == {}
+
+
+class TestRateLimitRetry:
+    """Odoo SaaS answers a burst of requests with 429 Too Many Requests.
+
+    A single retry after the ``Retry-After`` delay turns a transient throttle
+    into a successful call instead of an ``errors`` entry in session-bootstrap.
+    """
+
+    @staticmethod
+    def _rate_limited(retry_after=None):
+        resp = _stub_response({"message": "Too Many Requests"}, status_code=429)
+        resp.reason = "Too Many Requests"
+        resp.url = "https://mycompany.example.com/json/2/res.partner/fields_get"
+        resp.headers = {"Retry-After": str(retry_after)} if retry_after is not None else {}
+        return resp
+
+    def test_retries_once_after_429_and_returns_the_result(self):
+        client = _make_client()
+        client.session.post = MagicMock(side_effect=[self._rate_limited(retry_after=2), _stub_response({"id": 1})])
+        with patch("odoo_mcp.odoo_client.time.sleep") as sleep:
+            result = client.execute_method("res.partner", "read", [1])
+        assert result == {"id": 1}
+        assert client.session.post.call_count == 2
+        sleep.assert_called_once_with(2.0)
+
+    def test_429_without_retry_after_header_waits_the_default_delay(self):
+        client = _make_client()
+        client.session.post = MagicMock(side_effect=[self._rate_limited(), _stub_response([])])
+        with patch("odoo_mcp.odoo_client.time.sleep") as sleep:
+            client.execute_method("res.partner", "read", [1])
+        sleep.assert_called_once_with(RATE_LIMIT_RETRY_DEFAULT_DELAY)
+
+    def test_retry_after_is_capped_so_a_hostile_header_cannot_stall_the_server(self):
+        client = _make_client()
+        client.session.post = MagicMock(side_effect=[self._rate_limited(retry_after=3600), _stub_response([])])
+        with patch("odoo_mcp.odoo_client.time.sleep") as sleep:
+            client.execute_method("res.partner", "read", [1])
+        sleep.assert_called_once_with(RATE_LIMIT_RETRY_MAX_DELAY)
+
+    def test_unparseable_retry_after_falls_back_to_the_default_delay(self):
+        client = _make_client()
+        client.session.post = MagicMock(
+            side_effect=[self._rate_limited(retry_after="Wed, 21 Oct 2026 07:28:00 GMT"), _stub_response([])]
+        )
+        with patch("odoo_mcp.odoo_client.time.sleep") as sleep:
+            client.execute_method("res.partner", "read", [1])
+        sleep.assert_called_once_with(RATE_LIMIT_RETRY_DEFAULT_DELAY)
+
+    def test_second_429_is_raised_not_retried_forever(self):
+        client = _make_client()
+        client.session.post = MagicMock(
+            side_effect=[self._rate_limited(retry_after=1), self._rate_limited(retry_after=1)]
+        )
+        with patch("odoo_mcp.odoo_client.time.sleep"), pytest.raises(ValueError, match="429"):
+            client.execute_method("res.partner", "read", [1])
+        assert client.session.post.call_count == 2
+
+    def test_other_http_errors_are_not_retried(self):
+        client = _make_client()
+        failed = _stub_response({"message": "boom"}, status_code=500)
+        failed.reason = "Internal Server Error"
+        failed.url = "https://mycompany.example.com/json/2/res.partner/read"
+        client.session.post = MagicMock(return_value=failed)
+        with patch("odoo_mcp.odoo_client.time.sleep") as sleep, pytest.raises(ValueError, match="500"):
+            client.execute_method("res.partner", "read", [1])
+        assert client.session.post.call_count == 1
+        sleep.assert_not_called()
+
+    def test_side_effect_methods_are_never_retried_after_429(self):
+        """A 429 may be raised after partial processing on some stacks — never re-send a write."""
+        client = _make_client()
+        client.session.post = MagicMock(side_effect=[self._rate_limited(retry_after=1), _stub_response([])])
+        with patch("odoo_mcp.odoo_client.time.sleep") as sleep, pytest.raises(ValueError, match="429"):
+            client.execute_method("res.partner", "unlink", [1])
+        assert client.session.post.call_count == 1
+        sleep.assert_not_called()
+
+    def test_connection_error_on_the_retry_surfaces_as_connection_error(self):
+        import requests
+
+        client = _make_client()
+        client.session.post = MagicMock(
+            side_effect=[self._rate_limited(retry_after=1), requests.exceptions.ConnectionError("down")]
+        )
+        with patch("odoo_mcp.odoo_client.time.sleep"), pytest.raises(ConnectionError):
+            client.execute_method("res.partner", "read", [1])

--- a/tests/test_orm_guides.py
+++ b/tests/test_orm_guides.py
@@ -1,0 +1,212 @@
+"""Unit tests for the v1.18 ORM guide resources (points 4–8 and 10 of the API-reference plan).
+
+Static guides live in ``odoo_mcp.orm_guides`` and are transcribed from the Odoo 19
+source / docs; ``odoo://session`` is live (context_get + user + languages).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import odoo_mcp.app  # noqa: F401
+import odoo_mcp.resources as resources
+from odoo_mcp import orm_guides
+from odoo_mcp.server import read_resource
+
+# ----- odoo://api/datetime -----
+
+
+def test_datetime_reference_pins_server_formats_and_utc_storage():
+    ref = orm_guides.datetime_reference()
+    assert ref["write_formats"]["date"] == "YYYY-MM-DD"
+    assert ref["write_formats"]["datetime"] == "YYYY-MM-DD HH:MM:SS"
+    assert "utc" in ref["storage"].lower() and "client" in ref["timezone"].lower()
+    assert "T" in ref["rejected_forms"][0] or "iso" in ref["rejected_forms"][0].lower()
+
+
+def test_datetime_reference_documents_dynamic_domain_values():
+    ref = orm_guides.datetime_reference()
+    assert ref["dynamic_domain_values"]["units"] == {
+        "d": "days",
+        "w": "weeks",
+        "m": "months",
+        "y": "years",
+        "H": "hours",
+        "M": "minutes",
+        "S": "seconds",
+    }
+    assert "=monday -1w" in json.dumps(ref["dynamic_domain_values"]["examples"])
+
+
+# ----- odoo://api/mail-thread -----
+
+
+def test_mail_thread_reference_gives_the_keyword_only_message_post_signature():
+    ref = orm_guides.mail_thread_reference()
+    post = ref["message_post"]
+    assert post["keyword_only"] is True
+    assert "body_is_html" in post["params"] and "partner_ids" in post["params"]
+    assert post["returns"].startswith("list") and "[123]" in post["returns"]  # JSON-2 unwraps the recordset to .ids
+    assert "outgoing_email_to" in post["signature"]
+    assert "ids" in post["json2_example"]
+
+
+def test_mail_thread_reference_lists_the_notification_kill_switches():
+    ref = orm_guides.mail_thread_reference()
+    switches = ref["context_kill_switches"]
+    for key in (
+        "mail_notrack",
+        "tracking_disable",
+        "mail_create_nosubscribe",
+        "mail_create_nolog",
+        "mail_notify_force_send",
+    ):
+        assert key in switches
+
+
+def test_mail_thread_reference_covers_followers_and_activities():
+    ref = orm_guides.mail_thread_reference()
+    assert "partner_ids" in ref["followers"]["message_subscribe"]
+    assert "act_type_xmlid" in ref["activities"]["activity_schedule"]
+    assert "activity_feedback" in ref["activities"]
+
+
+# ----- odoo://api/security-model -----
+
+
+def test_security_model_reference_states_the_composition_rules():
+    ref = orm_guides.security_model_reference()
+    assert "union" in ref["access_rights"]["composition"].lower()
+    assert "allow" in ref["record_rules"]["default"].lower()
+    assert "and" in ref["record_rules"]["global_rules"].lower() and "or" in ref["record_rules"]["group_rules"].lower()
+    assert "fields_get" in ref["field_groups"]["symptom"]
+
+
+def test_security_model_reference_points_to_the_callable_checks():
+    ref = orm_guides.security_model_reference()
+    assert "has_access" in ref["how_to_check"]
+    assert "403" in ref["how_to_check"]["check_access"]
+    assert "has_group" in ref["how_to_check"]
+
+
+# ----- odoo://api/web-read -----
+
+
+def test_web_read_reference_shows_the_nested_specification():
+    ref = orm_guides.web_read_reference()
+    spec = ref["specification"]["example"]
+    assert spec["partner_id"]["fields"]["name"] == {}
+    assert ref["methods"]["web_search_read"]["returns"].startswith("{'length'")
+    assert "load" in ref["specification"]["many2one_without_fields"]
+
+
+def test_web_read_reference_marks_web_save_as_a_write():
+    ref = orm_guides.web_read_reference()
+    assert ref["methods"]["web_save"]["side_effect"] is True
+    assert ref["methods"]["web_read"]["side_effect"] is False
+
+
+# ----- odoo://api/xmlids -----
+
+
+def test_xmlids_reference_gives_the_only_public_resolver():
+    ref = orm_guides.xmlids_reference()
+    assert "check_object_reference" in ref["resolve"]["method"]
+    assert ref["resolve"]["model"] == "ir.model.data"
+    assert "env.ref" in ref["resolve"]["note"]
+
+
+def test_xmlids_reference_lists_custom_model_constraints():
+    ref = orm_guides.xmlids_reference()
+    assert "x_" in ref["custom_models"]["name_prefix"]
+    assert "manual" in ref["custom_models"]["state"]
+    assert any("compute" in c.lower() for c in ref["custom_fields"]["not_possible"])
+
+
+# ----- odoo://domain-syntax additions -----
+
+
+def test_domain_syntax_now_documents_dynamic_dates_date_parts_and_any_bang():
+    out = json.loads(resources.get_domain_syntax())
+    assert out["dynamic_dates"]["units"]["H"] == "hours"
+    assert "month_number" in out["date_parts"]["granularities"]
+    assert "any!" in out["operators"]["relational"]
+
+
+# ----- odoo://session (live) -----
+
+_USER = {"id": 7, "name": "Bot", "login": "bot", "company_id": [1, "Cyanview"], "company_ids": [1, 2]}
+
+
+def _session_client(context=None, user=_USER, langs=None, companies=None):
+    client = MagicMock()
+
+    def execute(model, method, *args, **kwargs):
+        if (model, method) == ("res.users", "context_get"):
+            return context if context is not None else {"lang": "en_US", "tz": "Europe/Brussels", "uid": 7}
+        if (model, method) == ("res.lang", "get_installed"):
+            return langs if langs is not None else [["en_US", "English (US)"], ["fr_FR", "French"]]
+        raise AssertionError(f"unexpected call {model}.{method}")
+
+    client.execute_method.side_effect = execute
+    client.read_records.return_value = [user] if user else []
+    client.search_read.return_value = (
+        companies if companies is not None else [{"id": 1, "name": "Cyanview"}, {"id": 2, "name": "Cyanview US"}]
+    )
+    return client
+
+
+def test_session_resource_assembles_identity_timezone_and_companies():
+    client = _session_client()
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        out = json.loads(resources.get_session())
+    assert out["uid"] == 7 and out["login"] == "bot"
+    assert out["lang"] == "en_US" and out["tz"] == "Europe/Brussels"
+    assert out["company"] == {"id": 1, "name": "Cyanview"}
+    assert out["allowed_companies"] == [{"id": 1, "name": "Cyanview"}, {"id": 2, "name": "Cyanview US"}]
+    assert out["installed_languages"] == [
+        {"code": "en_US", "name": "English (US)"},
+        {"code": "fr_FR", "name": "French"},
+    ]
+    assert "allowed_company_ids" in out["context_hint"]
+
+
+def test_session_resource_reads_the_user_by_the_uid_from_context_get():
+    client = _session_client()
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        resources.get_session()
+    assert client.read_records.call_args.args[:2] == ("res.users", [7])
+    assert client.search_read.call_args.kwargs.get("domain") == [["id", "in", [1, 2]]]
+
+
+def test_session_resource_reports_a_failed_context_get_without_raising():
+    client = MagicMock()
+    client.execute_method.side_effect = ValueError("Request failed: 401 UNAUTHORIZED")
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        out = json.loads(resources.get_session())
+    assert "401" in out["error"]
+
+
+# ----- bridge -----
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "odoo://api/datetime",
+        "odoo://api/mail-thread",
+        "odoo://api/security-model",
+        "odoo://api/web-read",
+        "odoo://api/xmlids",
+    ],
+)
+def test_bridge_routes_the_static_guides(uri):
+    out = json.loads(read_resource(uri, max_chars=0))
+    assert "error" not in out and out["source"]
+
+
+def test_bridge_routes_session():
+    with patch.object(resources, "get_odoo_client", return_value=_session_client()):
+        out = json.loads(read_resource("odoo://session", max_chars=0))
+    assert out["uid"] == 7

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -232,3 +232,81 @@ def test_non_schema_handlers_reject_malformed_model_names_before_any_call(call):
     assert "Invalid model name" in payload["error"]
     assert client.method_calls == []
     assert live_doc.call_count == 0
+
+
+# ----- odoo://record/{model}/{id} must not ship binary blobs -----
+
+_FIELDS_WITH_IMAGES = {
+    **_VALID_FIELDS,
+    "image_1920": {"type": "binary", "string": "Image"},
+    "avatar_128": {"type": "binary", "string": "Avatar"},
+}
+
+
+def _record_client(fields, record):
+    client = _stub_client({"res.partner": fields})
+    client.read_records.return_value = [record]
+    return client
+
+
+def test_record_excludes_binary_fields_from_the_read():
+    """A partner with images weighed 568 KB of base64 — truncated to 15 000 chars it was unreadable JSON."""
+    client = _record_client(_FIELDS_WITH_IMAGES, {"id": 1, "name": "Azure", "partner_id": False, "state": "draft"})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        out = json.loads(resources.get_record("res.partner", "1"))
+    requested = client.read_records.call_args.kwargs["fields"]
+    assert set(requested) == {"id", "name", "partner_id", "state"}
+    assert out["name"] == "Azure"
+    assert out["_omitted_binary_fields"] == ["avatar_128", "image_1920"]
+
+
+def test_record_without_binary_fields_has_no_omission_marker():
+    client = _record_client(_VALID_FIELDS, {"id": 1, "name": "Azure"})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        out = json.loads(resources.get_record("res.partner", "1"))
+    assert "_omitted_binary_fields" not in out
+    assert out == {"id": 1, "name": "Azure"}
+
+
+def test_record_field_lookup_shares_the_compact_schema_cache_entry():
+    client = _record_client(_FIELDS_WITH_IMAGES, {"id": 1})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        resources.get_model_quick_schema("res.partner")
+        resources.get_record("res.partner", "1")
+    assert client.get_model_fields.call_count == 1
+    assert _attributes_requested(client) == [list(COMPACT_FIELD_ATTRIBUTES)]
+
+
+def test_record_unknown_model_reports_not_found_without_reading():
+    client = _stub_client({"this.does.not.exist": _ERROR_SENTINEL})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        out = json.loads(resources.get_record("this.does.not.exist", "1"))
+    assert "not found" in out["error"]
+    assert client.read_records.call_count == 0
+
+
+def test_record_missing_id_still_reports_not_found():
+    client = _record_client(_VALID_FIELDS, {"id": 1})
+    client.read_records.return_value = []
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        out = json.loads(resources.get_record("res.partner", "999999999"))
+    assert out["error"] == "Record not found: res.partner ID 999999999"
+
+
+def test_record_with_only_binary_fields_never_sends_an_empty_field_list():
+    """Odoo's read() treats fields=[] as 'all fields' — which would bring the blobs back."""
+    only_binary = {"image_1920": {"type": "binary", "string": "Image"}}
+    client = _record_client(only_binary, {"id": 1})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        out = json.loads(resources.get_record("res.partner", "1"))
+    assert "error" in out
+    assert client.read_records.call_count == 0
+
+
+@pytest.mark.parametrize("record_id", ["", "None", "abc", "1.5"])
+def test_record_rejects_a_bad_record_id_before_any_odoo_call(record_id):
+    client = _record_client(_VALID_FIELDS, {"id": 1})
+    with patch.object(resources, "get_odoo_client", return_value=client):
+        out = json.loads(resources.get_record("res.partner", record_id))
+    assert "error" in out
+    assert client.method_calls == []


### PR DESCRIPTION
## Summary

Ten new `odoo://` resources (28 → 38) and two robustness fixes, all found while auditing every resource against the production Odoo (saas~19.2).

### Added
- **Static API references** transcribed from the Odoo 19 source/docs, each payload naming its source file: `odoo://api/json2-protocol`, `odoo://api/version-drift`, `odoo://api/x2many-commands`, `odoo://api/datetime`, `odoo://api/mail-thread`, `odoo://api/security-model`, `odoo://api/web-read`, `odoo://api/xmlids` (`api_reference.py`, `orm_guides.py`).
- **Live catalogues**: `odoo://api-index` (`/doc-bearer/index.json` compacted from 2.4 MB to ~90 KB, cached per `(url, username)`, bounded) and `odoo://session` (`context_get` + user + companies + installed languages).
- `odoo://domain-syntax` gains `dynamic_dates`, `date_parts`, `any!` / `not any!`.
- Handler ↔ bridge-route parity is now pinned by a test.

### Fixed
- `odoo://record/{model}/{id}` no longer ships binary fields (a partner weighed 568 KB of base64 and the 15 000-char cap cut the JSON mid-blob); omitted names are listed under `_omitted_binary_fields`.
- `OdooClient` retries read methods once after `429 Too Many Requests` (Retry-After honoured, capped at 5 s); side-effect methods are never re-sent.

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/live` → 519 passed (458 before)
- [x] `black --check` / `isort --check-only` clean; `ruff` 26 / `mypy` 51 (unchanged baseline)
- [x] Every one of the 38 resources read live against erp.cyanview.com through both the `read_resource` bridge and the native resource path
- [x] Two code-review passes; every factual claim in the static references verified against `~/ddev/odoo19-source` (403 vs 404 for private methods, `check_access_rights` deprecated not removed, `message_post` returns `[id]`, PR numbers)

https://claude.ai/code/session_01KAef5yfHM7ZdtoPnizGwoa
