### PR TITLE
fix(safety): gate every write in strict/locked mode and report safety on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Strict mode now gates every write.** Since v1.10.0 a MEDIUM method
+  (`create`, `write`, `copy`, `name_create`, `load`) on a non-sensitive model
+  only required confirmation when it touched more than one record: a `write` on
+  one real quotation, opportunity or customer executed unconfirmed from a single
+  tool call with `pending_confirmation=false`, and `batch_execute` inherited the
+  hole because `classify_batch` only aggregates the per-operation flags. In
+  `strict` (the default) and `locked` every side-effect call now issues a
+  confirmation token whatever the record count; `permissive` is unchanged.
+  `tests/test_strict_single_write_gate.py` pins the closure end-to-end through
+  `execute_method`.
+- **`safety` is reported on successful `execute_method` responses** (it was
+  `null` unless the call was blocked or gated), so a caller can see the risk
+  level and the reason a call was or was not gated. The `search_read` fallback
+  and generic error paths still omit it.
+
 ## [1.18.0] - 2026-09-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Note: live tests under `tests/live/` are **script-style runners**, not pytest mo
 
 Run `black . && isort .` before pushing — CI enforces formatting.
 
-**Lint and typecheck are not clean gates.** Baseline as of v1.18.0: `pytest --ignore=tests/live` → **519 passed** (unit coverage 75 %); `black --check .` and `isort --check-only .` → **clean**; `ruff check .` → **26 errors** (20 E501, 6 E402); `mypy src/odoo_mcp` → **51 errors** (27 `resources.py`, 14 `server.py`, 6 `utils.py`, 1 each in `prompts.py` / `constants.py` / `user_clients.py`, plus 1 `import-untyped` in `odoo_client.py` when `types-requests` is absent from the venv; counts drift slightly with the mypy version — 2.1.0 here). No function is rated worse than radon C except `find_model_resource` (D, 21) and `get_error_suggestion` (D, 22). Judge a change by *no new errors against that baseline*, not by a zero exit code. All 6 remaining E402s are in `tests/live/`, where `load_dotenv()` must run before the `odoo_mcp` imports — inherent to those script-style runners, not a defect. None of them come from the deliberate "import `app.py` first" ordering in `server.py`/`resources.py`, so do not reorder module imports to chase them.
+**Lint and typecheck are not clean gates.** Baseline as of v1.18.0: `pytest --ignore=tests/live` → **532 passed** (unit coverage 75 %); `black --check .` and `isort --check-only .` → **clean**; `ruff check .` → **26 errors** (20 E501, 6 E402); `mypy src/odoo_mcp` → **51 errors** (27 `resources.py`, 14 `server.py`, 6 `utils.py`, 1 each in `prompts.py` / `constants.py` / `user_clients.py`, plus 1 `import-untyped` in `odoo_client.py` when `types-requests` is absent from the venv; counts drift slightly with the mypy version — 2.1.0 here). No function is rated worse than radon C except `find_model_resource` (D, 21) and `get_error_suggestion` (D, 22). Judge a change by *no new errors against that baseline*, not by a zero exit code. All 6 remaining E402s are in `tests/live/`, where `load_dotenv()` must run before the `odoo_mcp` imports — inherent to those script-style runners, not a defect. None of them come from the deliberate "import `app.py` first" ordering in `server.py`/`resources.py`, so do not reorder module imports to chase them.
 
 ## High-level architecture
 
@@ -138,7 +138,7 @@ src/odoo_mcp/
 1. Validate model (`_validate_model`) and method (`_validate_method`) — regex + length, else 400.
 2. Block `@api.private` methods statically (PRIVATE_METHOD_HINTS) and dynamically (live `/doc-bearer/`).
 3. Classify via `safety.classify_operation` → SAFE / MEDIUM / HIGH / BLOCKED.
-4. If gate triggers → return `pending_confirmation=true` with a single-use, 120s, op-bound `confirmation_token` in `hint`. Caller must re-call with both `confirmed=true` AND that token. **`confirmed=true` alone does not bypass the gate** — this is the v1.14.0 hardening.
+4. Gated, blocked and directly executed responses carry `safety` (the `SafetyClassification`) so a caller can see why a call was or was not gated; only the `search_read` fallback and generic error paths omit it. If gate triggers → return `pending_confirmation=true` with a single-use, 120s, op-bound `confirmation_token` in `hint`. Caller must re-call with both `confirmed=true` AND that token. **`confirmed=true` alone does not bypass the gate** — this is the v1.14.0 hardening.
 5. Merge `MCP_DEFAULT_CONTEXT` into kwargs (explicit context wins).
 6. Resolve Many2one names via `resolve_json` (uses `name_search`, validates target model against BLOCKED_MODELS).
 7. Convert positional → named args via `arg_mapping`.
@@ -175,13 +175,13 @@ Activated by `USERS_DB_PATH` (HTTP transport). Key invariants:
 | Level | Behavior |
 |-------|----------|
 | `SAFE` | Execute immediately |
-| `MEDIUM` | Confirm in `strict` mode (default); only HIGH/BLOCKED in `permissive` |
+| `MEDIUM` | Confirm in `strict` (default) and `locked`, for any record count; proceed in `permissive` |
 | `HIGH` | Always confirm |
 | `BLOCKED` | Always refuse |
 
 Classification also takes a `role` (multi-user mode): `readonly` users get BLOCKED for any non-safe method, before model rules are even consulted. `tests/test_safety_role.py` pins this.
 
-- **Batch rule (strict mode)**: a MEDIUM method affecting more than one record is escalated to confirmation. The count comes from `_estimate_record_count`, which reads the payload from **either** `args_json` or `kwargs_json` (`_COUNTED_ARG` in `safety.py`: `write`/`unlink`/`copy` → `ids`, `create` → `vals_list`, `load` → `data`; `action_*`/`button_*` → `ids`). v2 is named-args-only, so both spellings must be counted — counting only the positional form lets a bulk `unlink` slip past the gate by moving `ids` into `kwargs_json`.
+- **Every side-effect call is gated in `strict` and `locked`** (fixed after v1.18.0): a MEDIUM method (`create`, `write`, `copy`, `name_create`, `load`) requires a confirmation token whatever the record count. Until v1.18.0 a single-record write on a non-sensitive model ran unconfirmed from one tool call, and `batch_execute` inherited that because `classify_batch` only aggregates the per-op flags; `tests/test_strict_single_write_gate.py` pins the closure. `permissive` still lets MEDIUM calls through. The record count still matters for the audit reason and for permissive-mode reporting — it comes from `_estimate_record_count`, which reads the payload from **either** `args_json` or `kwargs_json` (`_COUNTED_ARG` in `safety.py`: `write`/`unlink`/`copy` → `ids`, `create` → `vals_list`, `load` → `data`; `action_*`/`button_*` → `ids`). v2 is named-args-only, so both spellings must be counted — counting only the positional form lets a bulk `unlink` slip past the gate by moving `ids` into `kwargs_json`.
 - **Unknown methods** classify as MEDIUM: confirm in `strict`, allow in `permissive`.
 
 - **BLOCKED_MODELS** (writes always refused): `ir.rule`, `ir.model.access`, `ir.module.module`, `ir.config_parameter`, `ir.model`, `res.users`, `res.groups`, `res.users.apikeys`. The `resolve_json` parameter also rejects these as targets — agents cannot use it to read security-critical data. `res.users.apikeys` is blocked because Odoo 19.1+ exposes programmatic API-key management (`res.users.apikeys.generate` / `.revoke` over JSON-2 — Odoo restricts it to *Settings* admins by default, opt-in for others via `base.enable_programmatic_api_keys`, but the connected API user is often privileged); it's a distinct model name from `res.users`, so without an explicit entry an agent could mint a persistent API key (up to 3 months) that outlives the MCP session.

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Pre-execution safety classification gates dangerous operations behind confirmati
 | Level | Behavior | Confirm? |
 |-------|----------|----------|
 | `SAFE` | Execute immediately | Never |
-| `MEDIUM` | Gate based on mode/volume | Conditional |
+| `MEDIUM` | Confirm in `strict` / `locked` for any record count; proceed in `permissive` | Conditional |
 | `HIGH` | Always require confirmation | Always |
 | `BLOCKED` | Always refuse | N/A |
 

--- a/src/odoo_mcp/safety.py
+++ b/src/odoo_mcp/safety.py
@@ -404,32 +404,31 @@ def classify_operation(
             )
 
         # Modes treated as confirmation-required ("strict" semantics).
-        # Note: "locked" inherits "strict" classifier behaviour for unknown
-        # and batch operations (in addition to its own read_only / allowlist
-        # gates resolved at the profile layer).
-        # Strict and locked modes: confirm if batch (record_count > 1)
-        if mode in _STRICT_EQUIV and record_count is not None and record_count > 1:
+        # Note: "locked" inherits "strict" classifier behaviour (in addition to
+        # its own read_only / allowlist gates resolved at the profile layer).
+        # Every side-effect call is gated, whatever the record count: before
+        # v1.18.1 a single-record write/create on a non-sensitive model ran
+        # unconfirmed from one tool call, and batch_execute inherited that.
+        if mode in _STRICT_EQUIV:
+            scope = f"{record_count} record(s)" if record_count is not None else "an unknown number of records"
             return SafetyClassification(
                 risk_level=RiskLevel.MEDIUM,
                 model=model,
                 method=method,
                 record_count=record_count,
                 requires_confirmation=True,
-                reason=(
-                    f"'{method}' affects {record_count} records "
-                    f"(strict mode requires confirmation for batch operations)."
-                ),
+                reason=f"'{method}' on '{model}' affects {scope} (strict mode confirms every write).",
                 cascade_warning=cascade_warning,
             )
 
-        # Otherwise: safe to proceed
+        # Permissive mode: medium-risk writes proceed without a gate.
         return SafetyClassification(
             risk_level=RiskLevel.MEDIUM,
             model=model,
             method=method,
             record_count=record_count,
             requires_confirmation=False,
-            reason=f"'{method}' classified as medium risk, no confirmation needed.",
+            reason=f"'{method}' classified as medium risk, no confirmation needed in permissive mode.",
             cascade_warning=cascade_warning,
         )
 

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -334,23 +334,29 @@ def _classify_and_gate(
     confirmed: bool,
     confirmation_token: str | None,
     start_time: float,
-) -> ExecuteMethodResponse | None:
+) -> tuple[ExecuteMethodResponse | None, SafetyClassification]:
     """Run the safety classifier, the payload pre-flight and the confirmation gate.
 
-    Returns the response to send when the call must stop here (blocked, token
-    issued, token rejected, payload invalid), or ``None`` when execution may proceed.
+    Returns ``(response, classification)``: the response to send when the call must
+    stop here (blocked, token issued, token rejected, payload invalid), or ``None``
+    when execution may proceed. The classification is always returned so the
+    success response can report it — a caller must be able to see *why* a write
+    was or was not gated.
     """
     classification = classify_operation(model, method, args, kwargs, role=current_role())
 
     if classification.risk_level == RiskLevel.BLOCKED:
         audit_log(classification, confirmed=confirmed, executed=False)
-        return ExecuteMethodResponse(
-            success=False,
-            pending_confirmation=True,
-            safety=classification,
-            error=classification.blocked_reason,
-            hint="Use the Odoo web interface instead.",
-            execution_time_ms=_elapsed_ms(start_time),
+        return (
+            ExecuteMethodResponse(
+                success=False,
+                pending_confirmation=True,
+                safety=classification,
+                error=classification.blocked_reason,
+                hint="Use the Odoo web interface instead.",
+                execution_time_ms=_elapsed_ms(start_time),
+            ),
+            classification,
         )
 
     if classification.requires_confirmation:
@@ -362,11 +368,15 @@ def _classify_and_gate(
 
             validation = _validate_payload(odoo, model, method, args=args, kwargs=kwargs)
             if not validation.ok:
-                return ExecuteMethodResponse(
-                    success=False,
-                    error="Payload validation failed:\n  - " + "\n  - ".join(validation.errors),
-                    hint=f"Read odoo://model/{model}/quick-schema for the field list.",
-                    execution_time_ms=_elapsed_ms(start_time),
+                return (
+                    ExecuteMethodResponse(
+                        success=False,
+                        safety=classification,
+                        error="Payload validation failed:\n  - " + "\n  - ".join(validation.errors),
+                        hint=f"Read odoo://model/{model}/quick-schema for the field list.",
+                        execution_time_ms=_elapsed_ms(start_time),
+                    ),
+                    classification,
                 )
 
         # Args/kwargs are post-resolve_json and post-context-merge, so the digest
@@ -377,23 +387,34 @@ def _classify_and_gate(
             message = classification.reason
             if classification.cascade_warning:
                 message += f"\n\nWARNING: {classification.cascade_warning}"
-            return ExecuteMethodResponse(
-                success=False,
-                pending_confirmation=True,
-                safety=classification,
-                error=message,
-                hint=(
-                    f"Re-call execute_method with confirmed=true and "
-                    f"confirmation_token='{decision.token}' to proceed."
+            return (
+                ExecuteMethodResponse(
+                    success=False,
+                    pending_confirmation=True,
+                    safety=classification,
+                    error=message,
+                    hint=(
+                        f"Re-call execute_method with confirmed=true and "
+                        f"confirmation_token='{decision.token}' to proceed."
+                    ),
+                    execution_time_ms=_elapsed_ms(start_time),
                 ),
-                execution_time_ms=_elapsed_ms(start_time),
+                classification,
             )
         if decision.outcome == "reject":
-            return ExecuteMethodResponse(success=False, error=decision.error, execution_time_ms=_elapsed_ms(start_time))
+            return (
+                ExecuteMethodResponse(
+                    success=False,
+                    safety=classification,
+                    error=decision.error,
+                    execution_time_ms=_elapsed_ms(start_time),
+                ),
+                classification,
+            )
 
     if classification.risk_level != RiskLevel.SAFE:
         audit_log(classification, confirmed=confirmed, executed=True)
-    return None
+    return None, classification
 
 
 def _apply_search_defaults(method: str, args: list, kwargs: dict) -> tuple[list, dict]:
@@ -638,13 +659,17 @@ def execute_method(
         if rejected:
             return rejected
 
-        gated = _classify_and_gate(odoo, model, method, args, kwargs, confirmed, confirmation_token, start_time)
+        gated, classification = _classify_and_gate(
+            odoo, model, method, args, kwargs, confirmed, confirmation_token, start_time
+        )
         if gated:
             return gated
 
         args, kwargs = _apply_search_defaults(method, args, kwargs)
         result = odoo.execute_method(model, method, *args, **kwargs)
-        return ExecuteMethodResponse(success=True, result=result, execution_time_ms=_elapsed_ms(start_time))
+        return ExecuteMethodResponse(
+            success=True, result=result, safety=classification, execution_time_ms=_elapsed_ms(start_time)
+        )
 
     except Exception as e:
         error_msg = str(e)

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -121,18 +121,40 @@ class TestHighMethods:
 
 
 class TestMediumMethodsStrict:
-    """MEDIUM_METHODS in strict mode."""
+    """MEDIUM_METHODS in strict mode: every side-effect call is gated, whatever the record count."""
 
     @pytest.fixture(autouse=True)
     def set_strict_mode(self):
         with patch.dict(os.environ, {"MCP_SAFETY_MODE": "strict"}):
             yield
 
-    def test_single_record_write_no_confirm(self):
-        """Single-record write in strict does NOT require confirmation."""
-        result = classify_operation("res.partner", "write", [[1], {"name": "x"}])
+    @pytest.mark.parametrize("model", ["res.partner", "crm.lead", "sale.order", "product.product"])
+    def test_single_record_write_requires_confirm(self, model):
+        """A write on one real quotation / opportunity / customer must never execute from a single call."""
+        result = classify_operation(model, "write", [[1], {"name": "x"}])
         assert result.risk_level == RiskLevel.MEDIUM
-        assert result.requires_confirmation is False
+        assert result.requires_confirmation is True
+        assert result.record_count == 1
+
+    def test_single_create_requires_confirm(self):
+        result = classify_operation("res.partner", "create", [{"name": "x"}])
+        assert result.risk_level == RiskLevel.MEDIUM
+        assert result.requires_confirmation is True
+        assert result.record_count == 1
+
+    @pytest.mark.parametrize("method", ["copy", "name_create", "load"])
+    def test_other_medium_methods_require_confirm(self, method):
+        assert classify_operation("res.partner", method, [[1]]).requires_confirmation is True
+
+    def test_batch_of_single_record_writes_is_gated(self):
+        """batch_execute gates on the same classification — two ungated ops would slip a batch through."""
+        ops = [
+            {"model": "res.partner", "method": "write", "args_json": '[[1], {"name": "a"}]'},
+            {"model": "crm.lead", "method": "write", "args_json": '[[7], {"probability": 0}]'},
+        ]
+        _, overall, any_needs_confirmation = classify_batch(ops)
+        assert overall == RiskLevel.MEDIUM
+        assert any_needs_confirmation is True
 
     def test_multi_record_write_requires_confirm(self):
         """Multi-record write in strict DOES require confirmation."""
@@ -140,12 +162,6 @@ class TestMediumMethodsStrict:
         assert result.risk_level == RiskLevel.MEDIUM
         assert result.requires_confirmation is True
         assert result.record_count == 3
-
-    def test_single_create_no_confirm(self):
-        result = classify_operation("res.partner", "create", [{"name": "x"}])
-        assert result.risk_level == RiskLevel.MEDIUM
-        assert result.requires_confirmation is False
-        assert result.record_count == 1
 
     def test_batch_create_requires_confirm(self):
         result = classify_operation("res.partner", "create", [[{"name": "a"}, {"name": "b"}]])

--- a/tests/test_strict_single_write_gate.py
+++ b/tests/test_strict_single_write_gate.py
@@ -1,0 +1,72 @@
+"""The default (strict) profile must gate a single-record write and report its classification.
+
+Before this fix a ``write`` / ``create`` on one non-sensitive record executed from a
+single tool call with ``pending_confirmation=False`` and ``safety=None`` — the only
+thing that stopped a test run from mutating production was Odoo rejecting fake ids.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import odoo_mcp.server as server
+
+
+@pytest.fixture(autouse=True)
+def _strict(monkeypatch):
+    monkeypatch.delenv("MCP_READ_ONLY", raising=False)
+    monkeypatch.delenv("MCP_WRITE_ALLOWLIST", raising=False)
+    monkeypatch.delenv("MCP_VALIDATE_PAYLOADS", raising=False)
+    monkeypatch.setenv("MCP_SAFETY_MODE", "strict")
+
+
+def _call(client, **kwargs):
+    with patch.object(server, "get_odoo_client", return_value=client):
+        return server.execute_method(ctx=MagicMock(), **kwargs)
+
+
+@pytest.mark.parametrize(
+    "model,method,args_json",
+    [
+        ("res.partner", "write", '[[42], {"name": "x"}]'),
+        ("crm.lead", "write", '[[7], {"expected_revenue": 0}]'),
+        ("sale.order", "write", '[[15], {"note": "x"}]'),
+        ("sale.order", "create", '[{"partner_id": 1}]'),
+    ],
+)
+def test_single_record_write_is_token_gated_and_not_sent(model, method, args_json):
+    client = MagicMock()
+    resp = _call(client, model=model, method=method, args_json=args_json)
+    assert resp.success is False
+    assert resp.pending_confirmation is True
+    assert resp.safety is not None and resp.safety.requires_confirmation is True
+    assert "confirmation_token=" in resp.hint
+    assert client.execute_method.call_count == 0
+
+
+def test_confirmed_single_write_executes_and_reports_its_classification():
+    client = MagicMock()
+    client.execute_method.return_value = True
+    first = _call(client, model="res.partner", method="write", args_json='[[42], {"name": "x"}]')
+    token = first.hint.split("confirmation_token='")[1].split("'")[0]
+    resp = _call(
+        client,
+        model="res.partner",
+        method="write",
+        args_json='[[42], {"name": "x"}]',
+        confirmed=True,
+        confirmation_token=token,
+    )
+    assert resp.success is True
+    assert resp.safety is not None
+    assert resp.safety.risk_level.value == "medium"
+    assert client.execute_method.call_count == 1
+
+
+def test_safe_read_reports_safe_classification_on_success(monkeypatch):
+    monkeypatch.setenv("MCP_SAFETY_MODE", "permissive")
+    client = MagicMock()
+    client.execute_method.return_value = [{"id": 1}]
+    resp = _call(client, model="res.partner", method="search_read", kwargs_json='{"domain": [], "fields": ["id"]}')
+    assert resp.success is True
+    assert resp.safety is not None and resp.safety.risk_level.value == "safe"


### PR DESCRIPTION
## Summary

Closes the single-tool-call write hole in the safety layer.

Since v1.10.0 a MEDIUM method (`create`, `write`, `copy`, `name_create`, `load`) on a non-sensitive model only required confirmation when it touched more than one record. A `write` on one real quotation, opportunity or customer executed unconfirmed with `pending_confirmation=false` and `safety=null`; `batch_execute` inherited the hole because `classify_batch` only aggregates the per-operation flags.

- `classify_operation`: in `strict` (default) and `locked`, every side-effect call now issues a confirmation token whatever the record count. `permissive` unchanged; `readonly` role and locked-mode guards unaffected.
- `_classify_and_gate` returns the classification with the response; `execute_method` reports `safety` on success.
- Docs: CLAUDE.md safety table and batch rule, README table, CHANGELOG.

## Test plan
- [x] `tests/test_strict_single_write_gate.py`: single-record `write`/`create` on `res.partner`, `crm.lead`, `sale.order` return a token and send nothing; the confirmed re-call executes and reports `safety`
- [x] `tests/test_safety.py`: the four tests pinning the pass-through inverted; `classify_batch` of two single-record writes is gated
- [x] `uv run pytest tests/ --ignore=tests/live` → 532 passed; black/isort clean; ruff 26 / mypy 50 (baseline)
- [x] Live on erp.cyanview.com: three single-record writes gated with a token, target partner's `write_date` unchanged, `search_count` reports `safety: safe`
- [x] Code review: approved, no CRITICAL/HIGH

https://claude.ai/code/session_01KAef5yfHM7ZdtoPnizGwoa
